### PR TITLE
Feat/public notices announcements

### DIFF
--- a/apps/cms/migrations/20250409201657_add_body_to_community/migration.sql
+++ b/apps/cms/migrations/20250409201657_add_body_to_community/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `actionLabel` on the `Service` table. All the data in the column will be lost.
+  - You are about to drop the column `actionUrl` on the `Service` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Community" ADD COLUMN     "body" TEXT;
+
+-- AlterTable
+ALTER TABLE "Service" DROP COLUMN "actionLabel",
+DROP COLUMN "actionUrl";

--- a/apps/cms/migrations/20250409210204_add_body_and_user_groups_to_org_unit/migration.sql
+++ b/apps/cms/migrations/20250409210204_add_body_and_user_groups_to_org_unit/migration.sql
@@ -1,0 +1,20 @@
+-- AlterTable
+ALTER TABLE "OrgUnit" ADD COLUMN     "body" TEXT;
+
+-- CreateTable
+CREATE TABLE "_OrgUnit_userGroups" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_OrgUnit_userGroups_AB_unique" ON "_OrgUnit_userGroups"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_OrgUnit_userGroups_B_index" ON "_OrgUnit_userGroups"("B");
+
+-- AddForeignKey
+ALTER TABLE "_OrgUnit_userGroups" ADD CONSTRAINT "_OrgUnit_userGroups_A_fkey" FOREIGN KEY ("A") REFERENCES "OrgUnit"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_OrgUnit_userGroups" ADD CONSTRAINT "_OrgUnit_userGroups_B_fkey" FOREIGN KEY ("B") REFERENCES "UserGroup"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/cms/migrations/20250409212330_cupcakes/migration.sql
+++ b/apps/cms/migrations/20250409212330_cupcakes/migration.sql
@@ -1,0 +1,71 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `groomed` on the `Trail` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "AssemblyDistrict" ADD COLUMN     "body" TEXT,
+ADD COLUMN     "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "heroImage" TEXT,
+ADD COLUMN     "publishAt" TIMESTAMP(3),
+ADD COLUMN     "reviewDate" TIMESTAMP(3),
+ADD COLUMN     "unpublishAt" TIMESTAMP(3),
+ADD COLUMN     "updatedAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "Trail" DROP COLUMN "groomed";
+
+-- CreateTable
+CREATE TABLE "_AssemblyDistrict_tags" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_AssemblyDistrict_userGroups" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_AssemblyDistrict_contacts" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_AssemblyDistrict_tags_AB_unique" ON "_AssemblyDistrict_tags"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_AssemblyDistrict_tags_B_index" ON "_AssemblyDistrict_tags"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_AssemblyDistrict_userGroups_AB_unique" ON "_AssemblyDistrict_userGroups"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_AssemblyDistrict_userGroups_B_index" ON "_AssemblyDistrict_userGroups"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_AssemblyDistrict_contacts_AB_unique" ON "_AssemblyDistrict_contacts"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_AssemblyDistrict_contacts_B_index" ON "_AssemblyDistrict_contacts"("B");
+
+-- AddForeignKey
+ALTER TABLE "_AssemblyDistrict_tags" ADD CONSTRAINT "_AssemblyDistrict_tags_A_fkey" FOREIGN KEY ("A") REFERENCES "AssemblyDistrict"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_AssemblyDistrict_tags" ADD CONSTRAINT "_AssemblyDistrict_tags_B_fkey" FOREIGN KEY ("B") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_AssemblyDistrict_userGroups" ADD CONSTRAINT "_AssemblyDistrict_userGroups_A_fkey" FOREIGN KEY ("A") REFERENCES "AssemblyDistrict"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_AssemblyDistrict_userGroups" ADD CONSTRAINT "_AssemblyDistrict_userGroups_B_fkey" FOREIGN KEY ("B") REFERENCES "UserGroup"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_AssemblyDistrict_contacts" ADD CONSTRAINT "_AssemblyDistrict_contacts_A_fkey" FOREIGN KEY ("A") REFERENCES "AssemblyDistrict"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_AssemblyDistrict_contacts" ADD CONSTRAINT "_AssemblyDistrict_contacts_B_fkey" FOREIGN KEY ("B") REFERENCES "Contact"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/cms/migrations/20250409224642_create_public_notices/migration.sql
+++ b/apps/cms/migrations/20250409224642_create_public_notices/migration.sql
@@ -1,0 +1,110 @@
+-- CreateTable
+CREATE TABLE "PublicNotice" (
+    "id" TEXT NOT NULL,
+    "heroImage" TEXT,
+    "title" TEXT NOT NULL DEFAULT '',
+    "description" TEXT NOT NULL DEFAULT '',
+    "publishAt" TIMESTAMP(3),
+    "unpublishAt" TIMESTAMP(3),
+    "reviewDate" TIMESTAMP(3),
+    "slug" TEXT NOT NULL DEFAULT '',
+    "owner" TEXT,
+    "body" TEXT,
+    "actions" TEXT,
+    "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "effectiveDate" TIMESTAMP(3),
+    "endDate" TIMESTAMP(3),
+
+    CONSTRAINT "PublicNotice_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_Contact_publicNotices" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_PublicNotice_documents" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_PublicNotice_tags" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_PublicNotice_userGroups" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PublicNotice_title_key" ON "PublicNotice"("title");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PublicNotice_slug_key" ON "PublicNotice"("slug");
+
+-- CreateIndex
+CREATE INDEX "PublicNotice_owner_idx" ON "PublicNotice"("owner");
+
+-- CreateIndex
+CREATE INDEX "PublicNotice_actions_idx" ON "PublicNotice"("actions");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Contact_publicNotices_AB_unique" ON "_Contact_publicNotices"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Contact_publicNotices_B_index" ON "_Contact_publicNotices"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PublicNotice_documents_AB_unique" ON "_PublicNotice_documents"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PublicNotice_documents_B_index" ON "_PublicNotice_documents"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PublicNotice_tags_AB_unique" ON "_PublicNotice_tags"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PublicNotice_tags_B_index" ON "_PublicNotice_tags"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PublicNotice_userGroups_AB_unique" ON "_PublicNotice_userGroups"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PublicNotice_userGroups_B_index" ON "_PublicNotice_userGroups"("B");
+
+-- AddForeignKey
+ALTER TABLE "PublicNotice" ADD CONSTRAINT "PublicNotice_owner_fkey" FOREIGN KEY ("owner") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PublicNotice" ADD CONSTRAINT "PublicNotice_actions_fkey" FOREIGN KEY ("actions") REFERENCES "InternalLink"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Contact_publicNotices" ADD CONSTRAINT "_Contact_publicNotices_A_fkey" FOREIGN KEY ("A") REFERENCES "Contact"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Contact_publicNotices" ADD CONSTRAINT "_Contact_publicNotices_B_fkey" FOREIGN KEY ("B") REFERENCES "PublicNotice"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_documents" ADD CONSTRAINT "_PublicNotice_documents_A_fkey" FOREIGN KEY ("A") REFERENCES "Document"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_documents" ADD CONSTRAINT "_PublicNotice_documents_B_fkey" FOREIGN KEY ("B") REFERENCES "PublicNotice"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_tags" ADD CONSTRAINT "_PublicNotice_tags_A_fkey" FOREIGN KEY ("A") REFERENCES "PublicNotice"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_tags" ADD CONSTRAINT "_PublicNotice_tags_B_fkey" FOREIGN KEY ("B") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_userGroups" ADD CONSTRAINT "_PublicNotice_userGroups_A_fkey" FOREIGN KEY ("A") REFERENCES "PublicNotice"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_userGroups" ADD CONSTRAINT "_PublicNotice_userGroups_B_fkey" FOREIGN KEY ("B") REFERENCES "UserGroup"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/cms/migrations/20250410215751_add_relationships_to_public_notices_create_home_page_ct/migration.sql
+++ b/apps/cms/migrations/20250410215751_add_relationships_to_public_notices_create_home_page_ct/migration.sql
@@ -1,0 +1,189 @@
+-- CreateTable
+CREATE TABLE "HomePage" (
+    "id" INTEGER NOT NULL,
+    "heroImage" TEXT,
+    "title" TEXT NOT NULL DEFAULT '',
+    "description" TEXT NOT NULL DEFAULT '',
+    "toolbeltOne" TEXT,
+    "toolbeltTwo" TEXT,
+    "toolbeltThree" TEXT,
+    "toolbeltFour" TEXT,
+    "highlightOne" TEXT,
+    "highlightTwo" TEXT,
+    "highlightThree" TEXT,
+    "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "HomePage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_PublicNotice_assemblyDistricts" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_PublicNotice_communities" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_PublicNotice_facilities" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_PublicNotice_orgUnits" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_PublicNotice_parks" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_PublicNotice_services" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_PublicNotice_trails" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "HomePage_title_key" ON "HomePage"("title");
+
+-- CreateIndex
+CREATE INDEX "HomePage_toolbeltOne_idx" ON "HomePage"("toolbeltOne");
+
+-- CreateIndex
+CREATE INDEX "HomePage_toolbeltTwo_idx" ON "HomePage"("toolbeltTwo");
+
+-- CreateIndex
+CREATE INDEX "HomePage_toolbeltThree_idx" ON "HomePage"("toolbeltThree");
+
+-- CreateIndex
+CREATE INDEX "HomePage_toolbeltFour_idx" ON "HomePage"("toolbeltFour");
+
+-- CreateIndex
+CREATE INDEX "HomePage_highlightOne_idx" ON "HomePage"("highlightOne");
+
+-- CreateIndex
+CREATE INDEX "HomePage_highlightTwo_idx" ON "HomePage"("highlightTwo");
+
+-- CreateIndex
+CREATE INDEX "HomePage_highlightThree_idx" ON "HomePage"("highlightThree");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PublicNotice_assemblyDistricts_AB_unique" ON "_PublicNotice_assemblyDistricts"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PublicNotice_assemblyDistricts_B_index" ON "_PublicNotice_assemblyDistricts"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PublicNotice_communities_AB_unique" ON "_PublicNotice_communities"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PublicNotice_communities_B_index" ON "_PublicNotice_communities"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PublicNotice_facilities_AB_unique" ON "_PublicNotice_facilities"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PublicNotice_facilities_B_index" ON "_PublicNotice_facilities"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PublicNotice_orgUnits_AB_unique" ON "_PublicNotice_orgUnits"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PublicNotice_orgUnits_B_index" ON "_PublicNotice_orgUnits"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PublicNotice_parks_AB_unique" ON "_PublicNotice_parks"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PublicNotice_parks_B_index" ON "_PublicNotice_parks"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PublicNotice_services_AB_unique" ON "_PublicNotice_services"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PublicNotice_services_B_index" ON "_PublicNotice_services"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PublicNotice_trails_AB_unique" ON "_PublicNotice_trails"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PublicNotice_trails_B_index" ON "_PublicNotice_trails"("B");
+
+-- AddForeignKey
+ALTER TABLE "HomePage" ADD CONSTRAINT "HomePage_toolbeltOne_fkey" FOREIGN KEY ("toolbeltOne") REFERENCES "Highlight"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "HomePage" ADD CONSTRAINT "HomePage_toolbeltTwo_fkey" FOREIGN KEY ("toolbeltTwo") REFERENCES "Highlight"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "HomePage" ADD CONSTRAINT "HomePage_toolbeltThree_fkey" FOREIGN KEY ("toolbeltThree") REFERENCES "Highlight"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "HomePage" ADD CONSTRAINT "HomePage_toolbeltFour_fkey" FOREIGN KEY ("toolbeltFour") REFERENCES "Highlight"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "HomePage" ADD CONSTRAINT "HomePage_highlightOne_fkey" FOREIGN KEY ("highlightOne") REFERENCES "Highlight"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "HomePage" ADD CONSTRAINT "HomePage_highlightTwo_fkey" FOREIGN KEY ("highlightTwo") REFERENCES "Highlight"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "HomePage" ADD CONSTRAINT "HomePage_highlightThree_fkey" FOREIGN KEY ("highlightThree") REFERENCES "Highlight"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_assemblyDistricts" ADD CONSTRAINT "_PublicNotice_assemblyDistricts_A_fkey" FOREIGN KEY ("A") REFERENCES "AssemblyDistrict"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_assemblyDistricts" ADD CONSTRAINT "_PublicNotice_assemblyDistricts_B_fkey" FOREIGN KEY ("B") REFERENCES "PublicNotice"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_communities" ADD CONSTRAINT "_PublicNotice_communities_A_fkey" FOREIGN KEY ("A") REFERENCES "Community"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_communities" ADD CONSTRAINT "_PublicNotice_communities_B_fkey" FOREIGN KEY ("B") REFERENCES "PublicNotice"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_facilities" ADD CONSTRAINT "_PublicNotice_facilities_A_fkey" FOREIGN KEY ("A") REFERENCES "Facility"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_facilities" ADD CONSTRAINT "_PublicNotice_facilities_B_fkey" FOREIGN KEY ("B") REFERENCES "PublicNotice"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_orgUnits" ADD CONSTRAINT "_PublicNotice_orgUnits_A_fkey" FOREIGN KEY ("A") REFERENCES "OrgUnit"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_orgUnits" ADD CONSTRAINT "_PublicNotice_orgUnits_B_fkey" FOREIGN KEY ("B") REFERENCES "PublicNotice"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_parks" ADD CONSTRAINT "_PublicNotice_parks_A_fkey" FOREIGN KEY ("A") REFERENCES "Park"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_parks" ADD CONSTRAINT "_PublicNotice_parks_B_fkey" FOREIGN KEY ("B") REFERENCES "PublicNotice"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_services" ADD CONSTRAINT "_PublicNotice_services_A_fkey" FOREIGN KEY ("A") REFERENCES "PublicNotice"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_services" ADD CONSTRAINT "_PublicNotice_services_B_fkey" FOREIGN KEY ("B") REFERENCES "Service"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_trails" ADD CONSTRAINT "_PublicNotice_trails_A_fkey" FOREIGN KEY ("A") REFERENCES "PublicNotice"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_trails" ADD CONSTRAINT "_PublicNotice_trails_B_fkey" FOREIGN KEY ("B") REFERENCES "Trail"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/cms/migrations/20250421172234_add_urgency_to_public_notices/migration.sql
+++ b/apps/cms/migrations/20250421172234_add_urgency_to_public_notices/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "PublicNotice" ADD COLUMN     "urgency" INTEGER DEFAULT 2;

--- a/apps/cms/migrations/20250421174038_add_default_value_and_ordarable_to_urgency_field_on_public_notices/migration.sql
+++ b/apps/cms/migrations/20250421174038_add_default_value_and_ordarable_to_urgency_field_on_public_notices/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `urgency` on table `PublicNotice` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "PublicNotice" ALTER COLUMN "urgency" SET NOT NULL;

--- a/apps/cms/schema.graphql
+++ b/apps/cms/schema.graphql
@@ -176,11 +176,24 @@ input AlertCreateInput {
 
 type AssemblyDistrict {
   id: ID!
+  heroImage: String
   title: String
   description: String
+  publishAt: DateTime
+  unpublishAt: DateTime
+  reviewDate: DateTime
   liveUrl: String
   slug: String
   owner: User
+  body: String
+  tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
+  tagsCount(where: TagWhereInput! = {}): Int
+  userGroups(where: UserGroupWhereInput! = {}, orderBy: [UserGroupOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: UserGroupWhereUniqueInput): [UserGroup!]
+  userGroupsCount(where: UserGroupWhereInput! = {}): Int
+  contacts(where: ContactWhereInput! = {}, orderBy: [ContactOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ContactWhereUniqueInput): [Contact!]
+  contactsCount(where: ContactWhereInput! = {}): Int
+  createdAt: DateTime
+  updatedAt: DateTime
   photo: Image
   memberName: String
   bio: String
@@ -205,8 +218,17 @@ input AssemblyDistrictWhereInput {
   id: IDFilter
   title: StringFilter
   description: StringFilter
+  publishAt: DateTimeNullableFilter
+  unpublishAt: DateTimeNullableFilter
+  reviewDate: DateTimeNullableFilter
   slug: StringFilter
   owner: UserWhereInput
+  body: MyStringFilter
+  tags: TagManyRelationFilter
+  userGroups: UserGroupManyRelationFilter
+  contacts: ContactManyRelationFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
   photo: ImageWhereInput
   memberName: StringFilter
   bio: StringFilter
@@ -216,6 +238,24 @@ input AssemblyDistrictWhereInput {
   fax: StringNullableFilter
   termStart: DateTimeNullableFilter
   termEnd: DateTimeNullableFilter
+}
+
+input TagManyRelationFilter {
+  every: TagWhereInput
+  some: TagWhereInput
+  none: TagWhereInput
+}
+
+input UserGroupManyRelationFilter {
+  every: UserGroupWhereInput
+  some: UserGroupWhereInput
+  none: UserGroupWhereInput
+}
+
+input ContactManyRelationFilter {
+  every: ContactWhereInput
+  some: ContactWhereInput
+  none: ContactWhereInput
 }
 
 input StringNullableFilter {
@@ -235,9 +275,16 @@ input StringNullableFilter {
 
 input AssemblyDistrictOrderByInput {
   id: OrderDirection
+  heroImage: BlueHarvestImageOrderDirection
   title: OrderDirection
   description: OrderDirection
+  publishAt: OrderDirection
+  unpublishAt: OrderDirection
+  reviewDate: OrderDirection
   slug: OrderDirection
+  body: MyOrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
   memberName: OrderDirection
   bio: OrderDirection
   address: OrderDirection
@@ -248,11 +295,26 @@ input AssemblyDistrictOrderByInput {
   termEnd: OrderDirection
 }
 
+enum BlueHarvestImageOrderDirection {
+  asc
+  desc
+}
+
 input AssemblyDistrictUpdateInput {
+  heroImage: String
   title: String
   description: String
+  publishAt: DateTime
+  unpublishAt: DateTime
+  reviewDate: DateTime
   slug: String
   owner: UserRelateToOneForUpdateInput
+  body: String
+  tags: TagRelateToManyForUpdateInput
+  userGroups: UserGroupRelateToManyForUpdateInput
+  contacts: ContactRelateToManyForUpdateInput
+  createdAt: DateTime
+  updatedAt: DateTime
   photo: ImageRelateToOneForUpdateInput
   memberName: String
   bio: String
@@ -270,6 +332,27 @@ input UserRelateToOneForUpdateInput {
   disconnect: Boolean
 }
 
+input TagRelateToManyForUpdateInput {
+  disconnect: [TagWhereUniqueInput!]
+  set: [TagWhereUniqueInput!]
+  create: [TagCreateInput!]
+  connect: [TagWhereUniqueInput!]
+}
+
+input UserGroupRelateToManyForUpdateInput {
+  disconnect: [UserGroupWhereUniqueInput!]
+  set: [UserGroupWhereUniqueInput!]
+  create: [UserGroupCreateInput!]
+  connect: [UserGroupWhereUniqueInput!]
+}
+
+input ContactRelateToManyForUpdateInput {
+  disconnect: [ContactWhereUniqueInput!]
+  set: [ContactWhereUniqueInput!]
+  create: [ContactCreateInput!]
+  connect: [ContactWhereUniqueInput!]
+}
+
 input ImageRelateToOneForUpdateInput {
   create: ImageCreateInput
   connect: ImageWhereUniqueInput
@@ -282,10 +365,20 @@ input AssemblyDistrictUpdateArgs {
 }
 
 input AssemblyDistrictCreateInput {
+  heroImage: String
   title: String
   description: String
+  publishAt: DateTime
+  unpublishAt: DateTime
+  reviewDate: DateTime
   slug: String
   owner: UserRelateToOneForCreateInput
+  body: String
+  tags: TagRelateToManyForCreateInput
+  userGroups: UserGroupRelateToManyForCreateInput
+  contacts: ContactRelateToManyForCreateInput
+  createdAt: DateTime
+  updatedAt: DateTime
   photo: ImageRelateToOneForCreateInput
   memberName: String
   bio: String
@@ -300,6 +393,21 @@ input AssemblyDistrictCreateInput {
 input UserRelateToOneForCreateInput {
   create: UserCreateInput
   connect: UserWhereUniqueInput
+}
+
+input TagRelateToManyForCreateInput {
+  create: [TagCreateInput!]
+  connect: [TagWhereUniqueInput!]
+}
+
+input UserGroupRelateToManyForCreateInput {
+  create: [UserGroupCreateInput!]
+  connect: [UserGroupWhereUniqueInput!]
+}
+
+input ContactRelateToManyForCreateInput {
+  create: [ContactCreateInput!]
+  connect: [ContactWhereUniqueInput!]
 }
 
 input ImageRelateToOneForCreateInput {
@@ -318,19 +426,20 @@ type Community {
   liveUrl: String
   slug: String
   owner: User
-  mapId: String
+  body: String
   tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
   tagsCount(where: TagWhereInput! = {}): Int
   userGroups(where: UserGroupWhereInput! = {}, orderBy: [UserGroupOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: UserGroupWhereUniqueInput): [UserGroup!]
   userGroupsCount(where: UserGroupWhereInput! = {}): Int
   contacts(where: ContactWhereInput! = {}, orderBy: [ContactOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ContactWhereUniqueInput): [Contact!]
   contactsCount(where: ContactWhereInput! = {}): Int
+  createdAt: DateTime
+  updatedAt: DateTime
+  mapId: String
   services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
   servicesCount(where: ServiceWhereInput! = {}): Int
   districts(where: AssemblyDistrictWhereInput! = {}, orderBy: [AssemblyDistrictOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AssemblyDistrictWhereUniqueInput): [AssemblyDistrict!]
   districtsCount(where: AssemblyDistrictWhereInput! = {}): Int
-  createdAt: DateTime
-  updatedAt: DateTime
 }
 
 input CommunityWhereUniqueInput {
@@ -351,32 +460,15 @@ input CommunityWhereInput {
   reviewDate: DateTimeNullableFilter
   slug: StringFilter
   owner: UserWhereInput
-  mapId: StringFilter
+  body: MyStringFilter
   tags: TagManyRelationFilter
   userGroups: UserGroupManyRelationFilter
   contacts: ContactManyRelationFilter
-  services: ServiceManyRelationFilter
-  districts: AssemblyDistrictManyRelationFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
-}
-
-input TagManyRelationFilter {
-  every: TagWhereInput
-  some: TagWhereInput
-  none: TagWhereInput
-}
-
-input UserGroupManyRelationFilter {
-  every: UserGroupWhereInput
-  some: UserGroupWhereInput
-  none: UserGroupWhereInput
-}
-
-input ContactManyRelationFilter {
-  every: ContactWhereInput
-  some: ContactWhereInput
-  none: ContactWhereInput
+  mapId: StringFilter
+  services: ServiceManyRelationFilter
+  districts: AssemblyDistrictManyRelationFilter
 }
 
 input ServiceManyRelationFilter {
@@ -400,14 +492,10 @@ input CommunityOrderByInput {
   unpublishAt: OrderDirection
   reviewDate: OrderDirection
   slug: OrderDirection
-  mapId: OrderDirection
+  body: MyOrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
-}
-
-enum BlueHarvestImageOrderDirection {
-  asc
-  desc
+  mapId: OrderDirection
 }
 
 input CommunityUpdateInput {
@@ -419,35 +507,15 @@ input CommunityUpdateInput {
   reviewDate: DateTime
   slug: String
   owner: UserRelateToOneForUpdateInput
-  mapId: String
+  body: String
   tags: TagRelateToManyForUpdateInput
   userGroups: UserGroupRelateToManyForUpdateInput
   contacts: ContactRelateToManyForUpdateInput
-  services: ServiceRelateToManyForUpdateInput
-  districts: AssemblyDistrictRelateToManyForUpdateInput
   createdAt: DateTime
   updatedAt: DateTime
-}
-
-input TagRelateToManyForUpdateInput {
-  disconnect: [TagWhereUniqueInput!]
-  set: [TagWhereUniqueInput!]
-  create: [TagCreateInput!]
-  connect: [TagWhereUniqueInput!]
-}
-
-input UserGroupRelateToManyForUpdateInput {
-  disconnect: [UserGroupWhereUniqueInput!]
-  set: [UserGroupWhereUniqueInput!]
-  create: [UserGroupCreateInput!]
-  connect: [UserGroupWhereUniqueInput!]
-}
-
-input ContactRelateToManyForUpdateInput {
-  disconnect: [ContactWhereUniqueInput!]
-  set: [ContactWhereUniqueInput!]
-  create: [ContactCreateInput!]
-  connect: [ContactWhereUniqueInput!]
+  mapId: String
+  services: ServiceRelateToManyForUpdateInput
+  districts: AssemblyDistrictRelateToManyForUpdateInput
 }
 
 input ServiceRelateToManyForUpdateInput {
@@ -478,29 +546,15 @@ input CommunityCreateInput {
   reviewDate: DateTime
   slug: String
   owner: UserRelateToOneForCreateInput
-  mapId: String
+  body: String
   tags: TagRelateToManyForCreateInput
   userGroups: UserGroupRelateToManyForCreateInput
   contacts: ContactRelateToManyForCreateInput
-  services: ServiceRelateToManyForCreateInput
-  districts: AssemblyDistrictRelateToManyForCreateInput
   createdAt: DateTime
   updatedAt: DateTime
-}
-
-input TagRelateToManyForCreateInput {
-  create: [TagCreateInput!]
-  connect: [TagWhereUniqueInput!]
-}
-
-input UserGroupRelateToManyForCreateInput {
-  create: [UserGroupCreateInput!]
-  connect: [UserGroupWhereUniqueInput!]
-}
-
-input ContactRelateToManyForCreateInput {
-  create: [ContactCreateInput!]
-  connect: [ContactWhereUniqueInput!]
+  mapId: String
+  services: ServiceRelateToManyForCreateInput
+  districts: AssemblyDistrictRelateToManyForCreateInput
 }
 
 input ServiceRelateToManyForCreateInput {
@@ -531,6 +585,8 @@ type Contact {
   facilitiesCount(where: FacilityWhereInput! = {}): Int
   parks(where: ParkWhereInput! = {}, orderBy: [ParkOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ParkWhereUniqueInput): [Park!]
   parksCount(where: ParkWhereInput! = {}): Int
+  assemblyDistricts(where: AssemblyDistrictWhereInput! = {}, orderBy: [AssemblyDistrictOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AssemblyDistrictWhereUniqueInput): [AssemblyDistrict!]
+  assemblyDistrictsCount(where: AssemblyDistrictWhereInput! = {}): Int
   trails(where: TrailWhereInput! = {}, orderBy: [TrailOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TrailWhereUniqueInput): [Trail!]
   trailsCount(where: TrailWhereInput! = {}): Int
   user: User
@@ -556,6 +612,7 @@ input ContactWhereInput {
   orgUnits: OrgUnitManyRelationFilter
   facilities: FacilityManyRelationFilter
   parks: ParkManyRelationFilter
+  assemblyDistricts: AssemblyDistrictManyRelationFilter
   trails: TrailManyRelationFilter
   user: UserWhereInput
   editorNotes: StringFilter
@@ -611,6 +668,7 @@ input ContactUpdateInput {
   orgUnits: OrgUnitRelateToManyForUpdateInput
   facilities: FacilityRelateToManyForUpdateInput
   parks: ParkRelateToManyForUpdateInput
+  assemblyDistricts: AssemblyDistrictRelateToManyForUpdateInput
   trails: TrailRelateToManyForUpdateInput
   user: UserRelateToOneForUpdateInput
   editorNotes: String
@@ -667,6 +725,7 @@ input ContactCreateInput {
   orgUnits: OrgUnitRelateToManyForCreateInput
   facilities: FacilityRelateToManyForCreateInput
   parks: ParkRelateToManyForCreateInput
+  assemblyDistricts: AssemblyDistrictRelateToManyForCreateInput
   trails: TrailRelateToManyForCreateInput
   user: UserRelateToOneForCreateInput
   editorNotes: String
@@ -935,13 +994,13 @@ type Facility {
   address: Location
   contacts(where: ContactWhereInput! = {}, orderBy: [ContactOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ContactWhereUniqueInput): [Contact!]
   contactsCount(where: ContactWhereInput! = {}): Int
-  services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
-  servicesCount(where: ServiceWhereInput! = {}): Int
-  park: Park
   hours(where: OperatingHourWhereInput! = {}, orderBy: [OperatingHourOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OperatingHourWhereUniqueInput): [OperatingHour!]
   hoursCount(where: OperatingHourWhereInput! = {}): Int
   createdAt: DateTime
   updatedAt: DateTime
+  services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
+  servicesCount(where: ServiceWhereInput! = {}): Int
+  park: Park
 }
 
 input FacilityWhereUniqueInput {
@@ -967,11 +1026,11 @@ input FacilityWhereInput {
   userGroups: UserGroupManyRelationFilter
   address: LocationWhereInput
   contacts: ContactManyRelationFilter
-  services: ServiceManyRelationFilter
-  park: ParkWhereInput
   hours: OperatingHourManyRelationFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
+  services: ServiceManyRelationFilter
+  park: ParkWhereInput
 }
 
 input OperatingHourManyRelationFilter {
@@ -1008,11 +1067,11 @@ input FacilityUpdateInput {
   userGroups: UserGroupRelateToManyForUpdateInput
   address: LocationRelateToOneForUpdateInput
   contacts: ContactRelateToManyForUpdateInput
-  services: ServiceRelateToManyForUpdateInput
-  park: ParkRelateToOneForUpdateInput
   hours: OperatingHourRelateToManyForUpdateInput
   createdAt: DateTime
   updatedAt: DateTime
+  services: ServiceRelateToManyForUpdateInput
+  park: ParkRelateToOneForUpdateInput
 }
 
 input LocationRelateToOneForUpdateInput {
@@ -1021,17 +1080,17 @@ input LocationRelateToOneForUpdateInput {
   disconnect: Boolean
 }
 
-input ParkRelateToOneForUpdateInput {
-  create: ParkCreateInput
-  connect: ParkWhereUniqueInput
-  disconnect: Boolean
-}
-
 input OperatingHourRelateToManyForUpdateInput {
   disconnect: [OperatingHourWhereUniqueInput!]
   set: [OperatingHourWhereUniqueInput!]
   create: [OperatingHourCreateInput!]
   connect: [OperatingHourWhereUniqueInput!]
+}
+
+input ParkRelateToOneForUpdateInput {
+  create: ParkCreateInput
+  connect: ParkWhereUniqueInput
+  disconnect: Boolean
 }
 
 input FacilityUpdateArgs {
@@ -1053,11 +1112,11 @@ input FacilityCreateInput {
   userGroups: UserGroupRelateToManyForCreateInput
   address: LocationRelateToOneForCreateInput
   contacts: ContactRelateToManyForCreateInput
-  services: ServiceRelateToManyForCreateInput
-  park: ParkRelateToOneForCreateInput
   hours: OperatingHourRelateToManyForCreateInput
   createdAt: DateTime
   updatedAt: DateTime
+  services: ServiceRelateToManyForCreateInput
+  park: ParkRelateToOneForCreateInput
 }
 
 input LocationRelateToOneForCreateInput {
@@ -1065,14 +1124,14 @@ input LocationRelateToOneForCreateInput {
   connect: LocationWhereUniqueInput
 }
 
-input ParkRelateToOneForCreateInput {
-  create: ParkCreateInput
-  connect: ParkWhereUniqueInput
-}
-
 input OperatingHourRelateToManyForCreateInput {
   create: [OperatingHourCreateInput!]
   connect: [OperatingHourWhereUniqueInput!]
+}
+
+input ParkRelateToOneForCreateInput {
+  create: ParkCreateInput
+  connect: ParkWhereUniqueInput
 }
 
 type Highlight {
@@ -1352,18 +1411,21 @@ type OrgUnit {
   liveUrl: String
   slug: String
   owner: User
-  showPage: Boolean
+  body: String
   tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
   tagsCount(where: TagWhereInput! = {}): Int
+  userGroups(where: UserGroupWhereInput! = {}, orderBy: [UserGroupOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: UserGroupWhereUniqueInput): [UserGroup!]
+  userGroupsCount(where: UserGroupWhereInput! = {}): Int
   contacts(where: ContactWhereInput! = {}, orderBy: [ContactOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ContactWhereUniqueInput): [Contact!]
   contactsCount(where: ContactWhereInput! = {}): Int
+  createdAt: DateTime
+  updatedAt: DateTime
+  showPage: Boolean
   services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
   servicesCount(where: ServiceWhereInput! = {}): Int
   children(where: OrgUnitWhereInput! = {}, orderBy: [OrgUnitOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OrgUnitWhereUniqueInput): [OrgUnit!]
   childrenCount(where: OrgUnitWhereInput! = {}): Int
   parent: OrgUnit
-  createdAt: DateTime
-  updatedAt: DateTime
 }
 
 input OrgUnitWhereUniqueInput {
@@ -1384,14 +1446,16 @@ input OrgUnitWhereInput {
   reviewDate: DateTimeNullableFilter
   slug: StringFilter
   owner: UserWhereInput
-  showPage: BooleanFilter
+  body: MyStringFilter
   tags: TagManyRelationFilter
+  userGroups: UserGroupManyRelationFilter
   contacts: ContactManyRelationFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  showPage: BooleanFilter
   services: ServiceManyRelationFilter
   children: OrgUnitManyRelationFilter
   parent: OrgUnitWhereInput
-  createdAt: DateTimeNullableFilter
-  updatedAt: DateTimeNullableFilter
 }
 
 input BooleanFilter {
@@ -1408,9 +1472,10 @@ input OrgUnitOrderByInput {
   unpublishAt: OrderDirection
   reviewDate: OrderDirection
   slug: OrderDirection
-  showPage: OrderDirection
+  body: MyOrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
+  showPage: OrderDirection
 }
 
 input OrgUnitUpdateInput {
@@ -1422,14 +1487,16 @@ input OrgUnitUpdateInput {
   reviewDate: DateTime
   slug: String
   owner: UserRelateToOneForUpdateInput
-  showPage: Boolean
+  body: String
   tags: TagRelateToManyForUpdateInput
+  userGroups: UserGroupRelateToManyForUpdateInput
   contacts: ContactRelateToManyForUpdateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+  showPage: Boolean
   services: ServiceRelateToManyForUpdateInput
   children: OrgUnitRelateToManyForUpdateInput
   parent: OrgUnitRelateToOneForUpdateInput
-  createdAt: DateTime
-  updatedAt: DateTime
 }
 
 input OrgUnitRelateToOneForUpdateInput {
@@ -1452,14 +1519,16 @@ input OrgUnitCreateInput {
   reviewDate: DateTime
   slug: String
   owner: UserRelateToOneForCreateInput
-  showPage: Boolean
+  body: String
   tags: TagRelateToManyForCreateInput
+  userGroups: UserGroupRelateToManyForCreateInput
   contacts: ContactRelateToManyForCreateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+  showPage: Boolean
   services: ServiceRelateToManyForCreateInput
   children: OrgUnitRelateToManyForCreateInput
   parent: OrgUnitRelateToOneForCreateInput
-  createdAt: DateTime
-  updatedAt: DateTime
 }
 
 input OrgUnitRelateToOneForCreateInput {
@@ -1842,6 +1911,8 @@ type Tag {
   parksCount(where: ParkWhereInput! = {}): Int
   trails(where: TrailWhereInput! = {}, orderBy: [TrailOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TrailWhereUniqueInput): [Trail!]
   trailsCount(where: TrailWhereInput! = {}): Int
+  assemblyDistricts(where: AssemblyDistrictWhereInput! = {}, orderBy: [AssemblyDistrictOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AssemblyDistrictWhereUniqueInput): [AssemblyDistrict!]
+  assemblyDistrictsCount(where: AssemblyDistrictWhereInput! = {}): Int
 }
 
 input TagWhereUniqueInput {
@@ -1863,6 +1934,7 @@ input TagWhereInput {
   facilities: FacilityManyRelationFilter
   parks: ParkManyRelationFilter
   trails: TrailManyRelationFilter
+  assemblyDistricts: AssemblyDistrictManyRelationFilter
 }
 
 input ImageManyRelationFilter {
@@ -1887,6 +1959,7 @@ input TagUpdateInput {
   facilities: FacilityRelateToManyForUpdateInput
   parks: ParkRelateToManyForUpdateInput
   trails: TrailRelateToManyForUpdateInput
+  assemblyDistricts: AssemblyDistrictRelateToManyForUpdateInput
 }
 
 input ImageRelateToManyForUpdateInput {
@@ -1912,6 +1985,7 @@ input TagCreateInput {
   facilities: FacilityRelateToManyForCreateInput
   parks: ParkRelateToManyForCreateInput
   trails: TrailRelateToManyForCreateInput
+  assemblyDistricts: AssemblyDistrictRelateToManyForCreateInput
 }
 
 input ImageRelateToManyForCreateInput {
@@ -1936,6 +2010,10 @@ type Trail {
   userGroups(where: UserGroupWhereInput! = {}, orderBy: [UserGroupOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: UserGroupWhereUniqueInput): [UserGroup!]
   userGroupsCount(where: UserGroupWhereInput! = {}): Int
   address: Location
+  contacts(where: ContactWhereInput! = {}, orderBy: [ContactOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ContactWhereUniqueInput): [Contact!]
+  contactsCount(where: ContactWhereInput! = {}): Int
+  createdAt: DateTime
+  updatedAt: DateTime
   open: Boolean
   summer: Boolean
   fall: Boolean
@@ -1956,14 +2034,9 @@ type Trail {
   difficulty: String
   length: String
   elevationChange: String
-  groomed: Boolean
-  contacts(where: ContactWhereInput! = {}, orderBy: [ContactOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ContactWhereUniqueInput): [Contact!]
-  contactsCount(where: ContactWhereInput! = {}): Int
   services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
   servicesCount(where: ServiceWhereInput! = {}): Int
   park: Park
-  createdAt: DateTime
-  updatedAt: DateTime
 }
 
 input TrailWhereUniqueInput {
@@ -1988,6 +2061,9 @@ input TrailWhereInput {
   tags: TagManyRelationFilter
   userGroups: UserGroupManyRelationFilter
   address: LocationWhereInput
+  contacts: ContactManyRelationFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
   open: BooleanFilter
   summer: BooleanFilter
   fall: BooleanFilter
@@ -2008,12 +2084,8 @@ input TrailWhereInput {
   difficulty: StringNullableFilter
   length: StringFilter
   elevationChange: StringFilter
-  groomed: BooleanFilter
-  contacts: ContactManyRelationFilter
   services: ServiceManyRelationFilter
   park: ParkWhereInput
-  createdAt: DateTimeNullableFilter
-  updatedAt: DateTimeNullableFilter
 }
 
 input TrailOrderByInput {
@@ -2026,6 +2098,8 @@ input TrailOrderByInput {
   reviewDate: OrderDirection
   slug: OrderDirection
   body: MyOrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
   open: OrderDirection
   summer: OrderDirection
   fall: OrderDirection
@@ -2046,9 +2120,6 @@ input TrailOrderByInput {
   difficulty: OrderDirection
   length: OrderDirection
   elevationChange: OrderDirection
-  groomed: OrderDirection
-  createdAt: OrderDirection
-  updatedAt: OrderDirection
 }
 
 input TrailUpdateInput {
@@ -2064,6 +2135,9 @@ input TrailUpdateInput {
   tags: TagRelateToManyForUpdateInput
   userGroups: UserGroupRelateToManyForUpdateInput
   address: LocationRelateToOneForUpdateInput
+  contacts: ContactRelateToManyForUpdateInput
+  createdAt: DateTime
+  updatedAt: DateTime
   open: Boolean
   summer: Boolean
   fall: Boolean
@@ -2084,12 +2158,8 @@ input TrailUpdateInput {
   difficulty: String
   length: String
   elevationChange: String
-  groomed: Boolean
-  contacts: ContactRelateToManyForUpdateInput
   services: ServiceRelateToManyForUpdateInput
   park: ParkRelateToOneForUpdateInput
-  createdAt: DateTime
-  updatedAt: DateTime
 }
 
 input TrailUpdateArgs {
@@ -2110,6 +2180,9 @@ input TrailCreateInput {
   tags: TagRelateToManyForCreateInput
   userGroups: UserGroupRelateToManyForCreateInput
   address: LocationRelateToOneForCreateInput
+  contacts: ContactRelateToManyForCreateInput
+  createdAt: DateTime
+  updatedAt: DateTime
   open: Boolean
   summer: Boolean
   fall: Boolean
@@ -2130,12 +2203,8 @@ input TrailCreateInput {
   difficulty: String
   length: String
   elevationChange: String
-  groomed: Boolean
-  contacts: ContactRelateToManyForCreateInput
   services: ServiceRelateToManyForCreateInput
   park: ParkRelateToOneForCreateInput
-  createdAt: DateTime
-  updatedAt: DateTime
 }
 
 type Url {
@@ -2310,8 +2379,12 @@ type UserGroup {
   facilitiesCount(where: FacilityWhereInput! = {}): Int
   communities(where: CommunityWhereInput! = {}, orderBy: [CommunityOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: CommunityWhereUniqueInput): [Community!]
   communitiesCount(where: CommunityWhereInput! = {}): Int
+  orgUnits(where: OrgUnitWhereInput! = {}, orderBy: [OrgUnitOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OrgUnitWhereUniqueInput): [OrgUnit!]
+  orgUnitsCount(where: OrgUnitWhereInput! = {}): Int
   documentCollections(where: DocumentCollectionWhereInput! = {}, orderBy: [DocumentCollectionOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: DocumentCollectionWhereUniqueInput): [DocumentCollection!]
   documentCollectionsCount(where: DocumentCollectionWhereInput! = {}): Int
+  assemblyDistricts(where: AssemblyDistrictWhereInput! = {}, orderBy: [AssemblyDistrictOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AssemblyDistrictWhereUniqueInput): [AssemblyDistrict!]
+  assemblyDistrictsCount(where: AssemblyDistrictWhereInput! = {}): Int
 }
 
 input UserGroupWhereUniqueInput {
@@ -2332,7 +2405,9 @@ input UserGroupWhereInput {
   trails: TrailManyRelationFilter
   facilities: FacilityManyRelationFilter
   communities: CommunityManyRelationFilter
+  orgUnits: OrgUnitManyRelationFilter
   documentCollections: DocumentCollectionManyRelationFilter
+  assemblyDistricts: AssemblyDistrictManyRelationFilter
 }
 
 input UserManyRelationFilter {
@@ -2357,7 +2432,9 @@ input UserGroupUpdateInput {
   trails: TrailRelateToManyForUpdateInput
   facilities: FacilityRelateToManyForUpdateInput
   communities: CommunityRelateToManyForUpdateInput
+  orgUnits: OrgUnitRelateToManyForUpdateInput
   documentCollections: DocumentCollectionRelateToManyForUpdateInput
+  assemblyDistricts: AssemblyDistrictRelateToManyForUpdateInput
 }
 
 input UserRelateToManyForUpdateInput {
@@ -2382,7 +2459,9 @@ input UserGroupCreateInput {
   trails: TrailRelateToManyForCreateInput
   facilities: FacilityRelateToManyForCreateInput
   communities: CommunityRelateToManyForCreateInput
+  orgUnits: OrgUnitRelateToManyForCreateInput
   documentCollections: DocumentCollectionRelateToManyForCreateInput
+  assemblyDistricts: AssemblyDistrictRelateToManyForCreateInput
 }
 
 input UserRelateToManyForCreateInput {

--- a/apps/cms/schema.graphql
+++ b/apps/cms/schema.graphql
@@ -1649,18 +1649,18 @@ type Service {
   slug: String
   owner: User
   body: String
-  primaryAction: ExternalLink
-  secondaryActions(where: ExternalLinkWhereInput! = {}, orderBy: [ExternalLinkOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ExternalLinkWhereUniqueInput): [ExternalLink!]
-  secondaryActionsCount(where: ExternalLinkWhereInput! = {}): Int
-  actionLabel: String
-  actionUrl: String
   tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
   tagsCount(where: TagWhereInput! = {}): Int
   userGroups(where: UserGroupWhereInput! = {}, orderBy: [UserGroupOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: UserGroupWhereUniqueInput): [UserGroup!]
   userGroupsCount(where: UserGroupWhereInput! = {}): Int
-  primaryContact: Contact
+  primaryAction: ExternalLink
+  secondaryActions(where: ExternalLinkWhereInput! = {}, orderBy: [ExternalLinkOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ExternalLinkWhereUniqueInput): [ExternalLink!]
+  secondaryActionsCount(where: ExternalLinkWhereInput! = {}): Int
   contacts(where: ContactWhereInput! = {}, orderBy: [ContactOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ContactWhereUniqueInput): [Contact!]
   contactsCount(where: ContactWhereInput! = {}): Int
+  primaryContact: Contact
+  createdAt: DateTime
+  updatedAt: DateTime
   communities(where: CommunityWhereInput! = {}, orderBy: [CommunityOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: CommunityWhereUniqueInput): [Community!]
   communitiesCount(where: CommunityWhereInput! = {}): Int
   orgUnits(where: OrgUnitWhereInput! = {}, orderBy: [OrgUnitOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OrgUnitWhereUniqueInput): [OrgUnit!]
@@ -1671,8 +1671,6 @@ type Service {
   parksCount(where: ParkWhereInput! = {}): Int
   facilities(where: FacilityWhereInput! = {}, orderBy: [FacilityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: FacilityWhereUniqueInput): [Facility!]
   facilitiesCount(where: FacilityWhereInput! = {}): Int
-  createdAt: DateTime
-  updatedAt: DateTime
   editorNotes: String
 }
 
@@ -1695,21 +1693,19 @@ input ServiceWhereInput {
   slug: StringFilter
   owner: UserWhereInput
   body: MyStringFilter
-  primaryAction: ExternalLinkWhereInput
-  secondaryActions: ExternalLinkManyRelationFilter
-  actionLabel: StringNullableFilter
-  actionUrl: StringNullableFilter
   tags: TagManyRelationFilter
   userGroups: UserGroupManyRelationFilter
-  primaryContact: ContactWhereInput
+  primaryAction: ExternalLinkWhereInput
+  secondaryActions: ExternalLinkManyRelationFilter
   contacts: ContactManyRelationFilter
+  primaryContact: ContactWhereInput
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
   communities: CommunityManyRelationFilter
   orgUnits: OrgUnitManyRelationFilter
   trails: TrailManyRelationFilter
   parks: ParkManyRelationFilter
   facilities: FacilityManyRelationFilter
-  createdAt: DateTimeNullableFilter
-  updatedAt: DateTimeNullableFilter
   editorNotes: StringFilter
 }
 
@@ -1729,8 +1725,6 @@ input ServiceOrderByInput {
   reviewDate: OrderDirection
   slug: OrderDirection
   body: MyOrderDirection
-  actionLabel: OrderDirection
-  actionUrl: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
   editorNotes: OrderDirection
@@ -1746,21 +1740,19 @@ input ServiceUpdateInput {
   slug: String
   owner: UserRelateToOneForUpdateInput
   body: String
-  primaryAction: ExternalLinkRelateToOneForUpdateInput
-  secondaryActions: ExternalLinkRelateToManyForUpdateInput
-  actionLabel: String
-  actionUrl: String
   tags: TagRelateToManyForUpdateInput
   userGroups: UserGroupRelateToManyForUpdateInput
-  primaryContact: ContactRelateToOneForUpdateInput
+  primaryAction: ExternalLinkRelateToOneForUpdateInput
+  secondaryActions: ExternalLinkRelateToManyForUpdateInput
   contacts: ContactRelateToManyForUpdateInput
+  primaryContact: ContactRelateToOneForUpdateInput
+  createdAt: DateTime
+  updatedAt: DateTime
   communities: CommunityRelateToManyForUpdateInput
   orgUnits: OrgUnitRelateToManyForUpdateInput
   trails: TrailRelateToManyForUpdateInput
   parks: ParkRelateToManyForUpdateInput
   facilities: FacilityRelateToManyForUpdateInput
-  createdAt: DateTime
-  updatedAt: DateTime
   editorNotes: String
 }
 
@@ -1798,21 +1790,19 @@ input ServiceCreateInput {
   slug: String
   owner: UserRelateToOneForCreateInput
   body: String
-  primaryAction: ExternalLinkRelateToOneForCreateInput
-  secondaryActions: ExternalLinkRelateToManyForCreateInput
-  actionLabel: String
-  actionUrl: String
   tags: TagRelateToManyForCreateInput
   userGroups: UserGroupRelateToManyForCreateInput
-  primaryContact: ContactRelateToOneForCreateInput
+  primaryAction: ExternalLinkRelateToOneForCreateInput
+  secondaryActions: ExternalLinkRelateToManyForCreateInput
   contacts: ContactRelateToManyForCreateInput
+  primaryContact: ContactRelateToOneForCreateInput
+  createdAt: DateTime
+  updatedAt: DateTime
   communities: CommunityRelateToManyForCreateInput
   orgUnits: OrgUnitRelateToManyForCreateInput
   trails: TrailRelateToManyForCreateInput
   parks: ParkRelateToManyForCreateInput
   facilities: FacilityRelateToManyForCreateInput
-  createdAt: DateTime
-  updatedAt: DateTime
   editorNotes: String
 }
 

--- a/apps/cms/schema.graphql
+++ b/apps/cms/schema.graphql
@@ -1531,16 +1531,16 @@ type Park {
   address: Location
   contacts(where: ContactWhereInput! = {}, orderBy: [ContactOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ContactWhereUniqueInput): [Contact!]
   contactsCount(where: ContactWhereInput! = {}): Int
+  hours(where: OperatingHourWhereInput! = {}, orderBy: [OperatingHourOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OperatingHourWhereUniqueInput): [OperatingHour!]
+  hoursCount(where: OperatingHourWhereInput! = {}): Int
+  createdAt: DateTime
+  updatedAt: DateTime
   services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
   servicesCount(where: ServiceWhereInput! = {}): Int
   trails(where: TrailWhereInput! = {}, orderBy: [TrailOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TrailWhereUniqueInput): [Trail!]
   trailsCount(where: TrailWhereInput! = {}): Int
   facilities(where: FacilityWhereInput! = {}, orderBy: [FacilityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: FacilityWhereUniqueInput): [Facility!]
   facilitiesCount(where: FacilityWhereInput! = {}): Int
-  hours(where: OperatingHourWhereInput! = {}, orderBy: [OperatingHourOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OperatingHourWhereUniqueInput): [OperatingHour!]
-  hoursCount(where: OperatingHourWhereInput! = {}): Int
-  createdAt: DateTime
-  updatedAt: DateTime
 }
 
 input ParkWhereUniqueInput {
@@ -1566,12 +1566,12 @@ input ParkWhereInput {
   userGroups: UserGroupManyRelationFilter
   address: LocationWhereInput
   contacts: ContactManyRelationFilter
-  services: ServiceManyRelationFilter
-  trails: TrailManyRelationFilter
-  facilities: FacilityManyRelationFilter
   hours: OperatingHourManyRelationFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
+  services: ServiceManyRelationFilter
+  trails: TrailManyRelationFilter
+  facilities: FacilityManyRelationFilter
 }
 
 input ParkOrderByInput {
@@ -1602,12 +1602,12 @@ input ParkUpdateInput {
   userGroups: UserGroupRelateToManyForUpdateInput
   address: LocationRelateToOneForUpdateInput
   contacts: ContactRelateToManyForUpdateInput
-  services: ServiceRelateToManyForUpdateInput
-  trails: TrailRelateToManyForUpdateInput
-  facilities: FacilityRelateToManyForUpdateInput
   hours: OperatingHourRelateToManyForUpdateInput
   createdAt: DateTime
   updatedAt: DateTime
+  services: ServiceRelateToManyForUpdateInput
+  trails: TrailRelateToManyForUpdateInput
+  facilities: FacilityRelateToManyForUpdateInput
 }
 
 input ParkUpdateArgs {
@@ -1629,12 +1629,12 @@ input ParkCreateInput {
   userGroups: UserGroupRelateToManyForCreateInput
   address: LocationRelateToOneForCreateInput
   contacts: ContactRelateToManyForCreateInput
-  services: ServiceRelateToManyForCreateInput
-  trails: TrailRelateToManyForCreateInput
-  facilities: FacilityRelateToManyForCreateInput
   hours: OperatingHourRelateToManyForCreateInput
   createdAt: DateTime
   updatedAt: DateTime
+  services: ServiceRelateToManyForCreateInput
+  trails: TrailRelateToManyForCreateInput
+  facilities: FacilityRelateToManyForCreateInput
 }
 
 type Service {
@@ -1656,9 +1656,9 @@ type Service {
   primaryAction: ExternalLink
   secondaryActions(where: ExternalLinkWhereInput! = {}, orderBy: [ExternalLinkOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ExternalLinkWhereUniqueInput): [ExternalLink!]
   secondaryActionsCount(where: ExternalLinkWhereInput! = {}): Int
+  primaryContact: Contact
   contacts(where: ContactWhereInput! = {}, orderBy: [ContactOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ContactWhereUniqueInput): [Contact!]
   contactsCount(where: ContactWhereInput! = {}): Int
-  primaryContact: Contact
   createdAt: DateTime
   updatedAt: DateTime
   communities(where: CommunityWhereInput! = {}, orderBy: [CommunityOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: CommunityWhereUniqueInput): [Community!]
@@ -1697,8 +1697,8 @@ input ServiceWhereInput {
   userGroups: UserGroupManyRelationFilter
   primaryAction: ExternalLinkWhereInput
   secondaryActions: ExternalLinkManyRelationFilter
-  contacts: ContactManyRelationFilter
   primaryContact: ContactWhereInput
+  contacts: ContactManyRelationFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
   communities: CommunityManyRelationFilter
@@ -1744,8 +1744,8 @@ input ServiceUpdateInput {
   userGroups: UserGroupRelateToManyForUpdateInput
   primaryAction: ExternalLinkRelateToOneForUpdateInput
   secondaryActions: ExternalLinkRelateToManyForUpdateInput
-  contacts: ContactRelateToManyForUpdateInput
   primaryContact: ContactRelateToOneForUpdateInput
+  contacts: ContactRelateToManyForUpdateInput
   createdAt: DateTime
   updatedAt: DateTime
   communities: CommunityRelateToManyForUpdateInput
@@ -1794,8 +1794,8 @@ input ServiceCreateInput {
   userGroups: UserGroupRelateToManyForCreateInput
   primaryAction: ExternalLinkRelateToOneForCreateInput
   secondaryActions: ExternalLinkRelateToManyForCreateInput
-  contacts: ContactRelateToManyForCreateInput
   primaryContact: ContactRelateToOneForCreateInput
+  contacts: ContactRelateToManyForCreateInput
   createdAt: DateTime
   updatedAt: DateTime
   communities: CommunityRelateToManyForCreateInput

--- a/apps/cms/schema.graphql
+++ b/apps/cms/schema.graphql
@@ -1247,6 +1247,100 @@ input InternalLinkRelateToOneForCreateInput {
   connect: InternalLinkWhereUniqueInput
 }
 
+type HomePage {
+  id: ID!
+  heroImage: String
+  title: String
+  description: String
+  toolbeltOne: Highlight
+  toolbeltTwo: Highlight
+  toolbeltThree: Highlight
+  toolbeltFour: Highlight
+  highlightOne: Highlight
+  highlightTwo: Highlight
+  highlightThree: Highlight
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+input HomePageWhereUniqueInput {
+  id: ID
+  title: String
+}
+
+input HomePageWhereInput {
+  AND: [HomePageWhereInput!]
+  OR: [HomePageWhereInput!]
+  NOT: [HomePageWhereInput!]
+  id: IDFilter
+  title: StringFilter
+  description: StringFilter
+  toolbeltOne: HighlightWhereInput
+  toolbeltTwo: HighlightWhereInput
+  toolbeltThree: HighlightWhereInput
+  toolbeltFour: HighlightWhereInput
+  highlightOne: HighlightWhereInput
+  highlightTwo: HighlightWhereInput
+  highlightThree: HighlightWhereInput
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+}
+
+input HomePageOrderByInput {
+  id: OrderDirection
+  heroImage: BlueHarvestImageOrderDirection
+  title: OrderDirection
+  description: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input HomePageUpdateInput {
+  heroImage: String
+  title: String
+  description: String
+  toolbeltOne: HighlightRelateToOneForUpdateInput
+  toolbeltTwo: HighlightRelateToOneForUpdateInput
+  toolbeltThree: HighlightRelateToOneForUpdateInput
+  toolbeltFour: HighlightRelateToOneForUpdateInput
+  highlightOne: HighlightRelateToOneForUpdateInput
+  highlightTwo: HighlightRelateToOneForUpdateInput
+  highlightThree: HighlightRelateToOneForUpdateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+input HighlightRelateToOneForUpdateInput {
+  create: HighlightCreateInput
+  connect: HighlightWhereUniqueInput
+  disconnect: Boolean
+}
+
+input HomePageUpdateArgs {
+  where: HomePageWhereUniqueInput! = {id: 1}
+  data: HomePageUpdateInput!
+}
+
+input HomePageCreateInput {
+  heroImage: String
+  title: String
+  description: String
+  toolbeltOne: HighlightRelateToOneForCreateInput
+  toolbeltTwo: HighlightRelateToOneForCreateInput
+  toolbeltThree: HighlightRelateToOneForCreateInput
+  toolbeltFour: HighlightRelateToOneForCreateInput
+  highlightOne: HighlightRelateToOneForCreateInput
+  highlightTwo: HighlightRelateToOneForCreateInput
+  highlightThree: HighlightRelateToOneForCreateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+input HighlightRelateToOneForCreateInput {
+  create: HighlightCreateInput
+  connect: HighlightWhereUniqueInput
+}
+
 type Image {
   id: ID!
   title: String
@@ -1754,6 +1848,20 @@ type PublicNotice {
   updatedAt: DateTime
   effectiveDate: DateTime
   endDate: DateTime
+  parks(where: ParkWhereInput! = {}, orderBy: [ParkOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ParkWhereUniqueInput): [Park!]
+  parksCount(where: ParkWhereInput! = {}): Int
+  services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
+  servicesCount(where: ServiceWhereInput! = {}): Int
+  orgUnits(where: OrgUnitWhereInput! = {}, orderBy: [OrgUnitOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OrgUnitWhereUniqueInput): [OrgUnit!]
+  orgUnitsCount(where: OrgUnitWhereInput! = {}): Int
+  facilities(where: FacilityWhereInput! = {}, orderBy: [FacilityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: FacilityWhereUniqueInput): [Facility!]
+  facilitiesCount(where: FacilityWhereInput! = {}): Int
+  trails(where: TrailWhereInput! = {}, orderBy: [TrailOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TrailWhereUniqueInput): [Trail!]
+  trailsCount(where: TrailWhereInput! = {}): Int
+  communities(where: CommunityWhereInput! = {}, orderBy: [CommunityOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: CommunityWhereUniqueInput): [Community!]
+  communitiesCount(where: CommunityWhereInput! = {}): Int
+  assemblyDistricts(where: AssemblyDistrictWhereInput! = {}, orderBy: [AssemblyDistrictOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AssemblyDistrictWhereUniqueInput): [AssemblyDistrict!]
+  assemblyDistrictsCount(where: AssemblyDistrictWhereInput! = {}): Int
 }
 
 input PublicNoticeWhereUniqueInput {
@@ -1784,6 +1892,13 @@ input PublicNoticeWhereInput {
   updatedAt: DateTimeNullableFilter
   effectiveDate: DateTimeNullableFilter
   endDate: DateTimeNullableFilter
+  parks: ParkManyRelationFilter
+  services: ServiceManyRelationFilter
+  orgUnits: OrgUnitManyRelationFilter
+  facilities: FacilityManyRelationFilter
+  trails: TrailManyRelationFilter
+  communities: CommunityManyRelationFilter
+  assemblyDistricts: AssemblyDistrictManyRelationFilter
 }
 
 input PublicNoticeOrderByInput {
@@ -1821,6 +1936,13 @@ input PublicNoticeUpdateInput {
   updatedAt: DateTime
   effectiveDate: DateTime
   endDate: DateTime
+  parks: ParkRelateToManyForUpdateInput
+  services: ServiceRelateToManyForUpdateInput
+  orgUnits: OrgUnitRelateToManyForUpdateInput
+  facilities: FacilityRelateToManyForUpdateInput
+  trails: TrailRelateToManyForUpdateInput
+  communities: CommunityRelateToManyForUpdateInput
+  assemblyDistricts: AssemblyDistrictRelateToManyForUpdateInput
 }
 
 input PublicNoticeUpdateArgs {
@@ -1847,6 +1969,13 @@ input PublicNoticeCreateInput {
   updatedAt: DateTime
   effectiveDate: DateTime
   endDate: DateTime
+  parks: ParkRelateToManyForCreateInput
+  services: ServiceRelateToManyForCreateInput
+  orgUnits: OrgUnitRelateToManyForCreateInput
+  facilities: FacilityRelateToManyForCreateInput
+  trails: TrailRelateToManyForCreateInput
+  communities: CommunityRelateToManyForCreateInput
+  assemblyDistricts: AssemblyDistrictRelateToManyForCreateInput
 }
 
 type Service {
@@ -2682,6 +2811,12 @@ type Mutation {
   updateHighlights(data: [HighlightUpdateArgs!]!): [Highlight]
   deleteHighlight(where: HighlightWhereUniqueInput!): Highlight
   deleteHighlights(where: [HighlightWhereUniqueInput!]!): [Highlight]
+  createHomePage(data: HomePageCreateInput!): HomePage
+  createHomePages(data: [HomePageCreateInput!]!): [HomePage]
+  updateHomePage(where: HomePageWhereUniqueInput! = {id: 1}, data: HomePageUpdateInput!): HomePage
+  updateHomePages(data: [HomePageUpdateArgs!]!): [HomePage]
+  deleteHomePage(where: HomePageWhereUniqueInput! = {id: 1}): HomePage
+  deleteHomePages(where: [HomePageWhereUniqueInput!]!): [HomePage]
   createImage(data: ImageCreateInput!): Image
   createImages(data: [ImageCreateInput!]!): [Image]
   updateImage(where: ImageWhereUniqueInput!, data: ImageUpdateInput!): Image
@@ -2791,6 +2926,9 @@ type Query {
   highlight(where: HighlightWhereUniqueInput!): Highlight
   highlights(where: HighlightWhereInput! = {}, orderBy: [HighlightOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: HighlightWhereUniqueInput): [Highlight!]
   highlightsCount(where: HighlightWhereInput! = {}): Int
+  homePage(where: HomePageWhereUniqueInput! = {id: 1}): HomePage
+  homePages(where: HomePageWhereInput! = {id: {equals: 1}}, orderBy: [HomePageOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: HomePageWhereUniqueInput): [HomePage!]
+  homePagesCount(where: HomePageWhereInput! = {id: {equals: 1}}): Int
   image(where: ImageWhereUniqueInput!): Image
   images(where: ImageWhereInput! = {}, orderBy: [ImageOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ImageWhereUniqueInput): [Image!]
   imagesCount(where: ImageWhereInput! = {}): Int

--- a/apps/cms/schema.graphql
+++ b/apps/cms/schema.graphql
@@ -591,6 +591,8 @@ type Contact {
   trailsCount(where: TrailWhereInput! = {}): Int
   user: User
   editorNotes: String
+  publicNotices(where: PublicNoticeWhereInput! = {}, orderBy: [PublicNoticeOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PublicNoticeWhereUniqueInput): [PublicNotice!]
+  publicNoticesCount(where: PublicNoticeWhereInput! = {}): Int
 }
 
 input ContactWhereUniqueInput {
@@ -616,6 +618,7 @@ input ContactWhereInput {
   trails: TrailManyRelationFilter
   user: UserWhereInput
   editorNotes: StringFilter
+  publicNotices: PublicNoticeManyRelationFilter
 }
 
 input CommunityManyRelationFilter {
@@ -648,6 +651,12 @@ input TrailManyRelationFilter {
   none: TrailWhereInput
 }
 
+input PublicNoticeManyRelationFilter {
+  every: PublicNoticeWhereInput
+  some: PublicNoticeWhereInput
+  none: PublicNoticeWhereInput
+}
+
 input ContactOrderByInput {
   id: OrderDirection
   name: OrderDirection
@@ -672,6 +681,7 @@ input ContactUpdateInput {
   trails: TrailRelateToManyForUpdateInput
   user: UserRelateToOneForUpdateInput
   editorNotes: String
+  publicNotices: PublicNoticeRelateToManyForUpdateInput
 }
 
 input CommunityRelateToManyForUpdateInput {
@@ -709,6 +719,13 @@ input TrailRelateToManyForUpdateInput {
   connect: [TrailWhereUniqueInput!]
 }
 
+input PublicNoticeRelateToManyForUpdateInput {
+  disconnect: [PublicNoticeWhereUniqueInput!]
+  set: [PublicNoticeWhereUniqueInput!]
+  create: [PublicNoticeCreateInput!]
+  connect: [PublicNoticeWhereUniqueInput!]
+}
+
 input ContactUpdateArgs {
   where: ContactWhereUniqueInput!
   data: ContactUpdateInput!
@@ -729,6 +746,7 @@ input ContactCreateInput {
   trails: TrailRelateToManyForCreateInput
   user: UserRelateToOneForCreateInput
   editorNotes: String
+  publicNotices: PublicNoticeRelateToManyForCreateInput
 }
 
 input CommunityRelateToManyForCreateInput {
@@ -754,6 +772,11 @@ input ParkRelateToManyForCreateInput {
 input TrailRelateToManyForCreateInput {
   create: [TrailCreateInput!]
   connect: [TrailWhereUniqueInput!]
+}
+
+input PublicNoticeRelateToManyForCreateInput {
+  create: [PublicNoticeCreateInput!]
+  connect: [PublicNoticeWhereUniqueInput!]
 }
 
 type Document {
@@ -1706,6 +1729,126 @@ input ParkCreateInput {
   facilities: FacilityRelateToManyForCreateInput
 }
 
+type PublicNotice {
+  id: ID!
+  heroImage: String
+  title: String
+  description: String
+  publishAt: DateTime
+  unpublishAt: DateTime
+  reviewDate: DateTime
+  liveUrl: String
+  slug: String
+  owner: User
+  body: String
+  tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
+  tagsCount(where: TagWhereInput! = {}): Int
+  userGroups(where: UserGroupWhereInput! = {}, orderBy: [UserGroupOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: UserGroupWhereUniqueInput): [UserGroup!]
+  userGroupsCount(where: UserGroupWhereInput! = {}): Int
+  actions: InternalLink
+  documents(where: DocumentWhereInput! = {}, orderBy: [DocumentOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: DocumentWhereUniqueInput): [Document!]
+  documentsCount(where: DocumentWhereInput! = {}): Int
+  contacts(where: ContactWhereInput! = {}, orderBy: [ContactOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ContactWhereUniqueInput): [Contact!]
+  contactsCount(where: ContactWhereInput! = {}): Int
+  createdAt: DateTime
+  updatedAt: DateTime
+  effectiveDate: DateTime
+  endDate: DateTime
+}
+
+input PublicNoticeWhereUniqueInput {
+  id: ID
+  title: String
+  slug: String
+}
+
+input PublicNoticeWhereInput {
+  AND: [PublicNoticeWhereInput!]
+  OR: [PublicNoticeWhereInput!]
+  NOT: [PublicNoticeWhereInput!]
+  id: IDFilter
+  title: StringFilter
+  description: StringFilter
+  publishAt: DateTimeNullableFilter
+  unpublishAt: DateTimeNullableFilter
+  reviewDate: DateTimeNullableFilter
+  slug: StringFilter
+  owner: UserWhereInput
+  body: MyStringFilter
+  tags: TagManyRelationFilter
+  userGroups: UserGroupManyRelationFilter
+  actions: InternalLinkWhereInput
+  documents: DocumentManyRelationFilter
+  contacts: ContactManyRelationFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  effectiveDate: DateTimeNullableFilter
+  endDate: DateTimeNullableFilter
+}
+
+input PublicNoticeOrderByInput {
+  id: OrderDirection
+  heroImage: BlueHarvestImageOrderDirection
+  title: OrderDirection
+  description: OrderDirection
+  publishAt: OrderDirection
+  unpublishAt: OrderDirection
+  reviewDate: OrderDirection
+  slug: OrderDirection
+  body: MyOrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+  effectiveDate: OrderDirection
+  endDate: OrderDirection
+}
+
+input PublicNoticeUpdateInput {
+  heroImage: String
+  title: String
+  description: String
+  publishAt: DateTime
+  unpublishAt: DateTime
+  reviewDate: DateTime
+  slug: String
+  owner: UserRelateToOneForUpdateInput
+  body: String
+  tags: TagRelateToManyForUpdateInput
+  userGroups: UserGroupRelateToManyForUpdateInput
+  actions: InternalLinkRelateToOneForUpdateInput
+  documents: DocumentRelateToManyForUpdateInput
+  contacts: ContactRelateToManyForUpdateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+  effectiveDate: DateTime
+  endDate: DateTime
+}
+
+input PublicNoticeUpdateArgs {
+  where: PublicNoticeWhereUniqueInput!
+  data: PublicNoticeUpdateInput!
+}
+
+input PublicNoticeCreateInput {
+  heroImage: String
+  title: String
+  description: String
+  publishAt: DateTime
+  unpublishAt: DateTime
+  reviewDate: DateTime
+  slug: String
+  owner: UserRelateToOneForCreateInput
+  body: String
+  tags: TagRelateToManyForCreateInput
+  userGroups: UserGroupRelateToManyForCreateInput
+  actions: InternalLinkRelateToOneForCreateInput
+  documents: DocumentRelateToManyForCreateInput
+  contacts: ContactRelateToManyForCreateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+  effectiveDate: DateTime
+  endDate: DateTime
+}
+
 type Service {
   id: ID!
   heroImage: String
@@ -1913,6 +2056,8 @@ type Tag {
   trailsCount(where: TrailWhereInput! = {}): Int
   assemblyDistricts(where: AssemblyDistrictWhereInput! = {}, orderBy: [AssemblyDistrictOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AssemblyDistrictWhereUniqueInput): [AssemblyDistrict!]
   assemblyDistrictsCount(where: AssemblyDistrictWhereInput! = {}): Int
+  publicNotices(where: PublicNoticeWhereInput! = {}, orderBy: [PublicNoticeOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PublicNoticeWhereUniqueInput): [PublicNotice!]
+  publicNoticesCount(where: PublicNoticeWhereInput! = {}): Int
 }
 
 input TagWhereUniqueInput {
@@ -1935,6 +2080,7 @@ input TagWhereInput {
   parks: ParkManyRelationFilter
   trails: TrailManyRelationFilter
   assemblyDistricts: AssemblyDistrictManyRelationFilter
+  publicNotices: PublicNoticeManyRelationFilter
 }
 
 input ImageManyRelationFilter {
@@ -1960,6 +2106,7 @@ input TagUpdateInput {
   parks: ParkRelateToManyForUpdateInput
   trails: TrailRelateToManyForUpdateInput
   assemblyDistricts: AssemblyDistrictRelateToManyForUpdateInput
+  publicNotices: PublicNoticeRelateToManyForUpdateInput
 }
 
 input ImageRelateToManyForUpdateInput {
@@ -1986,6 +2133,7 @@ input TagCreateInput {
   parks: ParkRelateToManyForCreateInput
   trails: TrailRelateToManyForCreateInput
   assemblyDistricts: AssemblyDistrictRelateToManyForCreateInput
+  publicNotices: PublicNoticeRelateToManyForCreateInput
 }
 
 input ImageRelateToManyForCreateInput {
@@ -2385,6 +2533,8 @@ type UserGroup {
   documentCollectionsCount(where: DocumentCollectionWhereInput! = {}): Int
   assemblyDistricts(where: AssemblyDistrictWhereInput! = {}, orderBy: [AssemblyDistrictOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AssemblyDistrictWhereUniqueInput): [AssemblyDistrict!]
   assemblyDistrictsCount(where: AssemblyDistrictWhereInput! = {}): Int
+  publicNotices(where: PublicNoticeWhereInput! = {}, orderBy: [PublicNoticeOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PublicNoticeWhereUniqueInput): [PublicNotice!]
+  publicNoticesCount(where: PublicNoticeWhereInput! = {}): Int
 }
 
 input UserGroupWhereUniqueInput {
@@ -2408,6 +2558,7 @@ input UserGroupWhereInput {
   orgUnits: OrgUnitManyRelationFilter
   documentCollections: DocumentCollectionManyRelationFilter
   assemblyDistricts: AssemblyDistrictManyRelationFilter
+  publicNotices: PublicNoticeManyRelationFilter
 }
 
 input UserManyRelationFilter {
@@ -2435,6 +2586,7 @@ input UserGroupUpdateInput {
   orgUnits: OrgUnitRelateToManyForUpdateInput
   documentCollections: DocumentCollectionRelateToManyForUpdateInput
   assemblyDistricts: AssemblyDistrictRelateToManyForUpdateInput
+  publicNotices: PublicNoticeRelateToManyForUpdateInput
 }
 
 input UserRelateToManyForUpdateInput {
@@ -2462,6 +2614,7 @@ input UserGroupCreateInput {
   orgUnits: OrgUnitRelateToManyForCreateInput
   documentCollections: DocumentCollectionRelateToManyForCreateInput
   assemblyDistricts: AssemblyDistrictRelateToManyForCreateInput
+  publicNotices: PublicNoticeRelateToManyForCreateInput
 }
 
 input UserRelateToManyForCreateInput {
@@ -2565,6 +2718,12 @@ type Mutation {
   updateParks(data: [ParkUpdateArgs!]!): [Park]
   deletePark(where: ParkWhereUniqueInput!): Park
   deleteParks(where: [ParkWhereUniqueInput!]!): [Park]
+  createPublicNotice(data: PublicNoticeCreateInput!): PublicNotice
+  createPublicNotices(data: [PublicNoticeCreateInput!]!): [PublicNotice]
+  updatePublicNotice(where: PublicNoticeWhereUniqueInput!, data: PublicNoticeUpdateInput!): PublicNotice
+  updatePublicNotices(data: [PublicNoticeUpdateArgs!]!): [PublicNotice]
+  deletePublicNotice(where: PublicNoticeWhereUniqueInput!): PublicNotice
+  deletePublicNotices(where: [PublicNoticeWhereUniqueInput!]!): [PublicNotice]
   createService(data: ServiceCreateInput!): Service
   createServices(data: [ServiceCreateInput!]!): [Service]
   updateService(where: ServiceWhereUniqueInput!, data: ServiceUpdateInput!): Service
@@ -2650,6 +2809,9 @@ type Query {
   park(where: ParkWhereUniqueInput!): Park
   parks(where: ParkWhereInput! = {}, orderBy: [ParkOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ParkWhereUniqueInput): [Park!]
   parksCount(where: ParkWhereInput! = {}): Int
+  publicNotice(where: PublicNoticeWhereUniqueInput!): PublicNotice
+  publicNotices(where: PublicNoticeWhereInput! = {}, orderBy: [PublicNoticeOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PublicNoticeWhereUniqueInput): [PublicNotice!]
+  publicNoticesCount(where: PublicNoticeWhereInput! = {}): Int
   service(where: ServiceWhereUniqueInput!): Service
   services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
   servicesCount(where: ServiceWhereInput! = {}): Int

--- a/apps/cms/schema.graphql
+++ b/apps/cms/schema.graphql
@@ -1846,6 +1846,7 @@ type PublicNotice {
   contactsCount(where: ContactWhereInput! = {}): Int
   createdAt: DateTime
   updatedAt: DateTime
+  urgency: Int
   effectiveDate: DateTime
   endDate: DateTime
   parks(where: ParkWhereInput! = {}, orderBy: [ParkOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ParkWhereUniqueInput): [Park!]
@@ -1890,6 +1891,7 @@ input PublicNoticeWhereInput {
   contacts: ContactManyRelationFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
+  urgency: IntFilter
   effectiveDate: DateTimeNullableFilter
   endDate: DateTimeNullableFilter
   parks: ParkManyRelationFilter
@@ -1913,6 +1915,7 @@ input PublicNoticeOrderByInput {
   body: MyOrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
+  urgency: OrderDirection
   effectiveDate: OrderDirection
   endDate: OrderDirection
 }
@@ -1934,6 +1937,7 @@ input PublicNoticeUpdateInput {
   contacts: ContactRelateToManyForUpdateInput
   createdAt: DateTime
   updatedAt: DateTime
+  urgency: Int
   effectiveDate: DateTime
   endDate: DateTime
   parks: ParkRelateToManyForUpdateInput
@@ -1967,6 +1971,7 @@ input PublicNoticeCreateInput {
   contacts: ContactRelateToManyForCreateInput
   createdAt: DateTime
   updatedAt: DateTime
+  urgency: Int
   effectiveDate: DateTime
   endDate: DateTime
   parks: ParkRelateToManyForCreateInput

--- a/apps/cms/schema.prisma
+++ b/apps/cms/schema.prisma
@@ -277,23 +277,21 @@ model Service {
   owner            User?          @relation("Service_owner", fields: [ownerId], references: [id])
   ownerId          String?        @map("owner")
   body             String?
+  tags             Tag[]          @relation("Service_tags")
+  userGroups       UserGroup[]    @relation("Service_userGroups")
   primaryAction    ExternalLink?  @relation("Service_primaryAction", fields: [primaryActionId], references: [id])
   primaryActionId  String?        @map("primaryAction")
   secondaryActions ExternalLink[] @relation("Service_secondaryActions")
-  actionLabel      String?
-  actionUrl        String?
-  tags             Tag[]          @relation("Service_tags")
-  userGroups       UserGroup[]    @relation("Service_userGroups")
+  contacts         Contact[]      @relation("Contact_services")
   primaryContact   Contact?       @relation("Service_primaryContact", fields: [primaryContactId], references: [id])
   primaryContactId String?        @map("primaryContact")
-  contacts         Contact[]      @relation("Contact_services")
+  createdAt        DateTime?      @default(now())
+  updatedAt        DateTime?      @default(now()) @updatedAt
   communities      Community[]    @relation("Community_services")
   orgUnits         OrgUnit[]      @relation("OrgUnit_services")
   trails           Trail[]        @relation("Service_trails")
   parks            Park[]         @relation("Park_services")
   facilities       Facility[]     @relation("Facility_services")
-  createdAt        DateTime?      @default(now())
-  updatedAt        DateTime?      @default(now()) @updatedAt
   editorNotes      String         @default("")
 
   @@index([ownerId])

--- a/apps/cms/schema.prisma
+++ b/apps/cms/schema.prisma
@@ -96,17 +96,19 @@ model Contact {
   user              User?              @relation("Contact_user", fields: [userId], references: [id])
   userId            String?            @unique @map("user")
   editorNotes       String             @default("")
+  publicNotices     PublicNotice[]     @relation("Contact_publicNotices")
 }
 
 model Document {
-  id            String               @id @default(cuid())
-  title         String               @default("")
-  description   String               @default("")
-  tags          Tag[]                @relation("Document_tags")
-  file_filesize Int?
-  file_filename String?
-  collections   DocumentCollection[] @relation("Document_collections")
-  editorNotes   String               @default("")
+  id                          String               @id @default(cuid())
+  title                       String               @default("")
+  description                 String               @default("")
+  tags                        Tag[]                @relation("Document_tags")
+  file_filesize               Int?
+  file_filename               String?
+  collections                 DocumentCollection[] @relation("Document_collections")
+  editorNotes                 String               @default("")
+  from_PublicNotice_documents PublicNotice[]       @relation("PublicNotice_documents")
 
   @@index([title])
 }
@@ -195,10 +197,11 @@ model Image {
 }
 
 model InternalLink {
-  id                        String      @id @default(cuid())
-  label                     String      @default("")
+  id                        String         @id @default(cuid())
+  label                     String         @default("")
   selectItem                Json?
-  from_Highlight_linkedItem Highlight[] @relation("Highlight_linkedItem")
+  from_Highlight_linkedItem Highlight[]    @relation("Highlight_linkedItem")
+  from_PublicNotice_actions PublicNotice[] @relation("PublicNotice_actions")
 }
 
 model Location {
@@ -279,6 +282,33 @@ model Park {
   @@index([addressId])
 }
 
+model PublicNotice {
+  id            String        @id @default(cuid())
+  heroImage     String?
+  title         String        @unique @default("")
+  description   String        @default("")
+  publishAt     DateTime?
+  unpublishAt   DateTime?
+  reviewDate    DateTime?
+  slug          String        @unique @default("")
+  owner         User?         @relation("PublicNotice_owner", fields: [ownerId], references: [id])
+  ownerId       String?       @map("owner")
+  body          String?
+  tags          Tag[]         @relation("PublicNotice_tags")
+  userGroups    UserGroup[]   @relation("PublicNotice_userGroups")
+  actions       InternalLink? @relation("PublicNotice_actions", fields: [actionsId], references: [id])
+  actionsId     String?       @map("actions")
+  documents     Document[]    @relation("PublicNotice_documents")
+  contacts      Contact[]     @relation("Contact_publicNotices")
+  createdAt     DateTime?     @default(now())
+  updatedAt     DateTime?     @default(now()) @updatedAt
+  effectiveDate DateTime?
+  endDate       DateTime?
+
+  @@index([ownerId])
+  @@index([actionsId])
+}
+
 model Service {
   id               String         @id @default(cuid())
   heroImage        String?
@@ -326,6 +356,7 @@ model Tag {
   parks               Park[]               @relation("Park_tags")
   trails              Trail[]              @relation("Tag_trails")
   assemblyDistricts   AssemblyDistrict[]   @relation("AssemblyDistrict_tags")
+  publicNotices       PublicNotice[]       @relation("PublicNotice_tags")
 }
 
 model Trail {
@@ -407,6 +438,7 @@ model User {
   from_Facility_owner           Facility[]           @relation("Facility_owner")
   from_OrgUnit_owner            OrgUnit[]            @relation("OrgUnit_owner")
   from_Park_owner               Park[]               @relation("Park_owner")
+  from_PublicNotice_owner       PublicNotice[]       @relation("PublicNotice_owner")
   from_Service_owner            Service[]            @relation("Service_owner")
   from_Trail_owner              Trail[]              @relation("Trail_owner")
   from_Url_owner                Url[]                @relation("Url_owner")
@@ -428,6 +460,7 @@ model UserGroup {
   orgUnits            OrgUnit[]            @relation("OrgUnit_userGroups")
   documentCollections DocumentCollection[] @relation("DocumentCollection_userGroups")
   assemblyDistricts   AssemblyDistrict[]   @relation("AssemblyDistrict_userGroups")
+  publicNotices       PublicNotice[]       @relation("PublicNotice_userGroups")
 
   @@index([ownerId])
 }

--- a/apps/cms/schema.prisma
+++ b/apps/cms/schema.prisma
@@ -24,11 +24,21 @@ model Alert {
 
 model AssemblyDistrict {
   id                       String      @id @default(cuid())
+  heroImage                String?
   title                    String      @unique @default("")
   description              String      @default("")
+  publishAt                DateTime?
+  unpublishAt              DateTime?
+  reviewDate               DateTime?
   slug                     String      @unique @default("")
   owner                    User?       @relation("AssemblyDistrict_owner", fields: [ownerId], references: [id])
   ownerId                  String?     @map("owner")
+  body                     String?
+  tags                     Tag[]       @relation("AssemblyDistrict_tags")
+  userGroups               UserGroup[] @relation("AssemblyDistrict_userGroups")
+  contacts                 Contact[]   @relation("AssemblyDistrict_contacts")
+  createdAt                DateTime?   @default(now())
+  updatedAt                DateTime?   @default(now()) @updatedAt
   photo                    Image?      @relation("AssemblyDistrict_photo", fields: [photoId], references: [id])
   photoId                  String?     @map("photo")
   memberName               String      @default("")
@@ -56,34 +66,36 @@ model Community {
   slug        String             @unique @default("")
   owner       User?              @relation("Community_owner", fields: [ownerId], references: [id])
   ownerId     String?            @map("owner")
-  mapId       String             @default("")
+  body        String?
   tags        Tag[]              @relation("Community_tags")
   userGroups  UserGroup[]        @relation("Community_userGroups")
   contacts    Contact[]          @relation("Community_contacts")
-  services    Service[]          @relation("Community_services")
-  districts   AssemblyDistrict[] @relation("Community_districts")
   createdAt   DateTime?          @default(now())
   updatedAt   DateTime?          @default(now()) @updatedAt
+  mapId       String             @default("")
+  services    Service[]          @relation("Community_services")
+  districts   AssemblyDistrict[] @relation("Community_districts")
 
   @@index([ownerId])
 }
 
 model Contact {
-  id              String      @id @default(cuid())
-  name            String      @default("")
-  title           String?
-  phone           String?
-  email           String?
-  primaryServices Service[]   @relation("Service_primaryContact")
-  services        Service[]   @relation("Contact_services")
-  communities     Community[] @relation("Community_contacts")
-  orgUnits        OrgUnit[]   @relation("Contact_orgUnits")
-  facilities      Facility[]  @relation("Contact_facilities")
-  parks           Park[]      @relation("Contact_parks")
-  trails          Trail[]     @relation("Contact_trails")
-  user            User?       @relation("Contact_user", fields: [userId], references: [id])
-  userId          String?     @unique @map("user")
-  editorNotes     String      @default("")
+  id                String             @id @default(cuid())
+  name              String             @default("")
+  title             String?
+  phone             String?
+  email             String?
+  primaryServices   Service[]          @relation("Service_primaryContact")
+  services          Service[]          @relation("Contact_services")
+  communities       Community[]        @relation("Community_contacts")
+  orgUnits          OrgUnit[]          @relation("Contact_orgUnits")
+  facilities        Facility[]         @relation("Contact_facilities")
+  parks             Park[]             @relation("Contact_parks")
+  assemblyDistricts AssemblyDistrict[] @relation("AssemblyDistrict_contacts")
+  trails            Trail[]            @relation("Contact_trails")
+  user              User?              @relation("Contact_user", fields: [userId], references: [id])
+  userId            String?            @unique @map("user")
+  editorNotes       String             @default("")
 }
 
 model Document {
@@ -140,12 +152,12 @@ model Facility {
   address     Location?       @relation("Facility_address", fields: [addressId], references: [id])
   addressId   String?         @map("address")
   contacts    Contact[]       @relation("Contact_facilities")
-  services    Service[]       @relation("Facility_services")
-  park        Park?           @relation("Facility_park", fields: [parkId], references: [id])
-  parkId      String?         @map("park")
   hours       OperatingHour[] @relation("Facility_hours")
   createdAt   DateTime?       @default(now())
   updatedAt   DateTime?       @default(now()) @updatedAt
+  services    Service[]       @relation("Facility_services")
+  park        Park?           @relation("Facility_park", fields: [parkId], references: [id])
+  parkId      String?         @map("park")
 
   @@index([ownerId])
   @@index([addressId])
@@ -204,25 +216,27 @@ model Location {
 }
 
 model OrgUnit {
-  id          String    @id @default(cuid())
+  id          String      @id @default(cuid())
   heroImage   String?
-  title       String    @unique @default("")
-  description String    @default("")
+  title       String      @unique @default("")
+  description String      @default("")
   publishAt   DateTime?
   unpublishAt DateTime?
   reviewDate  DateTime?
-  slug        String    @unique @default("")
-  owner       User?     @relation("OrgUnit_owner", fields: [ownerId], references: [id])
-  ownerId     String?   @map("owner")
-  showPage    Boolean   @default(true)
-  tags        Tag[]     @relation("OrgUnit_tags")
-  contacts    Contact[] @relation("Contact_orgUnits")
-  services    Service[] @relation("OrgUnit_services")
-  children    OrgUnit[] @relation("OrgUnit_parent")
-  parent      OrgUnit?  @relation("OrgUnit_parent", fields: [parentId], references: [id])
-  parentId    String?   @map("parent")
-  createdAt   DateTime? @default(now())
-  updatedAt   DateTime? @default(now()) @updatedAt
+  slug        String      @unique @default("")
+  owner       User?       @relation("OrgUnit_owner", fields: [ownerId], references: [id])
+  ownerId     String?     @map("owner")
+  body        String?
+  tags        Tag[]       @relation("OrgUnit_tags")
+  userGroups  UserGroup[] @relation("OrgUnit_userGroups")
+  contacts    Contact[]   @relation("Contact_orgUnits")
+  createdAt   DateTime?   @default(now())
+  updatedAt   DateTime?   @default(now()) @updatedAt
+  showPage    Boolean     @default(true)
+  services    Service[]   @relation("OrgUnit_services")
+  children    OrgUnit[]   @relation("OrgUnit_parent")
+  parent      OrgUnit?    @relation("OrgUnit_parent", fields: [parentId], references: [id])
+  parentId    String?     @map("parent")
 
   @@index([ownerId])
   @@index([parentId])
@@ -311,6 +325,7 @@ model Tag {
   facilities          Facility[]           @relation("Facility_tags")
   parks               Park[]               @relation("Park_tags")
   trails              Trail[]              @relation("Tag_trails")
+  assemblyDistricts   AssemblyDistrict[]   @relation("AssemblyDistrict_tags")
 }
 
 model Trail {
@@ -329,6 +344,9 @@ model Trail {
   userGroups         UserGroup[] @relation("Trail_userGroups")
   address            Location?   @relation("Trail_address", fields: [addressId], references: [id])
   addressId          String?     @map("address")
+  contacts           Contact[]   @relation("Contact_trails")
+  createdAt          DateTime?   @default(now())
+  updatedAt          DateTime?   @default(now()) @updatedAt
   open               Boolean     @default(false)
   summer             Boolean     @default(false)
   fall               Boolean     @default(false)
@@ -349,13 +367,9 @@ model Trail {
   difficulty         String?
   length             String      @default("")
   elevationChange    String      @default("")
-  groomed            Boolean     @default(false)
-  contacts           Contact[]   @relation("Contact_trails")
   services           Service[]   @relation("Service_trails")
   park               Park?       @relation("Trail_park", fields: [parkId], references: [id])
   parkId             String?     @map("park")
-  createdAt          DateTime?   @default(now())
-  updatedAt          DateTime?   @default(now()) @updatedAt
 
   @@index([ownerId])
   @@index([addressId])
@@ -411,7 +425,9 @@ model UserGroup {
   trails              Trail[]              @relation("Trail_userGroups")
   facilities          Facility[]           @relation("Facility_userGroups")
   communities         Community[]          @relation("Community_userGroups")
+  orgUnits            OrgUnit[]            @relation("OrgUnit_userGroups")
   documentCollections DocumentCollection[] @relation("DocumentCollection_userGroups")
+  assemblyDistricts   AssemblyDistrict[]   @relation("AssemblyDistrict_userGroups")
 
   @@index([ownerId])
 }

--- a/apps/cms/schema.prisma
+++ b/apps/cms/schema.prisma
@@ -23,58 +23,60 @@ model Alert {
 }
 
 model AssemblyDistrict {
-  id                       String      @id @default(cuid())
-  heroImage                String?
-  title                    String      @unique @default("")
-  description              String      @default("")
-  publishAt                DateTime?
-  unpublishAt              DateTime?
-  reviewDate               DateTime?
-  slug                     String      @unique @default("")
-  owner                    User?       @relation("AssemblyDistrict_owner", fields: [ownerId], references: [id])
-  ownerId                  String?     @map("owner")
-  body                     String?
-  tags                     Tag[]       @relation("AssemblyDistrict_tags")
-  userGroups               UserGroup[] @relation("AssemblyDistrict_userGroups")
-  contacts                 Contact[]   @relation("AssemblyDistrict_contacts")
-  createdAt                DateTime?   @default(now())
-  updatedAt                DateTime?   @default(now()) @updatedAt
-  photo                    Image?      @relation("AssemblyDistrict_photo", fields: [photoId], references: [id])
-  photoId                  String?     @map("photo")
-  memberName               String      @default("")
-  bio                      String      @default("")
-  address                  String      @default("")
-  email                    String?
-  phone                    String?
-  fax                      String?
-  termStart                DateTime?
-  termEnd                  DateTime?
-  from_Community_districts Community[] @relation("Community_districts")
+  id                                  String         @id @default(cuid())
+  heroImage                           String?
+  title                               String         @unique @default("")
+  description                         String         @default("")
+  publishAt                           DateTime?
+  unpublishAt                         DateTime?
+  reviewDate                          DateTime?
+  slug                                String         @unique @default("")
+  owner                               User?          @relation("AssemblyDistrict_owner", fields: [ownerId], references: [id])
+  ownerId                             String?        @map("owner")
+  body                                String?
+  tags                                Tag[]          @relation("AssemblyDistrict_tags")
+  userGroups                          UserGroup[]    @relation("AssemblyDistrict_userGroups")
+  contacts                            Contact[]      @relation("AssemblyDistrict_contacts")
+  createdAt                           DateTime?      @default(now())
+  updatedAt                           DateTime?      @default(now()) @updatedAt
+  photo                               Image?         @relation("AssemblyDistrict_photo", fields: [photoId], references: [id])
+  photoId                             String?        @map("photo")
+  memberName                          String         @default("")
+  bio                                 String         @default("")
+  address                             String         @default("")
+  email                               String?
+  phone                               String?
+  fax                                 String?
+  termStart                           DateTime?
+  termEnd                             DateTime?
+  from_Community_districts            Community[]    @relation("Community_districts")
+  from_PublicNotice_assemblyDistricts PublicNotice[] @relation("PublicNotice_assemblyDistricts")
 
   @@index([ownerId])
   @@index([photoId])
 }
 
 model Community {
-  id          String             @id @default(cuid())
-  heroImage   String?
-  title       String             @unique @default("")
-  description String             @default("")
-  publishAt   DateTime?
-  unpublishAt DateTime?
-  reviewDate  DateTime?
-  slug        String             @unique @default("")
-  owner       User?              @relation("Community_owner", fields: [ownerId], references: [id])
-  ownerId     String?            @map("owner")
-  body        String?
-  tags        Tag[]              @relation("Community_tags")
-  userGroups  UserGroup[]        @relation("Community_userGroups")
-  contacts    Contact[]          @relation("Community_contacts")
-  createdAt   DateTime?          @default(now())
-  updatedAt   DateTime?          @default(now()) @updatedAt
-  mapId       String             @default("")
-  services    Service[]          @relation("Community_services")
-  districts   AssemblyDistrict[] @relation("Community_districts")
+  id                            String             @id @default(cuid())
+  heroImage                     String?
+  title                         String             @unique @default("")
+  description                   String             @default("")
+  publishAt                     DateTime?
+  unpublishAt                   DateTime?
+  reviewDate                    DateTime?
+  slug                          String             @unique @default("")
+  owner                         User?              @relation("Community_owner", fields: [ownerId], references: [id])
+  ownerId                       String?            @map("owner")
+  body                          String?
+  tags                          Tag[]              @relation("Community_tags")
+  userGroups                    UserGroup[]        @relation("Community_userGroups")
+  contacts                      Contact[]          @relation("Community_contacts")
+  createdAt                     DateTime?          @default(now())
+  updatedAt                     DateTime?          @default(now()) @updatedAt
+  mapId                         String             @default("")
+  services                      Service[]          @relation("Community_services")
+  districts                     AssemblyDistrict[] @relation("Community_districts")
+  from_PublicNotice_communities PublicNotice[]     @relation("PublicNotice_communities")
 
   @@index([ownerId])
 }
@@ -138,28 +140,29 @@ model ExternalLink {
 }
 
 model Facility {
-  id          String          @id @default(cuid())
-  heroImage   String?
-  title       String          @unique @default("")
-  description String          @default("")
-  publishAt   DateTime?
-  unpublishAt DateTime?
-  reviewDate  DateTime?
-  slug        String          @unique @default("")
-  owner       User?           @relation("Facility_owner", fields: [ownerId], references: [id])
-  ownerId     String?         @map("owner")
-  body        String?
-  tags        Tag[]           @relation("Facility_tags")
-  userGroups  UserGroup[]     @relation("Facility_userGroups")
-  address     Location?       @relation("Facility_address", fields: [addressId], references: [id])
-  addressId   String?         @map("address")
-  contacts    Contact[]       @relation("Contact_facilities")
-  hours       OperatingHour[] @relation("Facility_hours")
-  createdAt   DateTime?       @default(now())
-  updatedAt   DateTime?       @default(now()) @updatedAt
-  services    Service[]       @relation("Facility_services")
-  park        Park?           @relation("Facility_park", fields: [parkId], references: [id])
-  parkId      String?         @map("park")
+  id                           String          @id @default(cuid())
+  heroImage                    String?
+  title                        String          @unique @default("")
+  description                  String          @default("")
+  publishAt                    DateTime?
+  unpublishAt                  DateTime?
+  reviewDate                   DateTime?
+  slug                         String          @unique @default("")
+  owner                        User?           @relation("Facility_owner", fields: [ownerId], references: [id])
+  ownerId                      String?         @map("owner")
+  body                         String?
+  tags                         Tag[]           @relation("Facility_tags")
+  userGroups                   UserGroup[]     @relation("Facility_userGroups")
+  address                      Location?       @relation("Facility_address", fields: [addressId], references: [id])
+  addressId                    String?         @map("address")
+  contacts                     Contact[]       @relation("Contact_facilities")
+  hours                        OperatingHour[] @relation("Facility_hours")
+  createdAt                    DateTime?       @default(now())
+  updatedAt                    DateTime?       @default(now()) @updatedAt
+  services                     Service[]       @relation("Facility_services")
+  park                         Park?           @relation("Facility_park", fields: [parkId], references: [id])
+  parkId                       String?         @map("park")
+  from_PublicNotice_facilities PublicNotice[]  @relation("PublicNotice_facilities")
 
   @@index([ownerId])
   @@index([addressId])
@@ -167,20 +170,58 @@ model Facility {
 }
 
 model Highlight {
-  id           String        @id @default(cuid())
-  title        String        @unique @default("")
-  publishAt    DateTime?
-  unpublishAt  DateTime?
-  reviewDate   DateTime?
-  image        String?
-  message      String        @default("")
-  linkedItem   InternalLink? @relation("Highlight_linkedItem", fields: [linkedItemId], references: [id])
-  linkedItemId String?       @map("linkedItem")
-  editorNotes  String        @default("")
-  createdAt    DateTime?     @default(now())
-  updatedAt    DateTime?     @default(now()) @updatedAt
+  id                           String        @id @default(cuid())
+  title                        String        @unique @default("")
+  publishAt                    DateTime?
+  unpublishAt                  DateTime?
+  reviewDate                   DateTime?
+  image                        String?
+  message                      String        @default("")
+  linkedItem                   InternalLink? @relation("Highlight_linkedItem", fields: [linkedItemId], references: [id])
+  linkedItemId                 String?       @map("linkedItem")
+  editorNotes                  String        @default("")
+  createdAt                    DateTime?     @default(now())
+  updatedAt                    DateTime?     @default(now()) @updatedAt
+  from_HomePage_toolbeltOne    HomePage[]    @relation("HomePage_toolbeltOne")
+  from_HomePage_toolbeltTwo    HomePage[]    @relation("HomePage_toolbeltTwo")
+  from_HomePage_toolbeltThree  HomePage[]    @relation("HomePage_toolbeltThree")
+  from_HomePage_toolbeltFour   HomePage[]    @relation("HomePage_toolbeltFour")
+  from_HomePage_highlightOne   HomePage[]    @relation("HomePage_highlightOne")
+  from_HomePage_highlightTwo   HomePage[]    @relation("HomePage_highlightTwo")
+  from_HomePage_highlightThree HomePage[]    @relation("HomePage_highlightThree")
 
   @@index([linkedItemId])
+}
+
+model HomePage {
+  id               Int        @id
+  heroImage        String?
+  title            String     @unique @default("")
+  description      String     @default("")
+  toolbeltOne      Highlight? @relation("HomePage_toolbeltOne", fields: [toolbeltOneId], references: [id])
+  toolbeltOneId    String?    @map("toolbeltOne")
+  toolbeltTwo      Highlight? @relation("HomePage_toolbeltTwo", fields: [toolbeltTwoId], references: [id])
+  toolbeltTwoId    String?    @map("toolbeltTwo")
+  toolbeltThree    Highlight? @relation("HomePage_toolbeltThree", fields: [toolbeltThreeId], references: [id])
+  toolbeltThreeId  String?    @map("toolbeltThree")
+  toolbeltFour     Highlight? @relation("HomePage_toolbeltFour", fields: [toolbeltFourId], references: [id])
+  toolbeltFourId   String?    @map("toolbeltFour")
+  highlightOne     Highlight? @relation("HomePage_highlightOne", fields: [highlightOneId], references: [id])
+  highlightOneId   String?    @map("highlightOne")
+  highlightTwo     Highlight? @relation("HomePage_highlightTwo", fields: [highlightTwoId], references: [id])
+  highlightTwoId   String?    @map("highlightTwo")
+  highlightThree   Highlight? @relation("HomePage_highlightThree", fields: [highlightThreeId], references: [id])
+  highlightThreeId String?    @map("highlightThree")
+  createdAt        DateTime?  @default(now())
+  updatedAt        DateTime?  @default(now()) @updatedAt
+
+  @@index([toolbeltOneId])
+  @@index([toolbeltTwoId])
+  @@index([toolbeltThreeId])
+  @@index([toolbeltFourId])
+  @@index([highlightOneId])
+  @@index([highlightTwoId])
+  @@index([highlightThreeId])
 }
 
 model Image {
@@ -219,27 +260,28 @@ model Location {
 }
 
 model OrgUnit {
-  id          String      @id @default(cuid())
-  heroImage   String?
-  title       String      @unique @default("")
-  description String      @default("")
-  publishAt   DateTime?
-  unpublishAt DateTime?
-  reviewDate  DateTime?
-  slug        String      @unique @default("")
-  owner       User?       @relation("OrgUnit_owner", fields: [ownerId], references: [id])
-  ownerId     String?     @map("owner")
-  body        String?
-  tags        Tag[]       @relation("OrgUnit_tags")
-  userGroups  UserGroup[] @relation("OrgUnit_userGroups")
-  contacts    Contact[]   @relation("Contact_orgUnits")
-  createdAt   DateTime?   @default(now())
-  updatedAt   DateTime?   @default(now()) @updatedAt
-  showPage    Boolean     @default(true)
-  services    Service[]   @relation("OrgUnit_services")
-  children    OrgUnit[]   @relation("OrgUnit_parent")
-  parent      OrgUnit?    @relation("OrgUnit_parent", fields: [parentId], references: [id])
-  parentId    String?     @map("parent")
+  id                         String         @id @default(cuid())
+  heroImage                  String?
+  title                      String         @unique @default("")
+  description                String         @default("")
+  publishAt                  DateTime?
+  unpublishAt                DateTime?
+  reviewDate                 DateTime?
+  slug                       String         @unique @default("")
+  owner                      User?          @relation("OrgUnit_owner", fields: [ownerId], references: [id])
+  ownerId                    String?        @map("owner")
+  body                       String?
+  tags                       Tag[]          @relation("OrgUnit_tags")
+  userGroups                 UserGroup[]    @relation("OrgUnit_userGroups")
+  contacts                   Contact[]      @relation("Contact_orgUnits")
+  createdAt                  DateTime?      @default(now())
+  updatedAt                  DateTime?      @default(now()) @updatedAt
+  showPage                   Boolean        @default(true)
+  services                   Service[]      @relation("OrgUnit_services")
+  children                   OrgUnit[]      @relation("OrgUnit_parent")
+  parent                     OrgUnit?       @relation("OrgUnit_parent", fields: [parentId], references: [id])
+  parentId                   String?        @map("parent")
+  from_PublicNotice_orgUnits PublicNotice[] @relation("PublicNotice_orgUnits")
 
   @@index([ownerId])
   @@index([parentId])
@@ -255,88 +297,97 @@ model OperatingHour {
 }
 
 model Park {
-  id          String          @id @default(cuid())
-  heroImage   String?
-  title       String          @unique @default("")
-  description String          @default("")
-  publishAt   DateTime?
-  unpublishAt DateTime?
-  reviewDate  DateTime?
-  slug        String          @unique @default("")
-  owner       User?           @relation("Park_owner", fields: [ownerId], references: [id])
-  ownerId     String?         @map("owner")
-  body        String?
-  tags        Tag[]           @relation("Park_tags")
-  userGroups  UserGroup[]     @relation("Park_userGroups")
-  address     Location?       @relation("Park_address", fields: [addressId], references: [id])
-  addressId   String?         @map("address")
-  contacts    Contact[]       @relation("Contact_parks")
-  hours       OperatingHour[] @relation("Park_hours")
-  createdAt   DateTime?       @default(now())
-  updatedAt   DateTime?       @default(now()) @updatedAt
-  services    Service[]       @relation("Park_services")
-  trails      Trail[]         @relation("Trail_park")
-  facilities  Facility[]      @relation("Facility_park")
+  id                      String          @id @default(cuid())
+  heroImage               String?
+  title                   String          @unique @default("")
+  description             String          @default("")
+  publishAt               DateTime?
+  unpublishAt             DateTime?
+  reviewDate              DateTime?
+  slug                    String          @unique @default("")
+  owner                   User?           @relation("Park_owner", fields: [ownerId], references: [id])
+  ownerId                 String?         @map("owner")
+  body                    String?
+  tags                    Tag[]           @relation("Park_tags")
+  userGroups              UserGroup[]     @relation("Park_userGroups")
+  address                 Location?       @relation("Park_address", fields: [addressId], references: [id])
+  addressId               String?         @map("address")
+  contacts                Contact[]       @relation("Contact_parks")
+  hours                   OperatingHour[] @relation("Park_hours")
+  createdAt               DateTime?       @default(now())
+  updatedAt               DateTime?       @default(now()) @updatedAt
+  services                Service[]       @relation("Park_services")
+  trails                  Trail[]         @relation("Trail_park")
+  facilities              Facility[]      @relation("Facility_park")
+  from_PublicNotice_parks PublicNotice[]  @relation("PublicNotice_parks")
 
   @@index([ownerId])
   @@index([addressId])
 }
 
 model PublicNotice {
-  id            String        @id @default(cuid())
-  heroImage     String?
-  title         String        @unique @default("")
-  description   String        @default("")
-  publishAt     DateTime?
-  unpublishAt   DateTime?
-  reviewDate    DateTime?
-  slug          String        @unique @default("")
-  owner         User?         @relation("PublicNotice_owner", fields: [ownerId], references: [id])
-  ownerId       String?       @map("owner")
-  body          String?
-  tags          Tag[]         @relation("PublicNotice_tags")
-  userGroups    UserGroup[]   @relation("PublicNotice_userGroups")
-  actions       InternalLink? @relation("PublicNotice_actions", fields: [actionsId], references: [id])
-  actionsId     String?       @map("actions")
-  documents     Document[]    @relation("PublicNotice_documents")
-  contacts      Contact[]     @relation("Contact_publicNotices")
-  createdAt     DateTime?     @default(now())
-  updatedAt     DateTime?     @default(now()) @updatedAt
-  effectiveDate DateTime?
-  endDate       DateTime?
+  id                String             @id @default(cuid())
+  heroImage         String?
+  title             String             @unique @default("")
+  description       String             @default("")
+  publishAt         DateTime?
+  unpublishAt       DateTime?
+  reviewDate        DateTime?
+  slug              String             @unique @default("")
+  owner             User?              @relation("PublicNotice_owner", fields: [ownerId], references: [id])
+  ownerId           String?            @map("owner")
+  body              String?
+  tags              Tag[]              @relation("PublicNotice_tags")
+  userGroups        UserGroup[]        @relation("PublicNotice_userGroups")
+  actions           InternalLink?      @relation("PublicNotice_actions", fields: [actionsId], references: [id])
+  actionsId         String?            @map("actions")
+  documents         Document[]         @relation("PublicNotice_documents")
+  contacts          Contact[]          @relation("Contact_publicNotices")
+  createdAt         DateTime?          @default(now())
+  updatedAt         DateTime?          @default(now()) @updatedAt
+  effectiveDate     DateTime?
+  endDate           DateTime?
+  parks             Park[]             @relation("PublicNotice_parks")
+  services          Service[]          @relation("PublicNotice_services")
+  orgUnits          OrgUnit[]          @relation("PublicNotice_orgUnits")
+  facilities        Facility[]         @relation("PublicNotice_facilities")
+  trails            Trail[]            @relation("PublicNotice_trails")
+  communities       Community[]        @relation("PublicNotice_communities")
+  assemblyDistricts AssemblyDistrict[] @relation("PublicNotice_assemblyDistricts")
 
   @@index([ownerId])
   @@index([actionsId])
 }
 
 model Service {
-  id               String         @id @default(cuid())
-  heroImage        String?
-  title            String         @unique @default("")
-  description      String         @default("")
-  publishAt        DateTime?
-  unpublishAt      DateTime?
-  reviewDate       DateTime?
-  slug             String         @unique @default("")
-  owner            User?          @relation("Service_owner", fields: [ownerId], references: [id])
-  ownerId          String?        @map("owner")
-  body             String?
-  tags             Tag[]          @relation("Service_tags")
-  userGroups       UserGroup[]    @relation("Service_userGroups")
-  primaryAction    ExternalLink?  @relation("Service_primaryAction", fields: [primaryActionId], references: [id])
-  primaryActionId  String?        @map("primaryAction")
-  secondaryActions ExternalLink[] @relation("Service_secondaryActions")
-  primaryContact   Contact?       @relation("Service_primaryContact", fields: [primaryContactId], references: [id])
-  primaryContactId String?        @map("primaryContact")
-  contacts         Contact[]      @relation("Contact_services")
-  createdAt        DateTime?      @default(now())
-  updatedAt        DateTime?      @default(now()) @updatedAt
-  communities      Community[]    @relation("Community_services")
-  orgUnits         OrgUnit[]      @relation("OrgUnit_services")
-  trails           Trail[]        @relation("Service_trails")
-  parks            Park[]         @relation("Park_services")
-  facilities       Facility[]     @relation("Facility_services")
-  editorNotes      String         @default("")
+  id                         String         @id @default(cuid())
+  heroImage                  String?
+  title                      String         @unique @default("")
+  description                String         @default("")
+  publishAt                  DateTime?
+  unpublishAt                DateTime?
+  reviewDate                 DateTime?
+  slug                       String         @unique @default("")
+  owner                      User?          @relation("Service_owner", fields: [ownerId], references: [id])
+  ownerId                    String?        @map("owner")
+  body                       String?
+  tags                       Tag[]          @relation("Service_tags")
+  userGroups                 UserGroup[]    @relation("Service_userGroups")
+  primaryAction              ExternalLink?  @relation("Service_primaryAction", fields: [primaryActionId], references: [id])
+  primaryActionId            String?        @map("primaryAction")
+  secondaryActions           ExternalLink[] @relation("Service_secondaryActions")
+  primaryContact             Contact?       @relation("Service_primaryContact", fields: [primaryContactId], references: [id])
+  primaryContactId           String?        @map("primaryContact")
+  contacts                   Contact[]      @relation("Contact_services")
+  createdAt                  DateTime?      @default(now())
+  updatedAt                  DateTime?      @default(now()) @updatedAt
+  communities                Community[]    @relation("Community_services")
+  orgUnits                   OrgUnit[]      @relation("OrgUnit_services")
+  trails                     Trail[]        @relation("Service_trails")
+  parks                      Park[]         @relation("Park_services")
+  facilities                 Facility[]     @relation("Facility_services")
+  editorNotes                String         @default("")
+  from_PublicNotice_services PublicNotice[] @relation("PublicNotice_services")
 
   @@index([ownerId])
   @@index([primaryActionId])
@@ -360,47 +411,48 @@ model Tag {
 }
 
 model Trail {
-  id                 String      @id @default(cuid())
-  heroImage          String?
-  title              String      @unique @default("")
-  description        String      @default("")
-  publishAt          DateTime?
-  unpublishAt        DateTime?
-  reviewDate         DateTime?
-  slug               String      @unique @default("")
-  owner              User?       @relation("Trail_owner", fields: [ownerId], references: [id])
-  ownerId            String?     @map("owner")
-  body               String?
-  tags               Tag[]       @relation("Tag_trails")
-  userGroups         UserGroup[] @relation("Trail_userGroups")
-  address            Location?   @relation("Trail_address", fields: [addressId], references: [id])
-  addressId          String?     @map("address")
-  contacts           Contact[]   @relation("Contact_trails")
-  createdAt          DateTime?   @default(now())
-  updatedAt          DateTime?   @default(now()) @updatedAt
-  open               Boolean     @default(false)
-  summer             Boolean     @default(false)
-  fall               Boolean     @default(false)
-  winter             Boolean     @default(false)
-  spring             Boolean     @default(false)
-  hiking             Boolean     @default(false)
-  biking             Boolean     @default(false)
-  horsebackRiding    Boolean     @default(false)
-  crossCountrySkiing Boolean     @default(false)
-  snowshoeing        Boolean     @default(false)
-  frisbeeGolf        Boolean     @default(false)
-  dogWalking         Boolean     @default(false)
-  running            Boolean     @default(false)
-  snowMachining      Boolean     @default(false)
-  atv                Boolean     @default(false)
-  dirtBiking         Boolean     @default(false)
-  mushing            Boolean     @default(false)
-  difficulty         String?
-  length             String      @default("")
-  elevationChange    String      @default("")
-  services           Service[]   @relation("Service_trails")
-  park               Park?       @relation("Trail_park", fields: [parkId], references: [id])
-  parkId             String?     @map("park")
+  id                       String         @id @default(cuid())
+  heroImage                String?
+  title                    String         @unique @default("")
+  description              String         @default("")
+  publishAt                DateTime?
+  unpublishAt              DateTime?
+  reviewDate               DateTime?
+  slug                     String         @unique @default("")
+  owner                    User?          @relation("Trail_owner", fields: [ownerId], references: [id])
+  ownerId                  String?        @map("owner")
+  body                     String?
+  tags                     Tag[]          @relation("Tag_trails")
+  userGroups               UserGroup[]    @relation("Trail_userGroups")
+  address                  Location?      @relation("Trail_address", fields: [addressId], references: [id])
+  addressId                String?        @map("address")
+  contacts                 Contact[]      @relation("Contact_trails")
+  createdAt                DateTime?      @default(now())
+  updatedAt                DateTime?      @default(now()) @updatedAt
+  open                     Boolean        @default(false)
+  summer                   Boolean        @default(false)
+  fall                     Boolean        @default(false)
+  winter                   Boolean        @default(false)
+  spring                   Boolean        @default(false)
+  hiking                   Boolean        @default(false)
+  biking                   Boolean        @default(false)
+  horsebackRiding          Boolean        @default(false)
+  crossCountrySkiing       Boolean        @default(false)
+  snowshoeing              Boolean        @default(false)
+  frisbeeGolf              Boolean        @default(false)
+  dogWalking               Boolean        @default(false)
+  running                  Boolean        @default(false)
+  snowMachining            Boolean        @default(false)
+  atv                      Boolean        @default(false)
+  dirtBiking               Boolean        @default(false)
+  mushing                  Boolean        @default(false)
+  difficulty               String?
+  length                   String         @default("")
+  elevationChange          String         @default("")
+  services                 Service[]      @relation("Service_trails")
+  park                     Park?          @relation("Trail_park", fields: [parkId], references: [id])
+  parkId                   String?        @map("park")
+  from_PublicNotice_trails PublicNotice[] @relation("PublicNotice_trails")
 
   @@index([ownerId])
   @@index([addressId])

--- a/apps/cms/schema.prisma
+++ b/apps/cms/schema.prisma
@@ -254,12 +254,12 @@ model Park {
   address     Location?       @relation("Park_address", fields: [addressId], references: [id])
   addressId   String?         @map("address")
   contacts    Contact[]       @relation("Contact_parks")
-  services    Service[]       @relation("Park_services")
-  trails      Trail[]         @relation("Trail_park")
-  facilities  Facility[]      @relation("Facility_park")
   hours       OperatingHour[] @relation("Park_hours")
   createdAt   DateTime?       @default(now())
   updatedAt   DateTime?       @default(now()) @updatedAt
+  services    Service[]       @relation("Park_services")
+  trails      Trail[]         @relation("Trail_park")
+  facilities  Facility[]      @relation("Facility_park")
 
   @@index([ownerId])
   @@index([addressId])
@@ -282,9 +282,9 @@ model Service {
   primaryAction    ExternalLink?  @relation("Service_primaryAction", fields: [primaryActionId], references: [id])
   primaryActionId  String?        @map("primaryAction")
   secondaryActions ExternalLink[] @relation("Service_secondaryActions")
-  contacts         Contact[]      @relation("Contact_services")
   primaryContact   Contact?       @relation("Service_primaryContact", fields: [primaryContactId], references: [id])
   primaryContactId String?        @map("primaryContact")
+  contacts         Contact[]      @relation("Contact_services")
   createdAt        DateTime?      @default(now())
   updatedAt        DateTime?      @default(now()) @updatedAt
   communities      Community[]    @relation("Community_services")

--- a/apps/cms/schema.prisma
+++ b/apps/cms/schema.prisma
@@ -345,6 +345,7 @@ model PublicNotice {
   contacts          Contact[]          @relation("Contact_publicNotices")
   createdAt         DateTime?          @default(now())
   updatedAt         DateTime?          @default(now()) @updatedAt
+  urgency           Int                @default(2)
   effectiveDate     DateTime?
   endDate           DateTime?
   parks             Park[]             @relation("PublicNotice_parks")

--- a/apps/cms/src/app/fieldUtils.ts
+++ b/apps/cms/src/app/fieldUtils.ts
@@ -5,11 +5,22 @@ import {
   timestamp,
   virtual,
 } from '@keystone-6/core/fields';
-import { KeystoneContextFromListTypeInfo } from '@keystone-6/core/types';
+import {
+  BaseListTypeInfo,
+  KeystoneContextFromListTypeInfo,
+} from '@keystone-6/core/types';
 import { isAdmin } from './access/roles';
 import { isOwner } from './access/group';
 import { appConfig } from '../configs/appConfig';
 import { getDatetimeISOString } from './access';
+import {
+  blueHarvestImage,
+  BlueHarvestImageConfig,
+} from '../components/customFields/blueHarvestImage';
+import {
+  customText,
+  CustomTextOpts,
+} from '../components/customFields/Markdown';
 
 export const urlRegex = /^(https?:\/\/)[^\s/$.?#].[^\s]*$/;
 export const phoneNumberRegex =
@@ -169,7 +180,7 @@ export const publishable: BaseFields<any> = {
   }),
 };
 
-export function titleAndDescription(opts?: {
+type titleAndDescriptionOpts = {
   title?: {
     required?: boolean;
     lengthMin?: number;
@@ -179,7 +190,11 @@ export function titleAndDescription(opts?: {
   description?: {
     description?: string;
   };
-}): BaseFields<any> {
+};
+
+export function titleAndDescription(
+  opts?: titleAndDescriptionOpts,
+): BaseFields<any> {
   return {
     title: text({
       validation: {
@@ -312,4 +327,25 @@ export function services(listKey: string) {
     ref: `Service.${listKey}`,
     many: true,
   });
+}
+
+export function basePage(opts: {
+  listName: string;
+  customTextOpts?: CustomTextOpts<BaseListTypeInfo>;
+  heroImageConfig?: BlueHarvestImageConfig<BaseListTypeInfo>;
+  titleAndDescriptionOpts?: titleAndDescriptionOpts;
+}): BaseFields<any> {
+  return {
+    heroImage: blueHarvestImage(opts.heroImageConfig),
+    ...titleAndDescription(opts.titleAndDescriptionOpts),
+    ...publishable,
+    liveUrl: liveUrl(opts.listName),
+    slug,
+    owner,
+    body: customText(opts.customTextOpts),
+    tags: tags(opts.listName),
+    userGroups: userGroups(opts.listName),
+    contacts: contacts(opts.listName),
+    ...timestamps,
+  };
 }

--- a/apps/cms/src/app/fieldUtils.ts
+++ b/apps/cms/src/app/fieldUtils.ts
@@ -347,6 +347,8 @@ export function basePage(
     primaryContact?: boolean;
     address?: boolean;
     hours?: boolean;
+    documents?: boolean;
+    actions?: boolean;
   },
 ): BaseFields<any> {
   return {
@@ -398,6 +400,35 @@ export function basePage(
           },
         },
         many: true,
+      }),
+    }),
+
+    ...(opts?.actions && {
+      actions: relationship({
+        ref: 'InternalLink',
+        ui: {
+          itemView: {
+            fieldPosition: 'sidebar',
+          },
+          displayMode: 'cards',
+          cardFields: ['label', 'item'],
+          inlineCreate: { fields: ['label', 'selectItem'] },
+          inlineEdit: { fields: ['label', 'selectItem'] },
+        },
+      }),
+    }),
+
+    ...(opts?.documents && {
+      documents: relationship({
+        ref: 'Document',
+        many: true,
+        ui: {
+          displayMode: 'cards',
+          inlineConnect: true,
+          cardFields: ['title', 'description', 'file', 'tags'],
+          inlineCreate: { fields: ['title', 'description', 'file', 'tags'] },
+          inlineEdit: { fields: ['title', 'description', 'file', 'tags'] },
+        },
       }),
     }),
 

--- a/apps/cms/src/app/fieldUtils.ts
+++ b/apps/cms/src/app/fieldUtils.ts
@@ -27,7 +27,7 @@ import {
   TYPESENSE_CLIENT,
   TYPESENSE_COLLECTIONS,
 } from '../utils/typesense';
-import { capitalizeFirstLetter } from '../utils';
+import { capitalizeFirstLetter, toPascalCase } from '../utils';
 
 export const urlRegex = /^(https?:\/\/)[^\s/$.?#].[^\s]*$/;
 export const phoneNumberRegex =
@@ -500,12 +500,14 @@ export async function typesenseUpsert(
 ) {
   if ((operation === 'update' || operation === 'create') && item) {
     try {
-      const doc = await context.query[
-        capitalizeFirstLetter(listNameSingular)
-      ]?.findOne({
+      const thing = toPascalCase(listNameSingular);
+      console.log(thing);
+      const doc = await context.query[thing]?.findOne({
         where: { id: item.id.toString() },
         query,
       });
+
+      console.log(doc);
 
       const document = toSearchableObj(doc, listNameSingular);
 

--- a/apps/cms/src/app/fieldUtils.ts
+++ b/apps/cms/src/app/fieldUtils.ts
@@ -345,6 +345,8 @@ export function basePage(
     primaryAction?: boolean;
     secondaryActions?: boolean;
     primaryContact?: boolean;
+    address?: boolean;
+    hours?: boolean;
   },
 ): BaseFields<any> {
   return {
@@ -398,13 +400,51 @@ export function basePage(
         many: true,
       }),
     }),
-    contacts: contacts(listNamePlural),
+
+    ...(opts?.address && {
+      address: relationship({
+        ref: 'Location',
+        many: false,
+        ui: {
+          displayMode: 'cards',
+          cardFields: ['lineOne', 'lineTwo', 'city', 'state', 'zip'],
+          inlineCreate: {
+            fields: ['title', 'lineOne', 'lineTwo', 'city', 'state', 'zip'],
+          },
+          inlineEdit: {
+            fields: ['lineOne', 'lineTwo', 'city', 'state', 'zip'],
+          },
+          inlineConnect: true,
+          itemView: {
+            fieldPosition: 'sidebar',
+          },
+        },
+      }),
+    }),
+
     ...(opts?.primaryContact && {
       primaryContact: relationship({
         ref: `Contact.primary${capitalizeFirstLetter(listNamePlural)}`,
         ui: {
           itemView: {
             fieldPosition: 'sidebar',
+          },
+        },
+      }),
+    }),
+    contacts: contacts(listNamePlural),
+    ...(opts?.hours && {
+      hours: relationship({
+        ref: 'OperatingHour',
+        many: true,
+        ui: {
+          displayMode: 'cards',
+          cardFields: ['day', 'open', 'close'],
+          inlineCreate: {
+            fields: ['day', 'open', 'close'],
+          },
+          inlineEdit: {
+            fields: ['day', 'open', 'close'],
           },
         },
       }),

--- a/apps/cms/src/app/models/AssemblyDistrict.ts
+++ b/apps/cms/src/app/models/AssemblyDistrict.ts
@@ -1,12 +1,11 @@
 import { group, list, ListConfig } from '@keystone-6/core';
 import { generalItemAccess, generalOperationAccess } from '../access';
 import {
+  basePage,
   emailRegex,
-  liveUrl,
-  owner,
   phoneNumberRegex,
-  slug,
-  titleAndDescription,
+  typesenseDelete,
+  typesenseUpsert,
 } from '../fieldUtils';
 import { relationship, text, timestamp } from '@keystone-6/core/fields';
 
@@ -16,10 +15,7 @@ export const AssemblyDistrict: ListConfig<any> = list({
     item: generalItemAccess('AssemblyDistrict'),
   },
   fields: {
-    ...titleAndDescription(),
-    liveUrl: liveUrl(''),
-    slug,
-    owner,
+    ...basePage('assemblyDistricts'),
     ...group({
       label: 'Assembly Member Information',
       fields: {
@@ -117,5 +113,17 @@ export const AssemblyDistrict: ListConfig<any> = list({
         }),
       },
     }),
+  },
+  hooks: {
+    beforeOperation(args) {
+      typesenseDelete(args);
+    },
+    async afterOperation(args) {
+      typesenseUpsert(
+        'assemblyDistrict',
+        'id title description body slug liveUrl publishAt tags {name}',
+        args,
+      );
+    },
   },
 });

--- a/apps/cms/src/app/models/Contact.ts
+++ b/apps/cms/src/app/models/Contact.ts
@@ -1,7 +1,5 @@
 import { list, ListConfig } from '@keystone-6/core';
-import { allowAll } from '@keystone-6/core/access';
 import { relationship, text } from '@keystone-6/core/fields';
-import { isCollaborator, isContributor } from '../access/roles';
 import { generalOperationAccess } from '../access';
 
 const phoneNumberRegex =
@@ -96,6 +94,11 @@ export const Contact: ListConfig<any> = list({
     }),
     parks: relationship({
       ref: 'Park.contacts',
+      many: true,
+      ui: { hideCreate: true },
+    }),
+    assemblyDistricts: relationship({
+      ref: 'AssemblyDistrict.contacts',
       many: true,
       ui: { hideCreate: true },
     }),

--- a/apps/cms/src/app/models/Contact.ts
+++ b/apps/cms/src/app/models/Contact.ts
@@ -113,5 +113,9 @@ export const Contact: ListConfig<any> = list({
         displayMode: 'textarea',
       },
     }),
+    publicNotices: relationship({
+      ref: 'PublicNotice.contacts',
+      many: true,
+    }),
   },
 });

--- a/apps/cms/src/app/models/Facility.ts
+++ b/apps/cms/src/app/models/Facility.ts
@@ -1,38 +1,14 @@
 import { list, ListConfig } from '@keystone-6/core';
 import { generalItemAccess, generalOperationAccess } from '../access';
-import { blueHarvestImage } from '../../components/customFields/blueHarvestImage';
 import {
-  contacts,
-  liveUrl,
-  owner,
-  publishable,
+  basePage,
   services,
-  slug,
-  tags,
-  timestamps,
-  titleAndDescription,
-  userGroups,
+  typesenseDelete,
+  typesenseUpsert,
 } from '../fieldUtils';
 import { relationship } from '@keystone-6/core/fields';
-import { customText } from '../../components/customFields/Markdown';
-import { TYPESENSE_CLIENT, TYPESENSE_COLLECTIONS } from '../../utils/typesense';
 
 const listPlural = 'facilities';
-
-export function facilityToSearchableObj(item: any) {
-  return {
-    id: item.id,
-    title: item.title,
-    description: item.description,
-    body: item.body,
-    slug: item.slug,
-    published_at: item.publishAt
-      ? Math.floor(new Date(item.publishAt).getTime() / 1000)
-      : undefined,
-    tags: item.tags?.map((tag: { name: string }) => tag.name || ''),
-    type: 'facility',
-  };
-}
 
 export const Facility: ListConfig<any> = list({
   access: {
@@ -40,77 +16,23 @@ export const Facility: ListConfig<any> = list({
     item: generalItemAccess('Facility'),
   },
   fields: {
-    heroImage: blueHarvestImage(),
-    ...titleAndDescription(),
-    ...publishable,
-    liveUrl: liveUrl(listPlural),
-    slug,
-    owner,
-    body: customText(),
-    tags: tags(listPlural),
-    userGroups: userGroups(listPlural),
-    address: relationship({
-      ref: 'Location',
-      many: false,
-      ui: {
-        displayMode: 'cards',
-        cardFields: ['title', 'lineOne', 'lineTwo', 'city', 'state', 'zip'],
-        inlineCreate: {
-          fields: ['title', 'lineOne', 'lineTwo', 'city', 'state', 'zip'],
-        },
-        inlineConnect: true,
-        itemView: {
-          fieldPosition: 'sidebar',
-        },
-      },
+    ...basePage(listPlural, {
+      address: true,
     }),
-    contacts: contacts(listPlural),
     services: services(listPlural),
     park: relationship({ ref: 'Park.facilities', many: false }),
-    hours: relationship({
-      ref: 'OperatingHour',
-      many: true,
-      ui: {
-        displayMode: 'cards',
-        cardFields: ['day', 'open', 'close'],
-        inlineCreate: {
-          fields: ['day', 'open', 'close'],
-        },
-        inlineEdit: {
-          fields: ['day', 'open', 'close'],
-        },
-      },
-    }),
-    ...timestamps,
   },
 
   hooks: {
-    beforeOperation: {
-      async delete({ item }) {
-        try {
-          TYPESENSE_CLIENT.collections(TYPESENSE_COLLECTIONS.PAGES)
-            .documents(item.id.toString())
-            .delete();
-        } catch (e) {
-          console.error('Error deleting from Typesense', e);
-        }
-      },
+    beforeOperation(args) {
+      typesenseDelete(args);
     },
-    async afterOperation({ operation, item, context }) {
-      if (operation === 'update' || operation === 'create') {
-        const trail = await context.query.Facility.findOne({
-          where: { id: item.id.toString() },
-          query:
-            'id title description body slug liveUrl publishAt tags {name} owner {name} services {title}',
-        });
-        try {
-          await TYPESENSE_CLIENT.collections(TYPESENSE_COLLECTIONS.PAGES)
-            .documents()
-            .upsert(facilityToSearchableObj(item));
-        } catch (e) {
-          console.error('Error upserting to Typesense', e);
-        }
-      }
+    async afterOperation(args) {
+      typesenseUpsert(
+        'facility',
+        'id title description body slug liveUrl publishAt tags {name} owner {name} services {title}',
+        args,
+      );
     },
   },
 });

--- a/apps/cms/src/app/models/Facility.ts
+++ b/apps/cms/src/app/models/Facility.ts
@@ -18,17 +18,18 @@ export const Facility: ListConfig<any> = list({
   fields: {
     ...basePage(listPlural, {
       address: true,
+      hours: true,
     }),
     services: services(listPlural),
     park: relationship({ ref: 'Park.facilities', many: false }),
   },
 
   hooks: {
-    beforeOperation(args) {
-      typesenseDelete(args);
+    async beforeOperation(args) {
+      await typesenseDelete(args);
     },
     async afterOperation(args) {
-      typesenseUpsert(
+      await typesenseUpsert(
         'facility',
         'id title description body slug liveUrl publishAt tags {name} owner {name} services {title}',
         args,

--- a/apps/cms/src/app/models/HomePage.tsx
+++ b/apps/cms/src/app/models/HomePage.tsx
@@ -1,0 +1,51 @@
+import { group, list, ListConfig } from '@keystone-6/core';
+import { timestamps, titleAndDescription, userGroups } from '../fieldUtils';
+import { elevatedOperationAccess, isContentManager } from '../access';
+import { blueHarvestImage } from '../../components/customFields/blueHarvestImage';
+import { relationship } from '@keystone-6/core/fields';
+
+export const HomePage: ListConfig<any> = list({
+  isSingleton: true,
+  access: {
+    operation: elevatedOperationAccess,
+  },
+  ui: {
+    isHidden: isContentManager,
+  },
+  fields: {
+    heroImage: blueHarvestImage(),
+    ...titleAndDescription(),
+    ...group({
+      label: 'Toolbelt',
+      fields: {
+        toolbeltOne: relationship({
+          ref: 'Highlight',
+        }),
+        toolbeltTwo: relationship({
+          ref: 'Highlight',
+        }),
+        toolbeltThree: relationship({
+          ref: 'Highlight',
+        }),
+        toolbeltFour: relationship({
+          ref: 'Highlight',
+        }),
+      },
+    }),
+    ...group({
+      label: 'Highlights',
+      fields: {
+        highlightOne: relationship({
+          ref: 'Highlight',
+        }),
+        highlightTwo: relationship({
+          ref: 'Highlight',
+        }),
+        highlightThree: relationship({
+          ref: 'Highlight',
+        }),
+      },
+    }),
+    ...timestamps,
+  },
+});

--- a/apps/cms/src/app/models/InternalLink.ts
+++ b/apps/cms/src/app/models/InternalLink.ts
@@ -78,7 +78,6 @@ export const InternalLink: ListConfig<any> = list({
             const itemId = item.selectItem.itemId.value as string;
 
             const capitalizedListKey = capitalizeFirstLetter(listKey);
-            console.log(capitalizedListKey);
             try {
               const linkedItem = await context.query[
                 capitalizedListKey

--- a/apps/cms/src/app/models/OrgUnit.ts
+++ b/apps/cms/src/app/models/OrgUnit.ts
@@ -5,33 +5,18 @@ import {
   typesenseDelete,
   typesenseUpsert,
 } from '../fieldUtils';
-import { generalItemAccess, generalOperationAccess } from '../access';
-import { checkbox, relationship } from '@keystone-6/core/fields';
 import {
-  toSearchableObj,
-  TYPESENSE_CLIENT,
-  TYPESENSE_COLLECTIONS,
-  TypeSensePageDocument,
-} from '../../utils/typesense';
-
-export function orgUnitToSearchableObj(item: any): TypeSensePageDocument {
-  return {
-    id: item.id,
-    title: item.title,
-    slug: item.slug,
-    description: item.description,
-    type: 'department',
-    tags: item.tags.map((tag: { name: string }) => tag?.name || ''),
-    published_at: item.publishAt
-      ? Math.floor(new Date(item.publishAt).getTime() / 1000)
-      : Math.floor(new Date().getTime() / 1000),
-  };
-}
+  filterByPubDates,
+  generalItemAccess,
+  generalOperationAccess,
+} from '../access';
+import { checkbox, relationship } from '@keystone-6/core/fields';
 
 export const OrgUnit: ListConfig<any> = list({
   access: {
     operation: generalOperationAccess,
     item: generalItemAccess('OrgUnit'),
+    filter: filterByPubDates,
   },
   fields: {
     ...basePage('orgUnits'),

--- a/apps/cms/src/app/models/Park.ts
+++ b/apps/cms/src/app/models/Park.ts
@@ -26,11 +26,11 @@ export const Park: ListConfig<any> = list({
     facilities: relationship({ ref: 'Facility.park', many: true }),
   },
   hooks: {
-    beforeOperation(args) {
-      typesenseDelete(args);
+    async beforeOperation(args) {
+      await typesenseDelete(args);
     },
     async afterOperation(args) {
-      typesenseUpsert(
+      await typesenseUpsert(
         'park',
         'id title description body slug liveUrl publishAt owner {name} tags {name} services {title} trails {title} facilities {title}',
         args,

--- a/apps/cms/src/app/models/Park.ts
+++ b/apps/cms/src/app/models/Park.ts
@@ -1,45 +1,14 @@
 import { list, ListConfig } from '@keystone-6/core';
 import { generalItemAccess, generalOperationAccess } from '../access';
-import { blueHarvestImage } from '../../components/customFields/blueHarvestImage';
 import {
-  contacts,
-  liveUrl,
-  owner,
-  publishable,
+  basePage,
   services,
-  slug,
-  tags,
-  timestamps,
-  titleAndDescription,
-  userGroups,
+  typesenseDelete,
+  typesenseUpsert,
 } from '../fieldUtils';
 import { relationship } from '@keystone-6/core/fields';
-import { customText } from '../../components/customFields/Markdown';
-import { TYPESENSE_CLIENT, TYPESENSE_COLLECTIONS } from '../../utils/typesense';
 
 const listPlural = 'parks';
-
-export function parkToSearchableObj(item: any) {
-  return {
-    id: item.id,
-    title: item.title,
-    description: item.description,
-    body: item.body,
-    slug: item.slug,
-    published_at: item.publishAt
-      ? Math.floor(new Date(item.publishAt).getTime() / 1000)
-      : undefined,
-    tags: item.tags.map((tag: { name: string }) => tag.name || ''),
-    services: item.services.map(
-      (service: { title: string }) => service.title || '',
-    ),
-    trails: item.trails.map((trail: { title: string }) => trail.title || ''),
-    facilities: item.facilities.map(
-      (facility: { title: string }) => facility.title || '',
-    ),
-    type: 'park',
-  };
-}
 
 export const Park: ListConfig<any> = list({
   access: {
@@ -47,79 +16,25 @@ export const Park: ListConfig<any> = list({
     item: generalItemAccess('Park'),
   },
   fields: {
-    heroImage: blueHarvestImage(),
-    ...titleAndDescription(),
-    ...publishable,
-    liveUrl: liveUrl(listPlural),
-    slug,
-    owner,
-    body: customText(),
-    tags: tags(listPlural),
-    userGroups: userGroups(listPlural),
-    address: relationship({
-      ref: 'Location',
-      many: false,
-      ui: {
-        displayMode: 'cards',
-        cardFields: ['lineOne', 'lineTwo', 'city', 'state', 'zip'],
-        inlineCreate: {
-          fields: ['title', 'lineOne', 'lineTwo', 'city', 'state', 'zip'],
-        },
-        inlineEdit: { fields: ['lineOne', 'lineTwo', 'city', 'state', 'zip'] },
-        inlineConnect: true,
-        itemView: {
-          fieldPosition: 'sidebar',
-        },
-      },
+    ...basePage(listPlural, {
+      address: true,
+      hours: true,
     }),
-    contacts: contacts(listPlural),
+
     services: services(listPlural),
     trails: relationship({ ref: 'Trail.park', many: true }),
     facilities: relationship({ ref: 'Facility.park', many: true }),
-    hours: relationship({
-      ref: 'OperatingHour',
-      many: true,
-      ui: {
-        displayMode: 'cards',
-        cardFields: ['day', 'open', 'close'],
-        inlineCreate: {
-          fields: ['day', 'open', 'close'],
-        },
-        inlineEdit: {
-          fields: ['day', 'open', 'close'],
-        },
-      },
-    }),
-    ...timestamps,
   },
   hooks: {
-    beforeOperation: {
-      async delete({ item }) {
-        try {
-          TYPESENSE_CLIENT.collections(TYPESENSE_COLLECTIONS.PAGES)
-            .documents(item.id.toString())
-            .delete();
-        } catch (e) {
-          console.error('Error deleting Typesense document', e);
-        }
-      },
+    beforeOperation(args) {
+      typesenseDelete(args);
     },
-    async afterOperation({ operation, context, item }) {
-      if (operation === 'update' || operation === 'create') {
-        try {
-          const park = await context.query.Park.findOne({
-            where: { id: item.id.toString() },
-            query:
-              'id title description body slug liveUrl publishAt owner {name} tags {name} services {title} trails {title} facilities {title}',
-          });
-          const searchableObj = parkToSearchableObj(park);
-          await TYPESENSE_CLIENT.collections(TYPESENSE_COLLECTIONS.PAGES)
-            .documents()
-            .upsert(searchableObj);
-        } catch (e: any) {
-          console.error('Error updating Typesense document', e);
-        }
-      }
+    async afterOperation(args) {
+      typesenseUpsert(
+        'park',
+        'id title description body slug liveUrl publishAt owner {name} tags {name} services {title} trails {title} facilities {title}',
+        args,
+      );
     },
   },
 });

--- a/apps/cms/src/app/models/PublicNotice.ts
+++ b/apps/cms/src/app/models/PublicNotice.ts
@@ -6,6 +6,7 @@ import {
   generalOperationAccess,
 } from '../access';
 import { timestamp } from '@keystone-6/core/fields';
+import { createAndSendBulletin } from '../../utils/emailUtils';
 
 const listPlural = 'publicNotices';
 
@@ -34,5 +35,19 @@ export const PublicNotice: ListConfig<any> = list({
         views: './src/components/customFields/datetime/views.tsx',
       },
     }),
+  },
+
+  hooks: {
+    afterOperation: {
+      async create({ item }) {
+        await createAndSendBulletin(
+          item.title as string,
+          item.description as string,
+          'public-notices',
+          item.slug as string,
+          item.heroImage as string | undefined | null,
+        );
+      },
+    },
   },
 });

--- a/apps/cms/src/app/models/PublicNotice.ts
+++ b/apps/cms/src/app/models/PublicNotice.ts
@@ -24,9 +24,6 @@ export const PublicNotice: ListConfig<any> = list({
       },
       ui: {
         views: './src/components/customFields/datetime/views.tsx',
-        // itemView: {
-        //   fieldPosition: 'sidebar',
-        // },
       },
     }),
     endDate: timestamp({
@@ -35,9 +32,6 @@ export const PublicNotice: ListConfig<any> = list({
       },
       ui: {
         views: './src/components/customFields/datetime/views.tsx',
-        // itemView: {
-        //   fieldPosition: 'sidebar',
-        // },
       },
     }),
   },

--- a/apps/cms/src/app/models/PublicNotice.ts
+++ b/apps/cms/src/app/models/PublicNotice.ts
@@ -1,3 +1,38 @@
 import { list, ListConfig } from '@keystone-6/core';
+import { basePage } from '../fieldUtils';
+import {
+  filterByPubDates,
+  generalItemAccess,
+  generalOperationAccess,
+} from '../access';
+import { timestamp } from '@keystone-6/core/fields';
 
-export const PublicNotice: ListConfig<any> = list({});
+const listPlural = 'publicNotices';
+
+export const PublicNotice: ListConfig<any> = list({
+  access: {
+    operation: generalOperationAccess,
+    item: generalItemAccess('PublicNotice'),
+    filter: filterByPubDates,
+  },
+
+  fields: {
+    ...basePage(listPlural, { actions: true, documents: true }),
+    effectiveDate: timestamp({
+      db: {
+        isNullable: true,
+      },
+      ui: {
+        views: './src/components/customFields/datetime/views.tsx',
+      },
+    }),
+    endDate: timestamp({
+      db: {
+        isNullable: true,
+      },
+      ui: {
+        views: './src/components/customFields/datetime/views.tsx',
+      },
+    }),
+  },
+});

--- a/apps/cms/src/app/models/PublicNotice.ts
+++ b/apps/cms/src/app/models/PublicNotice.ts
@@ -24,6 +24,9 @@ export const PublicNotice: ListConfig<any> = list({
       },
       ui: {
         views: './src/components/customFields/datetime/views.tsx',
+        // itemView: {
+        //   fieldPosition: 'sidebar',
+        // },
       },
     }),
     endDate: timestamp({
@@ -32,6 +35,9 @@ export const PublicNotice: ListConfig<any> = list({
       },
       ui: {
         views: './src/components/customFields/datetime/views.tsx',
+        // itemView: {
+        //   fieldPosition: 'sidebar',
+        // },
       },
     }),
   },

--- a/apps/cms/src/app/models/PublicNotice.ts
+++ b/apps/cms/src/app/models/PublicNotice.ts
@@ -1,0 +1,3 @@
+import { list, ListConfig } from '@keystone-6/core';
+
+export const PublicNotice: ListConfig<any> = list({});

--- a/apps/cms/src/app/models/PublicNotice.ts
+++ b/apps/cms/src/app/models/PublicNotice.ts
@@ -5,7 +5,7 @@ import {
   generalItemAccess,
   generalOperationAccess,
 } from '../access';
-import { timestamp } from '@keystone-6/core/fields';
+import { relationship, timestamp } from '@keystone-6/core/fields';
 import { createAndSendBulletin } from '../../utils/emailUtils';
 
 const listPlural = 'publicNotices';
@@ -34,6 +34,34 @@ export const PublicNotice: ListConfig<any> = list({
       ui: {
         views: './src/components/customFields/datetime/views.tsx',
       },
+    }),
+    parks: relationship({
+      ref: 'Park',
+      many: true,
+    }),
+    services: relationship({
+      ref: 'Service',
+      many: true,
+    }),
+    orgUnits: relationship({
+      ref: 'OrgUnit',
+      many: true,
+    }),
+    facilities: relationship({
+      ref: 'Facility',
+      many: true,
+    }),
+    trails: relationship({
+      ref: 'Trail',
+      many: true,
+    }),
+    communities: relationship({
+      ref: 'Community',
+      many: true,
+    }),
+    assemblyDistricts: relationship({
+      ref: 'AssemblyDistrict',
+      many: true,
     }),
   },
 

--- a/apps/cms/src/app/models/PublicNotice.ts
+++ b/apps/cms/src/app/models/PublicNotice.ts
@@ -1,7 +1,7 @@
 import { list, ListConfig } from '@keystone-6/core';
 import { basePage, typesenseDelete, typesenseUpsert } from '../fieldUtils';
 import { generalItemAccess, generalOperationAccess } from '../access';
-import { relationship, timestamp } from '@keystone-6/core/fields';
+import { relationship, select, timestamp } from '@keystone-6/core/fields';
 import { createAndSendBulletin } from '../../utils/emailUtils';
 
 const listPlural = 'publicNotices';
@@ -14,6 +14,27 @@ export const PublicNotice: ListConfig<any> = list({
 
   fields: {
     ...basePage(listPlural, { actions: true, documents: true }),
+    urgency: select({
+      type: 'integer',
+      options: [
+        { label: 'Low', value: 1 },
+        { label: 'Normal', value: 2 },
+        { label: 'High', value: 3 },
+        { label: 'Urgent', value: 4 },
+        { label: 'Emergency', value: 5 },
+      ],
+      defaultValue: 2,
+      isOrderable: true,
+      validation: {
+        isRequired: true,
+      },
+      ui: {
+        displayMode: 'segmented-control',
+        itemView: {
+          fieldPosition: 'sidebar',
+        },
+      },
+    }),
     effectiveDate: timestamp({
       db: {
         isNullable: true,
@@ -67,7 +88,7 @@ export const PublicNotice: ListConfig<any> = list({
     async afterOperation(args) {
       await typesenseUpsert(
         'public-notice',
-        'id title slug description body publishAt tags {name} services {title} parks {title} orgUnits {title} facilities {title} trails {title} communities {title} assemblyDistricts {title}',
+        'id title slug description body publishAt tags {name} services {title} parks {title} orgUnits {title} facilities {title} trails {title} communities {title} assemblyDistricts {title} urgency',
         args,
       );
 

--- a/apps/cms/src/app/models/PublicNotice.ts
+++ b/apps/cms/src/app/models/PublicNotice.ts
@@ -66,7 +66,7 @@ export const PublicNotice: ListConfig<any> = list({
     },
     async afterOperation(args) {
       await typesenseUpsert(
-        'publicNotice',
+        'public-notice',
         'id title slug description body publishAt tags {name} services {title} parks {title} orgUnits {title} facilities {title} trails {title} communities {title} assemblyDistricts {title}',
         args,
       );

--- a/apps/cms/src/app/models/Service.ts
+++ b/apps/cms/src/app/models/Service.ts
@@ -1,17 +1,11 @@
 import { list, ListConfig } from '@keystone-6/core';
 import { relationship, text } from '@keystone-6/core/fields';
 import { basePage, typesenseDelete, typesenseUpsert } from '../fieldUtils';
-
 import {
   filterByPubDates,
   generalItemAccess,
   generalOperationAccess,
 } from '../access/utils';
-import {
-  toSearchableObj,
-  TYPESENSE_CLIENT,
-  TYPESENSE_COLLECTIONS,
-} from '../../utils/typesense';
 
 export const Service: ListConfig<any> = list({
   access: {

--- a/apps/cms/src/app/models/Service.ts
+++ b/apps/cms/src/app/models/Service.ts
@@ -104,11 +104,11 @@ export const Service: ListConfig<any> = list({
   },
   hooks: {
     async beforeOperation(args) {
-      typesenseDelete(args);
+      await typesenseDelete(args);
     },
 
     async afterOperation(args) {
-      typesenseUpsert(
+      await typesenseUpsert(
         'service',
         `id title description body slug owner {name} actionLabel publishAt tags {name} districts {title} orgUnits {title} communities {title}`,
         args,

--- a/apps/cms/src/app/models/Service.ts
+++ b/apps/cms/src/app/models/Service.ts
@@ -1,17 +1,6 @@
-import { group, list, ListConfig } from '@keystone-6/core';
+import { list, ListConfig } from '@keystone-6/core';
 import { relationship, text } from '@keystone-6/core/fields';
-import {
-  liveUrl,
-  owner,
-  publishable,
-  slug,
-  tags,
-  timestamps,
-  titleAndDescription,
-  urlRegex,
-  userGroups,
-} from '../fieldUtils';
-import { customText } from '../../components/customFields/Markdown';
+import { basePage, typesenseDelete, typesenseUpsert } from '../fieldUtils';
 
 import {
   filterByPubDates,
@@ -22,25 +11,7 @@ import {
   toSearchableObj,
   TYPESENSE_CLIENT,
   TYPESENSE_COLLECTIONS,
-  TypeSensePageDocument,
 } from '../../utils/typesense';
-import { blueHarvestImage } from '../../components/customFields/blueHarvestImage';
-
-export function serviceToSearchableObj(item: any): TypeSensePageDocument {
-  return {
-    id: item.id,
-    title: item.title,
-    description: item.description,
-    body: item.body,
-    slug: item.slug,
-    action_label: item.actionLabel,
-    published_at: item.publishAt
-      ? Math.floor(new Date(item.publishAt).getTime() / 1000)
-      : undefined,
-    tags: item.tags.map((tag: { name: string }) => tag.name || ''),
-    type: 'service',
-  };
-}
 
 export const Service: ListConfig<any> = list({
   access: {
@@ -52,118 +23,10 @@ export const Service: ListConfig<any> = list({
     maxTake: 100,
   },
   fields: {
-    heroImage: blueHarvestImage(),
-    ...titleAndDescription(),
-    ...publishable,
-    liveUrl: liveUrl('services'),
-    slug,
-    owner,
-    body: customText(),
-
-    primaryAction: relationship({
-      ref: 'ExternalLink',
-      ui: {
-        itemView: {
-          fieldPosition: 'sidebar',
-        },
-        displayMode: 'cards',
-        cardFields: ['label', 'url'],
-        inlineCreate: {
-          fields: ['label', 'url'],
-        },
-        inlineConnect: true,
-        inlineEdit: {
-          fields: ['label', 'url'],
-        },
-      },
-      many: false,
-    }),
-
-    secondaryActions: relationship({
-      ref: 'ExternalLink',
-      ui: {
-        itemView: {
-          fieldPosition: 'sidebar',
-        },
-        displayMode: 'cards',
-        cardFields: ['label', 'url'],
-        inlineCreate: {
-          fields: ['label', 'url'],
-        },
-        inlineConnect: true,
-        inlineEdit: {
-          fields: ['label', 'url'],
-        },
-      },
-      many: true,
-    }),
-
-    ...group({
-      label: 'Primary Action',
-      description:
-        'Deprecated, made readonly for now. Will be removed eventually.',
-      fields: {
-        actionLabel: text({
-          validation: {
-            length: {
-              max: 100,
-            },
-          },
-          db: {
-            isNullable: true,
-          },
-          ui: {
-            itemView: {
-              fieldPosition: 'sidebar',
-              fieldMode: 'read',
-            },
-            createView: {
-              fieldMode: 'hidden',
-            },
-          },
-        }),
-
-        actionUrl: text({
-          validation: {
-            match: {
-              regex: urlRegex,
-            },
-          },
-          db: {
-            isNullable: true,
-          },
-          ui: {
-            itemView: {
-              fieldPosition: 'sidebar',
-              fieldMode: 'read',
-            },
-            createView: {
-              fieldMode: 'hidden',
-            },
-          },
-        }),
-      },
-    }),
-
-    tags: tags('services'),
-    userGroups: userGroups('services'),
-    primaryContact: relationship({
-      ref: 'Contact.primaryServices',
-      ui: {
-        itemView: {
-          fieldPosition: 'sidebar',
-        },
-      },
-    }),
-
-    contacts: relationship({
-      ref: 'Contact.services',
-      many: true,
-      ui: {
-        itemView: {
-          fieldPosition: 'sidebar',
-        },
-      },
+    ...basePage('services', {
+      primaryAction: true,
+      secondaryActions: true,
+      primaryContact: true,
     }),
 
     communities: relationship({
@@ -204,6 +67,7 @@ export const Service: ListConfig<any> = list({
         hideCreate: true,
       },
     }),
+
     parks: relationship({
       ref: 'Park.services',
       many: true,
@@ -217,6 +81,7 @@ export const Service: ListConfig<any> = list({
         hideCreate: true,
       },
     }),
+
     facilities: relationship({
       ref: 'Facility.services',
       many: true,
@@ -231,7 +96,6 @@ export const Service: ListConfig<any> = list({
       },
     }),
 
-    ...timestamps,
     editorNotes: text({
       ui: {
         displayMode: 'textarea',
@@ -239,36 +103,16 @@ export const Service: ListConfig<any> = list({
     }),
   },
   hooks: {
-    async beforeOperation({ operation, context, item }) {
-      if (operation === 'delete') {
-        try {
-          TYPESENSE_CLIENT.collections(TYPESENSE_COLLECTIONS.PAGES)
-            .documents(item.id.toString())
-            .delete();
-        } catch (error: any) {
-          console.error('Error deleting Typesense document', error);
-        }
-      }
+    async beforeOperation(args) {
+      typesenseDelete(args);
     },
 
-    async afterOperation({ operation, context, item }) {
-      if (operation === 'update' || operation === 'create') {
-        try {
-          const service = await context.query.Service.findOne({
-            where: { id: item.id.toString() },
-            query:
-              'id title description body slug owner {name} actionLabel publishAt tags {name} districts {title} orgUnits {title} communities {title}',
-          });
-
-          const document = toSearchableObj(service, 'service');
-
-          await TYPESENSE_CLIENT.collections(TYPESENSE_COLLECTIONS.PAGES)
-            .documents()
-            .upsert(document);
-        } catch (error: any) {
-          console.error('Error updating Typesense document:', error);
-        }
-      }
+    async afterOperation(args) {
+      typesenseUpsert(
+        'service',
+        `id title description body slug owner {name} actionLabel publishAt tags {name} districts {title} orgUnits {title} communities {title}`,
+        args,
+      );
     },
   },
 });

--- a/apps/cms/src/app/models/Tag.ts
+++ b/apps/cms/src/app/models/Tag.ts
@@ -28,5 +28,9 @@ export const Tag: ListConfig<any> = list({
       ref: 'AssemblyDistrict.tags',
       many: true,
     }),
+    publicNotices: relationship({
+      ref: 'PublicNotice.tags',
+      many: true,
+    }),
   },
 });

--- a/apps/cms/src/app/models/Tag.ts
+++ b/apps/cms/src/app/models/Tag.ts
@@ -24,5 +24,9 @@ export const Tag: ListConfig<any> = list({
     facilities: relationship({ ref: 'Facility.tags', many: true }),
     parks: relationship({ ref: 'Park.tags', many: true }),
     trails: relationship({ ref: 'Trail.tags', many: true }),
+    assemblyDistricts: relationship({
+      ref: 'AssemblyDistrict.tags',
+      many: true,
+    }),
   },
 });

--- a/apps/cms/src/app/models/UserGroup.ts
+++ b/apps/cms/src/app/models/UserGroup.ts
@@ -2,7 +2,6 @@ import { list, ListConfig } from '@keystone-6/core';
 import { relationship, text } from '@keystone-6/core/fields';
 import { owner } from '../fieldUtils';
 import { generalItemAccess, generalOperationAccess } from '../access';
-import { AssemblyDistrict } from './AssemblyDistrict';
 
 export const UserGroup: ListConfig<any> = list({
   access: {
@@ -26,6 +25,10 @@ export const UserGroup: ListConfig<any> = list({
     }),
     assemblyDistricts: relationship({
       ref: 'AssemblyDistrict.userGroups',
+      many: true,
+    }),
+    publicNotices: relationship({
+      ref: 'PublicNotice.userGroups',
       many: true,
     }),
   },

--- a/apps/cms/src/app/models/UserGroup.ts
+++ b/apps/cms/src/app/models/UserGroup.ts
@@ -2,6 +2,7 @@ import { list, ListConfig } from '@keystone-6/core';
 import { relationship, text } from '@keystone-6/core/fields';
 import { owner } from '../fieldUtils';
 import { generalItemAccess, generalOperationAccess } from '../access';
+import { AssemblyDistrict } from './AssemblyDistrict';
 
 export const UserGroup: ListConfig<any> = list({
   access: {
@@ -18,8 +19,13 @@ export const UserGroup: ListConfig<any> = list({
     trails: relationship({ ref: 'Trail.userGroups', many: true }),
     facilities: relationship({ ref: 'Facility.userGroups', many: true }),
     communities: relationship({ ref: 'Community.userGroups', many: true }),
+    orgUnits: relationship({ ref: 'OrgUnit.userGroups', many: true }),
     documentCollections: relationship({
       ref: 'DocumentCollection.userGroups',
+      many: true,
+    }),
+    assemblyDistricts: relationship({
+      ref: 'AssemblyDistrict.userGroups',
       many: true,
     }),
   },

--- a/apps/cms/src/app/models/index.ts
+++ b/apps/cms/src/app/models/index.ts
@@ -8,6 +8,7 @@ import { DocumentCollection } from './DocumentCollection';
 import { ExternalLink } from './ExternalLink';
 import { Facility } from './Facility';
 import { Highlight } from './Highlight';
+import { HomePage } from './HomePage';
 import { Image } from './Image';
 import { InternalLink } from './InternalLink';
 import { Location } from './Location';
@@ -32,6 +33,7 @@ export const lists = {
   ExternalLink,
   Facility,
   Highlight,
+  HomePage: HomePage,
   Image,
   InternalLink,
   Location,

--- a/apps/cms/src/app/models/index.ts
+++ b/apps/cms/src/app/models/index.ts
@@ -14,6 +14,7 @@ import { Location } from './Location';
 import { OrgUnit } from './OrgUnit';
 import { OperatingHour } from './OperatingHour';
 import { Park } from './Park';
+import { PublicNotice } from './PublicNotice';
 import { Service } from './Service';
 import { Tag } from './Tag';
 import { Trail } from './Trail';
@@ -37,6 +38,7 @@ export const lists = {
   OrgUnit,
   OperatingHour,
   Park,
+  PublicNotice,
   Service,
   Tag,
   Trail,

--- a/apps/cms/src/components/DateTimePicker.tsx
+++ b/apps/cms/src/components/DateTimePicker.tsx
@@ -32,6 +32,8 @@ export function DateTimePicker({
         timeIntervals={15}
         dateFormat="Pp"
         className="w-full rounded-md border border-gray-300 p-2 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+        withPortal
+        isClearable
       />
       {startDate && (
         <p className="mt-2 text-sm text-gray-600">

--- a/apps/cms/src/components/DateTimePicker.tsx
+++ b/apps/cms/src/components/DateTimePicker.tsx
@@ -22,24 +22,18 @@ export function DateTimePicker({
 
   return (
     <div className="w-full max-w-sm">
-      <label className="mb-1 block text-sm font-medium text-gray-700">
-        Select Date & Time
-      </label>
       <DatePicker
         selected={startDate}
         onChange={handleChange}
         showTimeSelect
         timeIntervals={15}
         dateFormat="Pp"
-        className="w-full rounded-md border border-gray-300 p-2 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none"
-        withPortal
+        className="w-full rounded-md border border-gray-300 p-2 pl-10 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+        showIcon
+        calendarIconClassName="flex items-center justify-center size-6"
+        wrapperClassName="w-full"
         isClearable
       />
-      {startDate && (
-        <p className="mt-2 text-sm text-gray-600">
-          Selected: {format(startDate, 'PPpp')}
-        </p>
-      )}
     </div>
   );
 }

--- a/apps/cms/src/components/customFields/Markdown/index.ts
+++ b/apps/cms/src/components/customFields/Markdown/index.ts
@@ -171,10 +171,13 @@ const MyOrderDirectionEnum = graphql.enum({
   values: graphql.enumValues(['asc', 'desc']),
 });
 
+export type CustomTextOpts<ListTypeInfo extends BaseListTypeInfo> =
+  TextFieldConfig<ListTypeInfo>;
+
 export function customText<ListTypeInfo extends BaseListTypeInfo>({
   isIndexed,
   ...config
-}: TextFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> {
+}: CustomTextOpts<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> {
   return (meta) =>
     fieldType({
       kind: 'scalar',

--- a/apps/cms/src/components/customFields/blueHarvestImage/index.ts
+++ b/apps/cms/src/components/customFields/blueHarvestImage/index.ts
@@ -6,7 +6,7 @@ import {
   FieldTypeFunc,
 } from '@keystone-6/core/types';
 
-type BlueHarvestImageConfig<ListTypeInfo extends BaseListTypeInfo> =
+export type BlueHarvestImageConfig<ListTypeInfo extends BaseListTypeInfo> =
   CommonFieldConfig<ListTypeInfo> & {
     notBanner?: boolean;
   };

--- a/apps/cms/src/utils/emailUtils.tsx
+++ b/apps/cms/src/utils/emailUtils.tsx
@@ -1,0 +1,104 @@
+import axios, { AxiosError } from 'axios';
+import { appConfig } from '../configs/appConfig';
+
+export async function createAndSendBulletin(
+  title: string,
+  body: string,
+  listName: string,
+  slug: string,
+  imageUrl?: string | null,
+) {
+  try {
+    await axios.request({
+      method: 'post',
+      maxBodyLength: Infinity,
+      url: `https://${process.env.GOV_DELIVERY_SUB_DOMAIN}.govdelivery.com/api/account/${process.env.GOV_DELIVERY_ACCOUNT_CODE}/bulletins/send_now`,
+      auth: {
+        username: process.env.GOV_DELIVERY_USERNAME!,
+        password: process.env.GOV_DELIVERY_PASSWORD!,
+      },
+      headers: {
+        'Content-Type': 'application/xml',
+      },
+      data: `<bulletin>
+   <header>
+      <![CDATA[
+        <img 
+          src="${!!imageUrl ? imageUrl : 'https://content.govdelivery.com/attachments/fancy_images/AKMATSUGOV/2024/11/10609030/5868415/msb-banner_crop.png'}"
+          alt="Matsu Borough"
+          style="max-width: 700px; width: 100%; max-height: 300px; display: block; object-fit: cover;" 
+        />
+      ]]>
+   </header>
+   <FROM_ADDRESS_ID>${process.env.GOV_DELIVERY_FROM_ADDRESS}</FROM_ADDRESS_ID>
+   <subject>${title}</subject>
+   <body><![CDATA[
+    <div>
+      <div style="padding: 14px; background-color: #004990; color: #ffffff; text-align: center;">
+        <strong>
+          <p style="line-height: 1.5; font-family: Arial, sans-serif; font-size: 18px; text-align: center;">${title}<p>
+        </string>
+      </div>
+      <p style="margin-bottom: 8px; font-family: Arial, sans-serif; font-size: 16px; line-height: 1.25;">
+        Hello, this is a public notice from the Matanuska-Susitna Borough.
+      </p>
+      <p style="margin-bottom: 8px; font-family: Arial, sans-serif; font-size: 16px; line-height: 1.25;">${body}<p/>
+      <div style="text-align: center;">
+        <a
+          style="
+            background-color: #004990;
+            color: #ffffff;
+            padding: 8px 16px;
+            text-decoration: none;
+            display: inline-block;
+            border-radius: 4px;
+            font-family: Arial, sans-serif;
+            font-size: 16px;
+            font-weight: bold;
+            line-height: 1.5;
+            text-align: center;
+          "
+          href="${appConfig.siteUrl}/${listName}/${slug}"
+        >
+          View More
+        </a>
+      </div>
+    </div>
+   ]]></body>
+   <footer>
+      <![CDATA[
+      <div style="padding-top: 16px; border-top: 2px solid #ccc; margin-top: 16px;">
+        <p style="margin-bottom: 8px; font-family: Arial, sans-serif; font-size: 14px; line-height: 1.25; color: #0e0e0e">
+          This email was sent to you because you are subscribed to Public Notice Emails from the Matanuska-Susitna Borough. <a href="https://public.govdelivery.com/accounts/AKMATSUGOV/subscriber/new?preferences=true">Manage your subscription</a>
+        <p/>
+        <p style="margin-bottom: 8px; font-family: Arial, sans-serif; font-size: 14px; line-height: 1.25; color: #0e0e0e">
+          This service is provided to you at no charge by the <a href="${appConfig.siteUrl}">Matanuska-Susitna Borough</a>.
+        </p>
+      </div>
+      ]]>
+   </footer>
+   <publish_rss type='boolean'>false</publish_rss>
+   <open_tracking type='boolean'>true</open_tracking>
+   <click_tracking type='boolean'>true</click_tracking>
+   <share_content_enabled type='boolean'>true</share_content_enabled>
+   <topics type='array'>
+     <topic>
+       <code>AKMATSUGOVSTAGE_TEST_TOPIC</code>
+     </topic>
+   </topics>
+   <categories type='array' />
+ </bulletin>`,
+    });
+  } catch (err: any) {
+    if (err.response) {
+      console.error('Error response:', err.response.data);
+      console.error('Status code:', err.response.status);
+      console.error('Headers:', err.response.headers);
+    } else if (err.request) {
+      console.error('Error request:', err.request);
+    } else {
+      console.error('Error message:', err.message);
+    }
+    console.error('Error config:', err.config);
+  }
+}

--- a/apps/cms/src/utils/index.ts
+++ b/apps/cms/src/utils/index.ts
@@ -41,7 +41,10 @@ const ignoreWords = [
 ];
 
 const separators = [' ', '-', '_'];
-const separatorRegex = new RegExp(`[${separators.join('|')}]`, 'g');
+const escapedSeparators = separators
+  .map((s) => (s === '-' ? '\\-' : s))
+  .join('');
+const separatorRegex = new RegExp(`[${escapedSeparators}]`, 'gi');
 
 export function toTitleCase(str: string) {
   const lowerCaseStr = str.toLowerCase();

--- a/apps/cms/src/utils/typesense/index.ts
+++ b/apps/cms/src/utils/typesense/index.ts
@@ -17,6 +17,7 @@ export type TypeSensePageDocument = {
   departments?: string[];
   communities?: string[];
   type?: string;
+  related_entities?: string[];
 };
 
 export const TYPESENSE_COLLECTIONS = {
@@ -53,6 +54,12 @@ export const COLLECTIONS: CollectionCreateSchema[] = [
       { name: 'districts', type: 'string[]', optional: true, facet: true },
       { name: 'departments', type: 'string[]', optional: true, facet: true },
       { name: 'communities', type: 'string[]', optional: true, facet: true },
+      {
+        name: 'related_pages',
+        type: 'string[]',
+        optional: true,
+        facet: true,
+      },
       { name: 'type', type: 'string', optional: true, facet: true },
     ],
   },
@@ -165,25 +172,44 @@ export function toSearchableObj(
     ...(item.tags && {
       tags: item.tags.map((tag: { name: string }) => tag.name || ''),
     }),
+
     ...(item.orgUnits && {
       departments: item.orgUnits.map(
         (department: { title: string }) => department.title || '',
       ),
     }),
-    ...(item.services && {
-      services: item.services.map(
-        (service: { title: string }) => service.title || '',
-      ),
-    }),
+
     ...(item.districts && {
       districts: item.districts.map(
         (district: { title: string }) => district.title || '',
       ),
     }),
+
     ...(item.communities && {
       communities: item.communities.map(
         (community: { title: string }) => community.title || '',
       ),
     }),
+
+    related_pages: [
+      ...mapRelatedEntities(item.orgUnits, 'department'),
+      ...mapRelatedEntities(item.services, 'service'),
+      ...mapRelatedEntities(item.assemblyDistricts, 'district'),
+      ...mapRelatedEntities(item.communities, 'community'),
+      ...mapRelatedEntities(item.parks, 'park'),
+      ...mapRelatedEntities(item.trails, 'trail'),
+      ...mapRelatedEntities(item.facilities, 'facility'),
+    ],
   };
+}
+
+function mapRelatedEntities(
+  item: { title: string }[] | undefined | null,
+  type: string,
+) {
+  if (!item) return [];
+
+  return item.map((entity) => {
+    return type + ':' + entity.title;
+  });
 }

--- a/apps/cms/src/utils/typesense/index.ts
+++ b/apps/cms/src/utils/typesense/index.ts
@@ -54,6 +54,7 @@ export const COLLECTIONS: CollectionCreateSchema[] = [
       { name: 'districts', type: 'string[]', optional: true, facet: true },
       { name: 'departments', type: 'string[]', optional: true, facet: true },
       { name: 'communities', type: 'string[]', optional: true, facet: true },
+      { name: 'urgency', type: 'int32', optional: true, facet: true },
       {
         name: 'related_pages',
         type: 'string[]',
@@ -189,6 +190,10 @@ export function toSearchableObj(
       communities: item.communities.map(
         (community: { title: string }) => community.title || '',
       ),
+    }),
+
+    ...(item.urgency && {
+      urgency: item.urgency,
     }),
 
     related_pages: [

--- a/apps/cms/src/utils/typesense/index.ts
+++ b/apps/cms/src/utils/typesense/index.ts
@@ -170,6 +170,11 @@ export function toSearchableObj(
         (department: { title: string }) => department.title || '',
       ),
     }),
+    ...(item.services && {
+      services: item.services.map(
+        (service: { title: string }) => service.title || '',
+      ),
+    }),
     ...(item.districts && {
       districts: item.districts.map(
         (district: { title: string }) => district.title || '',


### PR DESCRIPTION
This pull request introduces several database schema updates and new features for the CMS application. The changes include adding new columns to existing tables, creating new tables, updating relationships, and enhancing the schema to support additional functionality like public notices and homepage content. Below is a summary of the most significant changes:

### Schema Updates and New Columns
* Added a `body` column to `Community`, `OrgUnit`, and `AssemblyDistrict` tables. Also added several timestamp and metadata columns to `AssemblyDistrict` for enhanced tracking (`createdAt`, `updatedAt`, `publishAt`, `unpublishAt`, `reviewDate`). (`[[1]](diffhunk://#diff-53ce3d8adbed16f5e91f58dcb607aeeec4ae4d35e5f6eed272822bfe0ff46e62R1-R13)`, `[[2]](diffhunk://#diff-73d6772fa0cf758692b04171e86aeb73c9caa8d9930179af50b50e2f80f21d12R1-R20)`, `[[3]](diffhunk://#diff-855ed833769ae70d054efd358006b3c4103efd1515f630f7bfb3df9e05c2aca6R1-R71)`)
* Added an `urgency` column to the `PublicNotice` table, initially optional with a default value of `2`, and later made required. (`[[1]](diffhunk://#diff-6c9b17f636c5e54ff961757e6d476d7a281b0cbdefe589083baea86e05e57866R1-R2)`, `[[2]](diffhunk://#diff-3b197bba1fe0c6d65a51a2a693bd3536e340f9988e2b3df64af56545ac53d92fR1-R8)`)

### New Tables and Relationships
* Created a `PublicNotice` table with fields for metadata, timestamps, and relationships. Added associated join tables for linking `PublicNotice` with `tags`, `documents`, `userGroups`, and other entities. (`[apps/cms/migrations/20250409224642_create_public_notices/migration.sqlR1-R110](diffhunk://#diff-88affc1a914a1deea9e99d5afcbde3f534f63c040a2c363eaee90e6ab1d8f820R1-R110)`)
* Introduced a `HomePage` table to manage homepage content, including toolbelt and highlight sections, with foreign key constraints to related entities. (`[apps/cms/migrations/20250410215751_add_relationships_to_public_notices_create_home_page_ct/migration.sqlR1-R189](diffhunk://#diff-ff913be460a7f97b4c4041dbc392236a11fe1cb3b15c115ad8c9f642009c6259R1-R189)`)

### Prisma Schema Enhancements
* Updated the Prisma schema to reflect changes in relationships and new fields. Added relationships for `PublicNotice` with `AssemblyDistrict`, `Community`, `Facility`, `OrgUnit`, and others. (`[[1]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5R27-R41)`, `[[2]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5R53)`, `[[3]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5L59-R79)`, `[[4]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5R96-R101)`, `[[5]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5R113)`, `[[6]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5L143-R165)`)

### Column Removals
* Dropped unused columns such as `actionLabel` and `actionUrl` from the `Service` table and `groomed` from the `Trail` table. (`[[1]](diffhunk://#diff-53ce3d8adbed16f5e91f58dcb607aeeec4ae4d35e5f6eed272822bfe0ff46e62R1-R13)`, `[[2]](diffhunk://#diff-855ed833769ae70d054efd358006b3c4103efd1515f630f7bfb3df9e05c2aca6R1-R71)`)

### Indexes and Constraints
* Added unique indexes and foreign key constraints for newly created tables to ensure data integrity and optimize queries. Examples include unique constraints on `PublicNotice.title` and `HomePage.title`. (`[[1]](diffhunk://#diff-88affc1a914a1deea9e99d5afcbde3f534f63c040a2c363eaee90e6ab1d8f820R1-R110)`, `[[2]](diffhunk://#diff-ff913be460a7f97b4c4041dbc392236a11fe1cb3b15c115ad8c9f642009c6259R1-R189)`)

These changes collectively enhance the CMS's capability to manage public notices, homepage content, and relationships between entities while improving schema consistency and performance.