### PR TITLE
feat: created the topics CT

### DIFF
--- a/apps/cms/migrations/20250610004556_create_topics/migration.sql
+++ b/apps/cms/migrations/20250610004556_create_topics/migration.sql
@@ -1,0 +1,1234 @@
+-- CreateTable
+CREATE TABLE "Topic" (
+    "id" TEXT NOT NULL,
+    "heroImage" TEXT,
+    "title" TEXT NOT NULL DEFAULT '',
+    "description" TEXT NOT NULL DEFAULT '',
+    "publishAt" TIMESTAMP(3),
+    "unpublishAt" TIMESTAMP(3),
+    "reviewDate" TIMESTAMP(3),
+    "slug" TEXT NOT NULL DEFAULT '',
+    "owner" TEXT,
+    "body" TEXT,
+    "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "status" TEXT NOT NULL DEFAULT 'unpublished',
+    "makeDrafts" TEXT,
+    "currentVersion" TEXT,
+
+    CONSTRAINT "Topic_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TopicDraft" (
+    "id" TEXT NOT NULL,
+    "original" TEXT,
+    "heroImage" TEXT,
+    "title" TEXT NOT NULL DEFAULT '',
+    "description" TEXT NOT NULL DEFAULT '',
+    "publishAt" TIMESTAMP(3),
+    "unpublishAt" TIMESTAMP(3),
+    "reviewDate" TIMESTAMP(3),
+    "owner" TEXT,
+    "body" TEXT,
+    "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "publish" TEXT,
+
+    CONSTRAINT "TopicDraft_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TopicVersion" (
+    "id" TEXT NOT NULL,
+    "original" TEXT,
+    "heroImage" TEXT,
+    "title" TEXT NOT NULL DEFAULT '',
+    "description" TEXT NOT NULL DEFAULT '',
+    "publishAt" TIMESTAMP(3),
+    "unpublishAt" TIMESTAMP(3),
+    "reviewDate" TIMESTAMP(3),
+    "owner" TEXT,
+    "body" TEXT,
+    "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "republish" TEXT,
+
+    CONSTRAINT "TopicVersion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_AssemblyDistrict_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicDraft_districts" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicVersion_districts" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_AssemblyDistrictDraft_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_AssemblyDistrictVersion_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_Board_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicDraft_boards" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicVersion_boards" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_BoardDraft_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_BoardVersion_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_Community_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicDraft_communities" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicVersion_communities" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_CommunityDraft_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_CommunityVersion_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_Topic_contacts" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicDraft_contacts" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicVersion_contacts" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_Topic_documents" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicDraft_documents" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicVersion_documents" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_Facility_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicDraft_facilities" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicVersion_facilities" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_FacilityDraft_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_FacilityVersion_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_Topic_userGroups" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_Topic_trails" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TrailDraft_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TrailVersion_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicDraft_userGroups" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicDraft_trails" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicVersion_userGroups" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicVersion_trails" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_Topic_highlights" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicDraft_highlights" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicVersion_highlights" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_Topic_actions" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicDraft_actions" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicVersion_actions" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_OrgUnit_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicDraft_orgUnits" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicVersion_orgUnits" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_OrgUnitDraft_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_OrgUnitVersion_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_Park_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicDraft_parks" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicVersion_parks" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_ParkDraft_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_ParkVersion_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_PublicNotice_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicDraft_publicNotices" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicVersion_publicNotices" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_PublicNoticeDraft_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_PublicNoticeVersion_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_Service_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicDraft_services" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicVersion_services" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_ServiceDraft_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_ServiceVersion_topics" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_Topic_tags" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicDraft_tags" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_TopicVersion_tags" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Topic_title_key" ON "Topic"("title");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Topic_slug_key" ON "Topic"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Topic_currentVersion_key" ON "Topic"("currentVersion");
+
+-- CreateIndex
+CREATE INDEX "Topic_owner_idx" ON "Topic"("owner");
+
+-- CreateIndex
+CREATE INDEX "TopicDraft_original_idx" ON "TopicDraft"("original");
+
+-- CreateIndex
+CREATE INDEX "TopicDraft_owner_idx" ON "TopicDraft"("owner");
+
+-- CreateIndex
+CREATE INDEX "TopicVersion_original_idx" ON "TopicVersion"("original");
+
+-- CreateIndex
+CREATE INDEX "TopicVersion_owner_idx" ON "TopicVersion"("owner");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_AssemblyDistrict_topics_AB_unique" ON "_AssemblyDistrict_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_AssemblyDistrict_topics_B_index" ON "_AssemblyDistrict_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicDraft_districts_AB_unique" ON "_TopicDraft_districts"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicDraft_districts_B_index" ON "_TopicDraft_districts"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicVersion_districts_AB_unique" ON "_TopicVersion_districts"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicVersion_districts_B_index" ON "_TopicVersion_districts"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_AssemblyDistrictDraft_topics_AB_unique" ON "_AssemblyDistrictDraft_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_AssemblyDistrictDraft_topics_B_index" ON "_AssemblyDistrictDraft_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_AssemblyDistrictVersion_topics_AB_unique" ON "_AssemblyDistrictVersion_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_AssemblyDistrictVersion_topics_B_index" ON "_AssemblyDistrictVersion_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Board_topics_AB_unique" ON "_Board_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Board_topics_B_index" ON "_Board_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicDraft_boards_AB_unique" ON "_TopicDraft_boards"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicDraft_boards_B_index" ON "_TopicDraft_boards"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicVersion_boards_AB_unique" ON "_TopicVersion_boards"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicVersion_boards_B_index" ON "_TopicVersion_boards"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_BoardDraft_topics_AB_unique" ON "_BoardDraft_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_BoardDraft_topics_B_index" ON "_BoardDraft_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_BoardVersion_topics_AB_unique" ON "_BoardVersion_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_BoardVersion_topics_B_index" ON "_BoardVersion_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Community_topics_AB_unique" ON "_Community_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Community_topics_B_index" ON "_Community_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicDraft_communities_AB_unique" ON "_TopicDraft_communities"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicDraft_communities_B_index" ON "_TopicDraft_communities"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicVersion_communities_AB_unique" ON "_TopicVersion_communities"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicVersion_communities_B_index" ON "_TopicVersion_communities"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_CommunityDraft_topics_AB_unique" ON "_CommunityDraft_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_CommunityDraft_topics_B_index" ON "_CommunityDraft_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_CommunityVersion_topics_AB_unique" ON "_CommunityVersion_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_CommunityVersion_topics_B_index" ON "_CommunityVersion_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Topic_contacts_AB_unique" ON "_Topic_contacts"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Topic_contacts_B_index" ON "_Topic_contacts"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicDraft_contacts_AB_unique" ON "_TopicDraft_contacts"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicDraft_contacts_B_index" ON "_TopicDraft_contacts"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicVersion_contacts_AB_unique" ON "_TopicVersion_contacts"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicVersion_contacts_B_index" ON "_TopicVersion_contacts"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Topic_documents_AB_unique" ON "_Topic_documents"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Topic_documents_B_index" ON "_Topic_documents"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicDraft_documents_AB_unique" ON "_TopicDraft_documents"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicDraft_documents_B_index" ON "_TopicDraft_documents"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicVersion_documents_AB_unique" ON "_TopicVersion_documents"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicVersion_documents_B_index" ON "_TopicVersion_documents"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Facility_topics_AB_unique" ON "_Facility_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Facility_topics_B_index" ON "_Facility_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicDraft_facilities_AB_unique" ON "_TopicDraft_facilities"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicDraft_facilities_B_index" ON "_TopicDraft_facilities"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicVersion_facilities_AB_unique" ON "_TopicVersion_facilities"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicVersion_facilities_B_index" ON "_TopicVersion_facilities"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_FacilityDraft_topics_AB_unique" ON "_FacilityDraft_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_FacilityDraft_topics_B_index" ON "_FacilityDraft_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_FacilityVersion_topics_AB_unique" ON "_FacilityVersion_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_FacilityVersion_topics_B_index" ON "_FacilityVersion_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Topic_userGroups_AB_unique" ON "_Topic_userGroups"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Topic_userGroups_B_index" ON "_Topic_userGroups"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Topic_trails_AB_unique" ON "_Topic_trails"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Topic_trails_B_index" ON "_Topic_trails"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TrailDraft_topics_AB_unique" ON "_TrailDraft_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TrailDraft_topics_B_index" ON "_TrailDraft_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TrailVersion_topics_AB_unique" ON "_TrailVersion_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TrailVersion_topics_B_index" ON "_TrailVersion_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicDraft_userGroups_AB_unique" ON "_TopicDraft_userGroups"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicDraft_userGroups_B_index" ON "_TopicDraft_userGroups"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicDraft_trails_AB_unique" ON "_TopicDraft_trails"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicDraft_trails_B_index" ON "_TopicDraft_trails"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicVersion_userGroups_AB_unique" ON "_TopicVersion_userGroups"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicVersion_userGroups_B_index" ON "_TopicVersion_userGroups"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicVersion_trails_AB_unique" ON "_TopicVersion_trails"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicVersion_trails_B_index" ON "_TopicVersion_trails"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Topic_highlights_AB_unique" ON "_Topic_highlights"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Topic_highlights_B_index" ON "_Topic_highlights"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicDraft_highlights_AB_unique" ON "_TopicDraft_highlights"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicDraft_highlights_B_index" ON "_TopicDraft_highlights"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicVersion_highlights_AB_unique" ON "_TopicVersion_highlights"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicVersion_highlights_B_index" ON "_TopicVersion_highlights"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Topic_actions_AB_unique" ON "_Topic_actions"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Topic_actions_B_index" ON "_Topic_actions"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicDraft_actions_AB_unique" ON "_TopicDraft_actions"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicDraft_actions_B_index" ON "_TopicDraft_actions"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicVersion_actions_AB_unique" ON "_TopicVersion_actions"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicVersion_actions_B_index" ON "_TopicVersion_actions"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_OrgUnit_topics_AB_unique" ON "_OrgUnit_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_OrgUnit_topics_B_index" ON "_OrgUnit_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicDraft_orgUnits_AB_unique" ON "_TopicDraft_orgUnits"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicDraft_orgUnits_B_index" ON "_TopicDraft_orgUnits"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicVersion_orgUnits_AB_unique" ON "_TopicVersion_orgUnits"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicVersion_orgUnits_B_index" ON "_TopicVersion_orgUnits"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_OrgUnitDraft_topics_AB_unique" ON "_OrgUnitDraft_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_OrgUnitDraft_topics_B_index" ON "_OrgUnitDraft_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_OrgUnitVersion_topics_AB_unique" ON "_OrgUnitVersion_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_OrgUnitVersion_topics_B_index" ON "_OrgUnitVersion_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Park_topics_AB_unique" ON "_Park_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Park_topics_B_index" ON "_Park_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicDraft_parks_AB_unique" ON "_TopicDraft_parks"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicDraft_parks_B_index" ON "_TopicDraft_parks"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicVersion_parks_AB_unique" ON "_TopicVersion_parks"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicVersion_parks_B_index" ON "_TopicVersion_parks"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_ParkDraft_topics_AB_unique" ON "_ParkDraft_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_ParkDraft_topics_B_index" ON "_ParkDraft_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_ParkVersion_topics_AB_unique" ON "_ParkVersion_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_ParkVersion_topics_B_index" ON "_ParkVersion_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PublicNotice_topics_AB_unique" ON "_PublicNotice_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PublicNotice_topics_B_index" ON "_PublicNotice_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicDraft_publicNotices_AB_unique" ON "_TopicDraft_publicNotices"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicDraft_publicNotices_B_index" ON "_TopicDraft_publicNotices"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicVersion_publicNotices_AB_unique" ON "_TopicVersion_publicNotices"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicVersion_publicNotices_B_index" ON "_TopicVersion_publicNotices"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PublicNoticeDraft_topics_AB_unique" ON "_PublicNoticeDraft_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PublicNoticeDraft_topics_B_index" ON "_PublicNoticeDraft_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PublicNoticeVersion_topics_AB_unique" ON "_PublicNoticeVersion_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PublicNoticeVersion_topics_B_index" ON "_PublicNoticeVersion_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Service_topics_AB_unique" ON "_Service_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Service_topics_B_index" ON "_Service_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicDraft_services_AB_unique" ON "_TopicDraft_services"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicDraft_services_B_index" ON "_TopicDraft_services"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicVersion_services_AB_unique" ON "_TopicVersion_services"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicVersion_services_B_index" ON "_TopicVersion_services"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_ServiceDraft_topics_AB_unique" ON "_ServiceDraft_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_ServiceDraft_topics_B_index" ON "_ServiceDraft_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_ServiceVersion_topics_AB_unique" ON "_ServiceVersion_topics"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_ServiceVersion_topics_B_index" ON "_ServiceVersion_topics"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Topic_tags_AB_unique" ON "_Topic_tags"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Topic_tags_B_index" ON "_Topic_tags"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicDraft_tags_AB_unique" ON "_TopicDraft_tags"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicDraft_tags_B_index" ON "_TopicDraft_tags"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_TopicVersion_tags_AB_unique" ON "_TopicVersion_tags"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_TopicVersion_tags_B_index" ON "_TopicVersion_tags"("B");
+
+-- AddForeignKey
+ALTER TABLE "Topic" ADD CONSTRAINT "Topic_owner_fkey" FOREIGN KEY ("owner") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Topic" ADD CONSTRAINT "Topic_currentVersion_fkey" FOREIGN KEY ("currentVersion") REFERENCES "TopicVersion"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TopicDraft" ADD CONSTRAINT "TopicDraft_original_fkey" FOREIGN KEY ("original") REFERENCES "Topic"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TopicDraft" ADD CONSTRAINT "TopicDraft_owner_fkey" FOREIGN KEY ("owner") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TopicVersion" ADD CONSTRAINT "TopicVersion_original_fkey" FOREIGN KEY ("original") REFERENCES "Topic"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TopicVersion" ADD CONSTRAINT "TopicVersion_owner_fkey" FOREIGN KEY ("owner") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_AssemblyDistrict_topics" ADD CONSTRAINT "_AssemblyDistrict_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "AssemblyDistrict"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_AssemblyDistrict_topics" ADD CONSTRAINT "_AssemblyDistrict_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_districts" ADD CONSTRAINT "_TopicDraft_districts_A_fkey" FOREIGN KEY ("A") REFERENCES "AssemblyDistrict"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_districts" ADD CONSTRAINT "_TopicDraft_districts_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_districts" ADD CONSTRAINT "_TopicVersion_districts_A_fkey" FOREIGN KEY ("A") REFERENCES "AssemblyDistrict"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_districts" ADD CONSTRAINT "_TopicVersion_districts_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_AssemblyDistrictDraft_topics" ADD CONSTRAINT "_AssemblyDistrictDraft_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "AssemblyDistrictDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_AssemblyDistrictDraft_topics" ADD CONSTRAINT "_AssemblyDistrictDraft_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_AssemblyDistrictVersion_topics" ADD CONSTRAINT "_AssemblyDistrictVersion_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "AssemblyDistrictVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_AssemblyDistrictVersion_topics" ADD CONSTRAINT "_AssemblyDistrictVersion_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Board_topics" ADD CONSTRAINT "_Board_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "Board"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Board_topics" ADD CONSTRAINT "_Board_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_boards" ADD CONSTRAINT "_TopicDraft_boards_A_fkey" FOREIGN KEY ("A") REFERENCES "Board"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_boards" ADD CONSTRAINT "_TopicDraft_boards_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_boards" ADD CONSTRAINT "_TopicVersion_boards_A_fkey" FOREIGN KEY ("A") REFERENCES "Board"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_boards" ADD CONSTRAINT "_TopicVersion_boards_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_BoardDraft_topics" ADD CONSTRAINT "_BoardDraft_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "BoardDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_BoardDraft_topics" ADD CONSTRAINT "_BoardDraft_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_BoardVersion_topics" ADD CONSTRAINT "_BoardVersion_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "BoardVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_BoardVersion_topics" ADD CONSTRAINT "_BoardVersion_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Community_topics" ADD CONSTRAINT "_Community_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "Community"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Community_topics" ADD CONSTRAINT "_Community_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_communities" ADD CONSTRAINT "_TopicDraft_communities_A_fkey" FOREIGN KEY ("A") REFERENCES "Community"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_communities" ADD CONSTRAINT "_TopicDraft_communities_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_communities" ADD CONSTRAINT "_TopicVersion_communities_A_fkey" FOREIGN KEY ("A") REFERENCES "Community"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_communities" ADD CONSTRAINT "_TopicVersion_communities_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_CommunityDraft_topics" ADD CONSTRAINT "_CommunityDraft_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "CommunityDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_CommunityDraft_topics" ADD CONSTRAINT "_CommunityDraft_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_CommunityVersion_topics" ADD CONSTRAINT "_CommunityVersion_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "CommunityVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_CommunityVersion_topics" ADD CONSTRAINT "_CommunityVersion_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Topic_contacts" ADD CONSTRAINT "_Topic_contacts_A_fkey" FOREIGN KEY ("A") REFERENCES "Contact"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Topic_contacts" ADD CONSTRAINT "_Topic_contacts_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_contacts" ADD CONSTRAINT "_TopicDraft_contacts_A_fkey" FOREIGN KEY ("A") REFERENCES "Contact"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_contacts" ADD CONSTRAINT "_TopicDraft_contacts_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_contacts" ADD CONSTRAINT "_TopicVersion_contacts_A_fkey" FOREIGN KEY ("A") REFERENCES "Contact"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_contacts" ADD CONSTRAINT "_TopicVersion_contacts_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Topic_documents" ADD CONSTRAINT "_Topic_documents_A_fkey" FOREIGN KEY ("A") REFERENCES "Document"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Topic_documents" ADD CONSTRAINT "_Topic_documents_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_documents" ADD CONSTRAINT "_TopicDraft_documents_A_fkey" FOREIGN KEY ("A") REFERENCES "Document"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_documents" ADD CONSTRAINT "_TopicDraft_documents_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_documents" ADD CONSTRAINT "_TopicVersion_documents_A_fkey" FOREIGN KEY ("A") REFERENCES "Document"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_documents" ADD CONSTRAINT "_TopicVersion_documents_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Facility_topics" ADD CONSTRAINT "_Facility_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "Facility"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Facility_topics" ADD CONSTRAINT "_Facility_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_facilities" ADD CONSTRAINT "_TopicDraft_facilities_A_fkey" FOREIGN KEY ("A") REFERENCES "Facility"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_facilities" ADD CONSTRAINT "_TopicDraft_facilities_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_facilities" ADD CONSTRAINT "_TopicVersion_facilities_A_fkey" FOREIGN KEY ("A") REFERENCES "Facility"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_facilities" ADD CONSTRAINT "_TopicVersion_facilities_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_FacilityDraft_topics" ADD CONSTRAINT "_FacilityDraft_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "FacilityDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_FacilityDraft_topics" ADD CONSTRAINT "_FacilityDraft_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_FacilityVersion_topics" ADD CONSTRAINT "_FacilityVersion_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "FacilityVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_FacilityVersion_topics" ADD CONSTRAINT "_FacilityVersion_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Topic_userGroups" ADD CONSTRAINT "_Topic_userGroups_A_fkey" FOREIGN KEY ("A") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Topic_userGroups" ADD CONSTRAINT "_Topic_userGroups_B_fkey" FOREIGN KEY ("B") REFERENCES "UserGroup"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Topic_trails" ADD CONSTRAINT "_Topic_trails_A_fkey" FOREIGN KEY ("A") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Topic_trails" ADD CONSTRAINT "_Topic_trails_B_fkey" FOREIGN KEY ("B") REFERENCES "Trail"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TrailDraft_topics" ADD CONSTRAINT "_TrailDraft_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TrailDraft_topics" ADD CONSTRAINT "_TrailDraft_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "TrailDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TrailVersion_topics" ADD CONSTRAINT "_TrailVersion_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TrailVersion_topics" ADD CONSTRAINT "_TrailVersion_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "TrailVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_userGroups" ADD CONSTRAINT "_TopicDraft_userGroups_A_fkey" FOREIGN KEY ("A") REFERENCES "TopicDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_userGroups" ADD CONSTRAINT "_TopicDraft_userGroups_B_fkey" FOREIGN KEY ("B") REFERENCES "UserGroup"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_trails" ADD CONSTRAINT "_TopicDraft_trails_A_fkey" FOREIGN KEY ("A") REFERENCES "TopicDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_trails" ADD CONSTRAINT "_TopicDraft_trails_B_fkey" FOREIGN KEY ("B") REFERENCES "Trail"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_userGroups" ADD CONSTRAINT "_TopicVersion_userGroups_A_fkey" FOREIGN KEY ("A") REFERENCES "TopicVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_userGroups" ADD CONSTRAINT "_TopicVersion_userGroups_B_fkey" FOREIGN KEY ("B") REFERENCES "UserGroup"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_trails" ADD CONSTRAINT "_TopicVersion_trails_A_fkey" FOREIGN KEY ("A") REFERENCES "TopicVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_trails" ADD CONSTRAINT "_TopicVersion_trails_B_fkey" FOREIGN KEY ("B") REFERENCES "Trail"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Topic_highlights" ADD CONSTRAINT "_Topic_highlights_A_fkey" FOREIGN KEY ("A") REFERENCES "Highlight"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Topic_highlights" ADD CONSTRAINT "_Topic_highlights_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_highlights" ADD CONSTRAINT "_TopicDraft_highlights_A_fkey" FOREIGN KEY ("A") REFERENCES "Highlight"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_highlights" ADD CONSTRAINT "_TopicDraft_highlights_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_highlights" ADD CONSTRAINT "_TopicVersion_highlights_A_fkey" FOREIGN KEY ("A") REFERENCES "Highlight"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_highlights" ADD CONSTRAINT "_TopicVersion_highlights_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Topic_actions" ADD CONSTRAINT "_Topic_actions_A_fkey" FOREIGN KEY ("A") REFERENCES "InternalLink"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Topic_actions" ADD CONSTRAINT "_Topic_actions_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_actions" ADD CONSTRAINT "_TopicDraft_actions_A_fkey" FOREIGN KEY ("A") REFERENCES "InternalLink"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_actions" ADD CONSTRAINT "_TopicDraft_actions_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_actions" ADD CONSTRAINT "_TopicVersion_actions_A_fkey" FOREIGN KEY ("A") REFERENCES "InternalLink"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_actions" ADD CONSTRAINT "_TopicVersion_actions_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_OrgUnit_topics" ADD CONSTRAINT "_OrgUnit_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "OrgUnit"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_OrgUnit_topics" ADD CONSTRAINT "_OrgUnit_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_orgUnits" ADD CONSTRAINT "_TopicDraft_orgUnits_A_fkey" FOREIGN KEY ("A") REFERENCES "OrgUnit"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_orgUnits" ADD CONSTRAINT "_TopicDraft_orgUnits_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_orgUnits" ADD CONSTRAINT "_TopicVersion_orgUnits_A_fkey" FOREIGN KEY ("A") REFERENCES "OrgUnit"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_orgUnits" ADD CONSTRAINT "_TopicVersion_orgUnits_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_OrgUnitDraft_topics" ADD CONSTRAINT "_OrgUnitDraft_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "OrgUnitDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_OrgUnitDraft_topics" ADD CONSTRAINT "_OrgUnitDraft_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_OrgUnitVersion_topics" ADD CONSTRAINT "_OrgUnitVersion_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "OrgUnitVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_OrgUnitVersion_topics" ADD CONSTRAINT "_OrgUnitVersion_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Park_topics" ADD CONSTRAINT "_Park_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "Park"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Park_topics" ADD CONSTRAINT "_Park_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_parks" ADD CONSTRAINT "_TopicDraft_parks_A_fkey" FOREIGN KEY ("A") REFERENCES "Park"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_parks" ADD CONSTRAINT "_TopicDraft_parks_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_parks" ADD CONSTRAINT "_TopicVersion_parks_A_fkey" FOREIGN KEY ("A") REFERENCES "Park"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_parks" ADD CONSTRAINT "_TopicVersion_parks_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ParkDraft_topics" ADD CONSTRAINT "_ParkDraft_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "ParkDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ParkDraft_topics" ADD CONSTRAINT "_ParkDraft_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ParkVersion_topics" ADD CONSTRAINT "_ParkVersion_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "ParkVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ParkVersion_topics" ADD CONSTRAINT "_ParkVersion_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_topics" ADD CONSTRAINT "_PublicNotice_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "PublicNotice"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNotice_topics" ADD CONSTRAINT "_PublicNotice_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_publicNotices" ADD CONSTRAINT "_TopicDraft_publicNotices_A_fkey" FOREIGN KEY ("A") REFERENCES "PublicNotice"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_publicNotices" ADD CONSTRAINT "_TopicDraft_publicNotices_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_publicNotices" ADD CONSTRAINT "_TopicVersion_publicNotices_A_fkey" FOREIGN KEY ("A") REFERENCES "PublicNotice"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_publicNotices" ADD CONSTRAINT "_TopicVersion_publicNotices_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNoticeDraft_topics" ADD CONSTRAINT "_PublicNoticeDraft_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "PublicNoticeDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNoticeDraft_topics" ADD CONSTRAINT "_PublicNoticeDraft_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNoticeVersion_topics" ADD CONSTRAINT "_PublicNoticeVersion_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "PublicNoticeVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicNoticeVersion_topics" ADD CONSTRAINT "_PublicNoticeVersion_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Service_topics" ADD CONSTRAINT "_Service_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "Service"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Service_topics" ADD CONSTRAINT "_Service_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_services" ADD CONSTRAINT "_TopicDraft_services_A_fkey" FOREIGN KEY ("A") REFERENCES "Service"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_services" ADD CONSTRAINT "_TopicDraft_services_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_services" ADD CONSTRAINT "_TopicVersion_services_A_fkey" FOREIGN KEY ("A") REFERENCES "Service"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_services" ADD CONSTRAINT "_TopicVersion_services_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ServiceDraft_topics" ADD CONSTRAINT "_ServiceDraft_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "ServiceDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ServiceDraft_topics" ADD CONSTRAINT "_ServiceDraft_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ServiceVersion_topics" ADD CONSTRAINT "_ServiceVersion_topics_A_fkey" FOREIGN KEY ("A") REFERENCES "ServiceVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ServiceVersion_topics" ADD CONSTRAINT "_ServiceVersion_topics_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Topic_tags" ADD CONSTRAINT "_Topic_tags_A_fkey" FOREIGN KEY ("A") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Topic_tags" ADD CONSTRAINT "_Topic_tags_B_fkey" FOREIGN KEY ("B") REFERENCES "Topic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_tags" ADD CONSTRAINT "_TopicDraft_tags_A_fkey" FOREIGN KEY ("A") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicDraft_tags" ADD CONSTRAINT "_TopicDraft_tags_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicDraft"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_tags" ADD CONSTRAINT "_TopicVersion_tags_A_fkey" FOREIGN KEY ("A") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TopicVersion_tags" ADD CONSTRAINT "_TopicVersion_tags_B_fkey" FOREIGN KEY ("B") REFERENCES "TopicVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/cms/schema.graphql
+++ b/apps/cms/schema.graphql
@@ -209,6 +209,8 @@ type AssemblyDistrict {
   termEnd: DateTime
   boards(where: BoardWhereInput! = {}, orderBy: [BoardOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: BoardWhereUniqueInput): [Board!]
   boardsCount(where: BoardWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   status: String
   drafts(where: AssemblyDistrictDraftWhereInput! = {}, orderBy: [AssemblyDistrictDraftOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AssemblyDistrictDraftWhereUniqueInput): [AssemblyDistrictDraft!]
   draftsCount(where: AssemblyDistrictDraftWhereInput! = {}): Int
@@ -255,6 +257,7 @@ input AssemblyDistrictWhereInput {
   termStart: DateTimeNullableFilter
   termEnd: DateTimeNullableFilter
   boards: BoardManyRelationFilter
+  topics: TopicManyRelationFilter
   status: StringFilter
   drafts: AssemblyDistrictDraftManyRelationFilter
   versions: AssemblyDistrictVersionManyRelationFilter
@@ -310,6 +313,12 @@ input BoardManyRelationFilter {
   every: BoardWhereInput
   some: BoardWhereInput
   none: BoardWhereInput
+}
+
+input TopicManyRelationFilter {
+  every: TopicWhereInput
+  some: TopicWhereInput
+  none: TopicWhereInput
 }
 
 input AssemblyDistrictDraftManyRelationFilter {
@@ -380,6 +389,7 @@ input AssemblyDistrictUpdateInput {
   termStart: DateTime
   termEnd: DateTime
   boards: BoardRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   status: String
   drafts: AssemblyDistrictDraftRelateToManyForUpdateInput
   makeDrafts: String
@@ -441,6 +451,13 @@ input BoardRelateToManyForUpdateInput {
   connect: [BoardWhereUniqueInput!]
 }
 
+input TopicRelateToManyForUpdateInput {
+  disconnect: [TopicWhereUniqueInput!]
+  set: [TopicWhereUniqueInput!]
+  create: [TopicCreateInput!]
+  connect: [TopicWhereUniqueInput!]
+}
+
 input AssemblyDistrictDraftRelateToManyForUpdateInput {
   disconnect: [AssemblyDistrictDraftWhereUniqueInput!]
   set: [AssemblyDistrictDraftWhereUniqueInput!]
@@ -493,6 +510,7 @@ input AssemblyDistrictCreateInput {
   termStart: DateTime
   termEnd: DateTime
   boards: BoardRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   status: String
   drafts: AssemblyDistrictDraftRelateToManyForCreateInput
   makeDrafts: String
@@ -538,6 +556,11 @@ input ImageRelateToOneForCreateInput {
 input BoardRelateToManyForCreateInput {
   create: [BoardCreateInput!]
   connect: [BoardWhereUniqueInput!]
+}
+
+input TopicRelateToManyForCreateInput {
+  create: [TopicCreateInput!]
+  connect: [TopicWhereUniqueInput!]
 }
 
 input AssemblyDistrictDraftRelateToManyForCreateInput {
@@ -590,6 +613,8 @@ type AssemblyDistrictDraft {
   termEnd: DateTime
   boards(where: BoardWhereInput! = {}, orderBy: [BoardOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: BoardWhereUniqueInput): [Board!]
   boardsCount(where: BoardWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   publish: String
 }
 
@@ -627,6 +652,7 @@ input AssemblyDistrictDraftWhereInput {
   termStart: DateTimeNullableFilter
   termEnd: DateTimeNullableFilter
   boards: BoardManyRelationFilter
+  topics: TopicManyRelationFilter
 }
 
 input AssemblyDistrictDraftOrderByInput {
@@ -678,6 +704,7 @@ input AssemblyDistrictDraftUpdateInput {
   termStart: DateTime
   termEnd: DateTime
   boards: BoardRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   publish: String
 }
 
@@ -719,6 +746,7 @@ input AssemblyDistrictDraftCreateInput {
   termStart: DateTime
   termEnd: DateTime
   boards: BoardRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   publish: String
 }
 
@@ -762,6 +790,8 @@ type AssemblyDistrictVersion {
   termEnd: DateTime
   boards(where: BoardWhereInput! = {}, orderBy: [BoardOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: BoardWhereUniqueInput): [Board!]
   boardsCount(where: BoardWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   isLive: AssemblyDistrict
   republish: String
 }
@@ -801,6 +831,7 @@ input AssemblyDistrictVersionWhereInput {
   termStart: DateTimeNullableFilter
   termEnd: DateTimeNullableFilter
   boards: BoardManyRelationFilter
+  topics: TopicManyRelationFilter
   isLive: AssemblyDistrictWhereInput
 }
 
@@ -853,6 +884,7 @@ input AssemblyDistrictVersionUpdateInput {
   termStart: DateTime
   termEnd: DateTime
   boards: BoardRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   isLive: AssemblyDistrictRelateToOneForUpdateInput
   republish: String
 }
@@ -889,6 +921,7 @@ input AssemblyDistrictVersionCreateInput {
   termStart: DateTime
   termEnd: DateTime
   boards: BoardRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   isLive: AssemblyDistrictRelateToOneForCreateInput
   republish: String
 }
@@ -927,6 +960,8 @@ type Board {
   districtsCount(where: AssemblyDistrictWhereInput! = {}): Int
   communities(where: CommunityWhereInput! = {}, orderBy: [CommunityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CommunityWhereUniqueInput): [Community!]
   communitiesCount(where: CommunityWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   status: String
   drafts(where: BoardDraftWhereInput! = {}, orderBy: [BoardDraftOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: BoardDraftWhereUniqueInput): [BoardDraft!]
   draftsCount(where: BoardDraftWhereInput! = {}): Int
@@ -971,6 +1006,7 @@ input BoardWhereInput {
   isActive: BooleanFilter
   districts: AssemblyDistrictManyRelationFilter
   communities: CommunityManyRelationFilter
+  topics: TopicManyRelationFilter
   status: StringFilter
   drafts: BoardDraftManyRelationFilter
   versions: BoardVersionManyRelationFilter
@@ -1050,6 +1086,7 @@ input BoardUpdateInput {
   isActive: Boolean
   districts: AssemblyDistrictRelateToManyForUpdateInput
   communities: CommunityRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   status: String
   drafts: BoardDraftRelateToManyForUpdateInput
   makeDrafts: String
@@ -1127,6 +1164,7 @@ input BoardCreateInput {
   isActive: Boolean
   districts: AssemblyDistrictRelateToManyForCreateInput
   communities: CommunityRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   status: String
   drafts: BoardDraftRelateToManyForCreateInput
   makeDrafts: String
@@ -1198,6 +1236,8 @@ type BoardDraft {
   districtsCount(where: AssemblyDistrictWhereInput! = {}): Int
   communities(where: CommunityWhereInput! = {}, orderBy: [CommunityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CommunityWhereUniqueInput): [Community!]
   communitiesCount(where: CommunityWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   publish: String
 }
 
@@ -1233,6 +1273,7 @@ input BoardDraftWhereInput {
   isActive: BooleanFilter
   districts: AssemblyDistrictManyRelationFilter
   communities: CommunityManyRelationFilter
+  topics: TopicManyRelationFilter
 }
 
 input BoardDraftOrderByInput {
@@ -1277,6 +1318,7 @@ input BoardDraftUpdateInput {
   isActive: Boolean
   districts: AssemblyDistrictRelateToManyForUpdateInput
   communities: CommunityRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   publish: String
 }
 
@@ -1316,6 +1358,7 @@ input BoardDraftCreateInput {
   isActive: Boolean
   districts: AssemblyDistrictRelateToManyForCreateInput
   communities: CommunityRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   publish: String
 }
 
@@ -1358,6 +1401,8 @@ type BoardVersion {
   districtsCount(where: AssemblyDistrictWhereInput! = {}): Int
   communities(where: CommunityWhereInput! = {}, orderBy: [CommunityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CommunityWhereUniqueInput): [Community!]
   communitiesCount(where: CommunityWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   isLive: Board
   republish: String
 }
@@ -1395,6 +1440,7 @@ input BoardVersionWhereInput {
   isActive: BooleanFilter
   districts: AssemblyDistrictManyRelationFilter
   communities: CommunityManyRelationFilter
+  topics: TopicManyRelationFilter
   isLive: BoardWhereInput
 }
 
@@ -1440,6 +1486,7 @@ input BoardVersionUpdateInput {
   isActive: Boolean
   districts: AssemblyDistrictRelateToManyForUpdateInput
   communities: CommunityRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   isLive: BoardRelateToOneForUpdateInput
   republish: String
 }
@@ -1474,6 +1521,7 @@ input BoardVersionCreateInput {
   isActive: Boolean
   districts: AssemblyDistrictRelateToManyForCreateInput
   communities: CommunityRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   isLive: BoardRelateToOneForCreateInput
   republish: String
 }
@@ -1606,6 +1654,8 @@ type Community {
   districtsCount(where: AssemblyDistrictWhereInput! = {}): Int
   boards(where: BoardWhereInput! = {}, orderBy: [BoardOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: BoardWhereUniqueInput): [Board!]
   boardsCount(where: BoardWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   status: String
   drafts(where: CommunityDraftWhereInput! = {}, orderBy: [CommunityDraftOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CommunityDraftWhereUniqueInput): [CommunityDraft!]
   draftsCount(where: CommunityDraftWhereInput! = {}): Int
@@ -1645,6 +1695,7 @@ input CommunityWhereInput {
   services: ServiceManyRelationFilter
   districts: AssemblyDistrictManyRelationFilter
   boards: BoardManyRelationFilter
+  topics: TopicManyRelationFilter
   status: StringFilter
   drafts: CommunityDraftManyRelationFilter
   versions: CommunityVersionManyRelationFilter
@@ -1705,6 +1756,7 @@ input CommunityUpdateInput {
   services: ServiceRelateToManyForUpdateInput
   districts: AssemblyDistrictRelateToManyForUpdateInput
   boards: BoardRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   status: String
   drafts: CommunityDraftRelateToManyForUpdateInput
   makeDrafts: String
@@ -1764,6 +1816,7 @@ input CommunityCreateInput {
   services: ServiceRelateToManyForCreateInput
   districts: AssemblyDistrictRelateToManyForCreateInput
   boards: BoardRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   status: String
   drafts: CommunityDraftRelateToManyForCreateInput
   makeDrafts: String
@@ -1821,6 +1874,8 @@ type CommunityDraft {
   districtsCount(where: AssemblyDistrictWhereInput! = {}): Int
   boards(where: BoardWhereInput! = {}, orderBy: [BoardOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: BoardWhereUniqueInput): [Board!]
   boardsCount(where: BoardWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   publish: String
 }
 
@@ -1851,6 +1906,7 @@ input CommunityDraftWhereInput {
   services: ServiceManyRelationFilter
   districts: AssemblyDistrictManyRelationFilter
   boards: BoardManyRelationFilter
+  topics: TopicManyRelationFilter
 }
 
 input CommunityDraftOrderByInput {
@@ -1887,6 +1943,7 @@ input CommunityDraftUpdateInput {
   services: ServiceRelateToManyForUpdateInput
   districts: AssemblyDistrictRelateToManyForUpdateInput
   boards: BoardRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   publish: String
 }
 
@@ -1921,6 +1978,7 @@ input CommunityDraftCreateInput {
   services: ServiceRelateToManyForCreateInput
   districts: AssemblyDistrictRelateToManyForCreateInput
   boards: BoardRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   publish: String
 }
 
@@ -1959,6 +2017,8 @@ type CommunityVersion {
   districtsCount(where: AssemblyDistrictWhereInput! = {}): Int
   boards(where: BoardWhereInput! = {}, orderBy: [BoardOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: BoardWhereUniqueInput): [Board!]
   boardsCount(where: BoardWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   isLive: Community
   republish: String
 }
@@ -1991,6 +2051,7 @@ input CommunityVersionWhereInput {
   services: ServiceManyRelationFilter
   districts: AssemblyDistrictManyRelationFilter
   boards: BoardManyRelationFilter
+  topics: TopicManyRelationFilter
   isLive: CommunityWhereInput
 }
 
@@ -2028,6 +2089,7 @@ input CommunityVersionUpdateInput {
   services: ServiceRelateToManyForUpdateInput
   districts: AssemblyDistrictRelateToManyForUpdateInput
   boards: BoardRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   isLive: CommunityRelateToOneForUpdateInput
   republish: String
 }
@@ -2057,6 +2119,7 @@ input CommunityVersionCreateInput {
   services: ServiceRelateToManyForCreateInput
   districts: AssemblyDistrictRelateToManyForCreateInput
   boards: BoardRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   isLive: CommunityRelateToOneForCreateInput
   republish: String
 }
@@ -2348,6 +2411,8 @@ type Facility {
   services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
   servicesCount(where: ServiceWhereInput! = {}): Int
   park: Park
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   status: String
   drafts(where: FacilityDraftWhereInput! = {}, orderBy: [FacilityDraftOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: FacilityDraftWhereUniqueInput): [FacilityDraft!]
   draftsCount(where: FacilityDraftWhereInput! = {}): Int
@@ -2388,6 +2453,7 @@ input FacilityWhereInput {
   updatedAt: DateTimeNullableFilter
   services: ServiceManyRelationFilter
   park: ParkWhereInput
+  topics: TopicManyRelationFilter
   status: StringFilter
   drafts: FacilityDraftManyRelationFilter
   versions: FacilityVersionManyRelationFilter
@@ -2449,6 +2515,7 @@ input FacilityUpdateInput {
   updatedAt: DateTime
   services: ServiceRelateToManyForUpdateInput
   park: ParkRelateToOneForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   status: String
   drafts: FacilityDraftRelateToManyForUpdateInput
   makeDrafts: String
@@ -2521,6 +2588,7 @@ input FacilityCreateInput {
   updatedAt: DateTime
   services: ServiceRelateToManyForCreateInput
   park: ParkRelateToOneForCreateInput
+  topics: TopicRelateToManyForCreateInput
   status: String
   drafts: FacilityDraftRelateToManyForCreateInput
   makeDrafts: String
@@ -2588,6 +2656,8 @@ type FacilityDraft {
   services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
   servicesCount(where: ServiceWhereInput! = {}): Int
   park: Park
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   publish: String
 }
 
@@ -2619,6 +2689,7 @@ input FacilityDraftWhereInput {
   updatedAt: DateTimeNullableFilter
   services: ServiceManyRelationFilter
   park: ParkWhereInput
+  topics: TopicManyRelationFilter
 }
 
 input FacilityDraftOrderByInput {
@@ -2656,6 +2727,7 @@ input FacilityDraftUpdateInput {
   updatedAt: DateTime
   services: ServiceRelateToManyForUpdateInput
   park: ParkRelateToOneForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   publish: String
 }
 
@@ -2691,6 +2763,7 @@ input FacilityDraftCreateInput {
   updatedAt: DateTime
   services: ServiceRelateToManyForCreateInput
   park: ParkRelateToOneForCreateInput
+  topics: TopicRelateToManyForCreateInput
   publish: String
 }
 
@@ -2729,6 +2802,8 @@ type FacilityVersion {
   services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
   servicesCount(where: ServiceWhereInput! = {}): Int
   park: Park
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   isLive: Facility
   republish: String
 }
@@ -2762,6 +2837,7 @@ input FacilityVersionWhereInput {
   updatedAt: DateTimeNullableFilter
   services: ServiceManyRelationFilter
   park: ParkWhereInput
+  topics: TopicManyRelationFilter
   isLive: FacilityWhereInput
 }
 
@@ -2800,6 +2876,7 @@ input FacilityVersionUpdateInput {
   updatedAt: DateTime
   services: ServiceRelateToManyForUpdateInput
   park: ParkRelateToOneForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   isLive: FacilityRelateToOneForUpdateInput
   republish: String
 }
@@ -2830,7 +2907,688 @@ input FacilityVersionCreateInput {
   updatedAt: DateTime
   services: ServiceRelateToManyForCreateInput
   park: ParkRelateToOneForCreateInput
+  topics: TopicRelateToManyForCreateInput
   isLive: FacilityRelateToOneForCreateInput
+  republish: String
+}
+
+type Topic {
+  id: ID!
+  heroImage: String
+  title: String
+  description: String
+  publishAt: DateTime
+  unpublishAt: DateTime
+  reviewDate: DateTime
+  liveUrl: String
+  slug: String
+  owner: User
+  body: String
+  tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
+  tagsCount(where: TagWhereInput! = {}): Int
+  userGroups(where: UserGroupWhereInput! = {}, orderBy: [UserGroupOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: UserGroupWhereUniqueInput): [UserGroup!]
+  userGroupsCount(where: UserGroupWhereInput! = {}): Int
+  actions(where: InternalLinkWhereInput! = {}, orderBy: [InternalLinkOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: InternalLinkWhereUniqueInput): [InternalLink!]
+  actionsCount(where: InternalLinkWhereInput! = {}): Int
+  documents(where: DocumentWhereInput! = {}, orderBy: [DocumentOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: DocumentWhereUniqueInput): [Document!]
+  documentsCount(where: DocumentWhereInput! = {}): Int
+  contacts(where: ContactWhereInput! = {}, orderBy: [ContactOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ContactWhereUniqueInput): [Contact!]
+  contactsCount(where: ContactWhereInput! = {}): Int
+  createdAt: DateTime
+  updatedAt: DateTime
+  highlights(where: HighlightWhereInput! = {}, orderBy: [HighlightOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: HighlightWhereUniqueInput): [Highlight!]
+  highlightsCount(where: HighlightWhereInput! = {}): Int
+  boards(where: BoardWhereInput! = {}, orderBy: [BoardOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: BoardWhereUniqueInput): [Board!]
+  boardsCount(where: BoardWhereInput! = {}): Int
+  services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
+  servicesCount(where: ServiceWhereInput! = {}): Int
+  communities(where: CommunityWhereInput! = {}, orderBy: [CommunityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CommunityWhereUniqueInput): [Community!]
+  communitiesCount(where: CommunityWhereInput! = {}): Int
+  districts(where: AssemblyDistrictWhereInput! = {}, orderBy: [AssemblyDistrictOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AssemblyDistrictWhereUniqueInput): [AssemblyDistrict!]
+  districtsCount(where: AssemblyDistrictWhereInput! = {}): Int
+  parks(where: ParkWhereInput! = {}, orderBy: [ParkOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ParkWhereUniqueInput): [Park!]
+  parksCount(where: ParkWhereInput! = {}): Int
+  trails(where: TrailWhereInput! = {}, orderBy: [TrailOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TrailWhereUniqueInput): [Trail!]
+  trailsCount(where: TrailWhereInput! = {}): Int
+  facilities(where: FacilityWhereInput! = {}, orderBy: [FacilityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: FacilityWhereUniqueInput): [Facility!]
+  facilitiesCount(where: FacilityWhereInput! = {}): Int
+  orgUnits(where: OrgUnitWhereInput! = {}, orderBy: [OrgUnitOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OrgUnitWhereUniqueInput): [OrgUnit!]
+  orgUnitsCount(where: OrgUnitWhereInput! = {}): Int
+  publicNotices(where: PublicNoticeWhereInput! = {}, orderBy: [PublicNoticeOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PublicNoticeWhereUniqueInput): [PublicNotice!]
+  publicNoticesCount(where: PublicNoticeWhereInput! = {}): Int
+  status: String
+  drafts(where: TopicDraftWhereInput! = {}, orderBy: [TopicDraftOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicDraftWhereUniqueInput): [TopicDraft!]
+  draftsCount(where: TopicDraftWhereInput! = {}): Int
+  makeDrafts: String
+  versions(where: TopicVersionWhereInput! = {}, orderBy: [TopicVersionOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicVersionWhereUniqueInput): [TopicVersion!]
+  versionsCount(where: TopicVersionWhereInput! = {}): Int
+  currentVersion: TopicVersion
+}
+
+input TopicWhereUniqueInput {
+  id: ID
+  title: String
+  slug: String
+  currentVersion: TopicVersionWhereUniqueInput
+}
+
+input TopicWhereInput {
+  AND: [TopicWhereInput!]
+  OR: [TopicWhereInput!]
+  NOT: [TopicWhereInput!]
+  id: IDFilter
+  title: StringFilter
+  description: StringFilter
+  publishAt: DateTimeNullableFilter
+  unpublishAt: DateTimeNullableFilter
+  reviewDate: DateTimeNullableFilter
+  slug: StringFilter
+  owner: UserWhereInput
+  body: MyStringFilter
+  tags: TagManyRelationFilter
+  userGroups: UserGroupManyRelationFilter
+  actions: InternalLinkManyRelationFilter
+  documents: DocumentManyRelationFilter
+  contacts: ContactManyRelationFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  highlights: HighlightManyRelationFilter
+  boards: BoardManyRelationFilter
+  services: ServiceManyRelationFilter
+  communities: CommunityManyRelationFilter
+  districts: AssemblyDistrictManyRelationFilter
+  parks: ParkManyRelationFilter
+  trails: TrailManyRelationFilter
+  facilities: FacilityManyRelationFilter
+  orgUnits: OrgUnitManyRelationFilter
+  publicNotices: PublicNoticeManyRelationFilter
+  status: StringFilter
+  drafts: TopicDraftManyRelationFilter
+  versions: TopicVersionManyRelationFilter
+  currentVersion: TopicVersionWhereInput
+}
+
+input HighlightManyRelationFilter {
+  every: HighlightWhereInput
+  some: HighlightWhereInput
+  none: HighlightWhereInput
+}
+
+input ParkManyRelationFilter {
+  every: ParkWhereInput
+  some: ParkWhereInput
+  none: ParkWhereInput
+}
+
+input TrailManyRelationFilter {
+  every: TrailWhereInput
+  some: TrailWhereInput
+  none: TrailWhereInput
+}
+
+input FacilityManyRelationFilter {
+  every: FacilityWhereInput
+  some: FacilityWhereInput
+  none: FacilityWhereInput
+}
+
+input OrgUnitManyRelationFilter {
+  every: OrgUnitWhereInput
+  some: OrgUnitWhereInput
+  none: OrgUnitWhereInput
+}
+
+input PublicNoticeManyRelationFilter {
+  every: PublicNoticeWhereInput
+  some: PublicNoticeWhereInput
+  none: PublicNoticeWhereInput
+}
+
+input TopicDraftManyRelationFilter {
+  every: TopicDraftWhereInput
+  some: TopicDraftWhereInput
+  none: TopicDraftWhereInput
+}
+
+input TopicVersionManyRelationFilter {
+  every: TopicVersionWhereInput
+  some: TopicVersionWhereInput
+  none: TopicVersionWhereInput
+}
+
+input TopicOrderByInput {
+  id: OrderDirection
+  heroImage: BlueHarvestImageOrderDirection
+  title: OrderDirection
+  description: OrderDirection
+  publishAt: OrderDirection
+  unpublishAt: OrderDirection
+  reviewDate: OrderDirection
+  slug: OrderDirection
+  body: MyOrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+  status: OrderDirection
+  makeDrafts: OrderDirection
+}
+
+input TopicUpdateInput {
+  heroImage: String
+  title: String
+  description: String
+  publishAt: DateTime
+  unpublishAt: DateTime
+  reviewDate: DateTime
+  slug: String
+  owner: UserRelateToOneForUpdateInput
+  body: String
+  tags: TagRelateToManyForUpdateInput
+  userGroups: UserGroupRelateToManyForUpdateInput
+  actions: InternalLinkRelateToManyForUpdateInput
+  documents: DocumentRelateToManyForUpdateInput
+  contacts: ContactRelateToManyForUpdateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+  highlights: HighlightRelateToManyForUpdateInput
+  boards: BoardRelateToManyForUpdateInput
+  services: ServiceRelateToManyForUpdateInput
+  communities: CommunityRelateToManyForUpdateInput
+  districts: AssemblyDistrictRelateToManyForUpdateInput
+  parks: ParkRelateToManyForUpdateInput
+  trails: TrailRelateToManyForUpdateInput
+  facilities: FacilityRelateToManyForUpdateInput
+  orgUnits: OrgUnitRelateToManyForUpdateInput
+  publicNotices: PublicNoticeRelateToManyForUpdateInput
+  status: String
+  drafts: TopicDraftRelateToManyForUpdateInput
+  makeDrafts: String
+  versions: TopicVersionRelateToManyForUpdateInput
+  currentVersion: TopicVersionRelateToOneForUpdateInput
+}
+
+input HighlightRelateToManyForUpdateInput {
+  disconnect: [HighlightWhereUniqueInput!]
+  set: [HighlightWhereUniqueInput!]
+  create: [HighlightCreateInput!]
+  connect: [HighlightWhereUniqueInput!]
+}
+
+input ParkRelateToManyForUpdateInput {
+  disconnect: [ParkWhereUniqueInput!]
+  set: [ParkWhereUniqueInput!]
+  create: [ParkCreateInput!]
+  connect: [ParkWhereUniqueInput!]
+}
+
+input TrailRelateToManyForUpdateInput {
+  disconnect: [TrailWhereUniqueInput!]
+  set: [TrailWhereUniqueInput!]
+  create: [TrailCreateInput!]
+  connect: [TrailWhereUniqueInput!]
+}
+
+input FacilityRelateToManyForUpdateInput {
+  disconnect: [FacilityWhereUniqueInput!]
+  set: [FacilityWhereUniqueInput!]
+  create: [FacilityCreateInput!]
+  connect: [FacilityWhereUniqueInput!]
+}
+
+input OrgUnitRelateToManyForUpdateInput {
+  disconnect: [OrgUnitWhereUniqueInput!]
+  set: [OrgUnitWhereUniqueInput!]
+  create: [OrgUnitCreateInput!]
+  connect: [OrgUnitWhereUniqueInput!]
+}
+
+input PublicNoticeRelateToManyForUpdateInput {
+  disconnect: [PublicNoticeWhereUniqueInput!]
+  set: [PublicNoticeWhereUniqueInput!]
+  create: [PublicNoticeCreateInput!]
+  connect: [PublicNoticeWhereUniqueInput!]
+}
+
+input TopicDraftRelateToManyForUpdateInput {
+  disconnect: [TopicDraftWhereUniqueInput!]
+  set: [TopicDraftWhereUniqueInput!]
+  create: [TopicDraftCreateInput!]
+  connect: [TopicDraftWhereUniqueInput!]
+}
+
+input TopicVersionRelateToManyForUpdateInput {
+  disconnect: [TopicVersionWhereUniqueInput!]
+  set: [TopicVersionWhereUniqueInput!]
+  create: [TopicVersionCreateInput!]
+  connect: [TopicVersionWhereUniqueInput!]
+}
+
+input TopicVersionRelateToOneForUpdateInput {
+  create: TopicVersionCreateInput
+  connect: TopicVersionWhereUniqueInput
+  disconnect: Boolean
+}
+
+input TopicUpdateArgs {
+  where: TopicWhereUniqueInput!
+  data: TopicUpdateInput!
+}
+
+input TopicCreateInput {
+  heroImage: String
+  title: String
+  description: String
+  publishAt: DateTime
+  unpublishAt: DateTime
+  reviewDate: DateTime
+  slug: String
+  owner: UserRelateToOneForCreateInput
+  body: String
+  tags: TagRelateToManyForCreateInput
+  userGroups: UserGroupRelateToManyForCreateInput
+  actions: InternalLinkRelateToManyForCreateInput
+  documents: DocumentRelateToManyForCreateInput
+  contacts: ContactRelateToManyForCreateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+  highlights: HighlightRelateToManyForCreateInput
+  boards: BoardRelateToManyForCreateInput
+  services: ServiceRelateToManyForCreateInput
+  communities: CommunityRelateToManyForCreateInput
+  districts: AssemblyDistrictRelateToManyForCreateInput
+  parks: ParkRelateToManyForCreateInput
+  trails: TrailRelateToManyForCreateInput
+  facilities: FacilityRelateToManyForCreateInput
+  orgUnits: OrgUnitRelateToManyForCreateInput
+  publicNotices: PublicNoticeRelateToManyForCreateInput
+  status: String
+  drafts: TopicDraftRelateToManyForCreateInput
+  makeDrafts: String
+  versions: TopicVersionRelateToManyForCreateInput
+  currentVersion: TopicVersionRelateToOneForCreateInput
+}
+
+input HighlightRelateToManyForCreateInput {
+  create: [HighlightCreateInput!]
+  connect: [HighlightWhereUniqueInput!]
+}
+
+input ParkRelateToManyForCreateInput {
+  create: [ParkCreateInput!]
+  connect: [ParkWhereUniqueInput!]
+}
+
+input TrailRelateToManyForCreateInput {
+  create: [TrailCreateInput!]
+  connect: [TrailWhereUniqueInput!]
+}
+
+input FacilityRelateToManyForCreateInput {
+  create: [FacilityCreateInput!]
+  connect: [FacilityWhereUniqueInput!]
+}
+
+input OrgUnitRelateToManyForCreateInput {
+  create: [OrgUnitCreateInput!]
+  connect: [OrgUnitWhereUniqueInput!]
+}
+
+input PublicNoticeRelateToManyForCreateInput {
+  create: [PublicNoticeCreateInput!]
+  connect: [PublicNoticeWhereUniqueInput!]
+}
+
+input TopicDraftRelateToManyForCreateInput {
+  create: [TopicDraftCreateInput!]
+  connect: [TopicDraftWhereUniqueInput!]
+}
+
+input TopicVersionRelateToManyForCreateInput {
+  create: [TopicVersionCreateInput!]
+  connect: [TopicVersionWhereUniqueInput!]
+}
+
+input TopicVersionRelateToOneForCreateInput {
+  create: TopicVersionCreateInput
+  connect: TopicVersionWhereUniqueInput
+}
+
+type TopicDraft {
+  id: ID!
+  original: Topic
+  heroImage: String
+  title: String
+  description: String
+  publishAt: DateTime
+  unpublishAt: DateTime
+  reviewDate: DateTime
+  liveUrl: String
+  owner: User
+  body: String
+  tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
+  tagsCount(where: TagWhereInput! = {}): Int
+  userGroups(where: UserGroupWhereInput! = {}, orderBy: [UserGroupOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: UserGroupWhereUniqueInput): [UserGroup!]
+  userGroupsCount(where: UserGroupWhereInput! = {}): Int
+  actions(where: InternalLinkWhereInput! = {}, orderBy: [InternalLinkOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: InternalLinkWhereUniqueInput): [InternalLink!]
+  actionsCount(where: InternalLinkWhereInput! = {}): Int
+  documents(where: DocumentWhereInput! = {}, orderBy: [DocumentOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: DocumentWhereUniqueInput): [Document!]
+  documentsCount(where: DocumentWhereInput! = {}): Int
+  contacts(where: ContactWhereInput! = {}, orderBy: [ContactOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ContactWhereUniqueInput): [Contact!]
+  contactsCount(where: ContactWhereInput! = {}): Int
+  createdAt: DateTime
+  updatedAt: DateTime
+  highlights(where: HighlightWhereInput! = {}, orderBy: [HighlightOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: HighlightWhereUniqueInput): [Highlight!]
+  highlightsCount(where: HighlightWhereInput! = {}): Int
+  boards(where: BoardWhereInput! = {}, orderBy: [BoardOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: BoardWhereUniqueInput): [Board!]
+  boardsCount(where: BoardWhereInput! = {}): Int
+  services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
+  servicesCount(where: ServiceWhereInput! = {}): Int
+  communities(where: CommunityWhereInput! = {}, orderBy: [CommunityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CommunityWhereUniqueInput): [Community!]
+  communitiesCount(where: CommunityWhereInput! = {}): Int
+  districts(where: AssemblyDistrictWhereInput! = {}, orderBy: [AssemblyDistrictOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AssemblyDistrictWhereUniqueInput): [AssemblyDistrict!]
+  districtsCount(where: AssemblyDistrictWhereInput! = {}): Int
+  parks(where: ParkWhereInput! = {}, orderBy: [ParkOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ParkWhereUniqueInput): [Park!]
+  parksCount(where: ParkWhereInput! = {}): Int
+  trails(where: TrailWhereInput! = {}, orderBy: [TrailOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TrailWhereUniqueInput): [Trail!]
+  trailsCount(where: TrailWhereInput! = {}): Int
+  facilities(where: FacilityWhereInput! = {}, orderBy: [FacilityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: FacilityWhereUniqueInput): [Facility!]
+  facilitiesCount(where: FacilityWhereInput! = {}): Int
+  orgUnits(where: OrgUnitWhereInput! = {}, orderBy: [OrgUnitOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OrgUnitWhereUniqueInput): [OrgUnit!]
+  orgUnitsCount(where: OrgUnitWhereInput! = {}): Int
+  publicNotices(where: PublicNoticeWhereInput! = {}, orderBy: [PublicNoticeOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PublicNoticeWhereUniqueInput): [PublicNotice!]
+  publicNoticesCount(where: PublicNoticeWhereInput! = {}): Int
+  publish: String
+}
+
+input TopicDraftWhereUniqueInput {
+  id: ID
+}
+
+input TopicDraftWhereInput {
+  AND: [TopicDraftWhereInput!]
+  OR: [TopicDraftWhereInput!]
+  NOT: [TopicDraftWhereInput!]
+  id: IDFilter
+  original: TopicWhereInput
+  title: StringFilter
+  description: StringFilter
+  publishAt: DateTimeNullableFilter
+  unpublishAt: DateTimeNullableFilter
+  reviewDate: DateTimeNullableFilter
+  owner: UserWhereInput
+  body: MyStringFilter
+  tags: TagManyRelationFilter
+  userGroups: UserGroupManyRelationFilter
+  actions: InternalLinkManyRelationFilter
+  documents: DocumentManyRelationFilter
+  contacts: ContactManyRelationFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  highlights: HighlightManyRelationFilter
+  boards: BoardManyRelationFilter
+  services: ServiceManyRelationFilter
+  communities: CommunityManyRelationFilter
+  districts: AssemblyDistrictManyRelationFilter
+  parks: ParkManyRelationFilter
+  trails: TrailManyRelationFilter
+  facilities: FacilityManyRelationFilter
+  orgUnits: OrgUnitManyRelationFilter
+  publicNotices: PublicNoticeManyRelationFilter
+}
+
+input TopicDraftOrderByInput {
+  id: OrderDirection
+  heroImage: BlueHarvestImageOrderDirection
+  title: OrderDirection
+  description: OrderDirection
+  publishAt: OrderDirection
+  unpublishAt: OrderDirection
+  reviewDate: OrderDirection
+  body: MyOrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+  publish: OrderDirection
+}
+
+input TopicDraftUpdateInput {
+  original: TopicRelateToOneForUpdateInput
+  heroImage: String
+  title: String
+  description: String
+  publishAt: DateTime
+  unpublishAt: DateTime
+  reviewDate: DateTime
+  owner: UserRelateToOneForUpdateInput
+  body: String
+  tags: TagRelateToManyForUpdateInput
+  userGroups: UserGroupRelateToManyForUpdateInput
+  actions: InternalLinkRelateToManyForUpdateInput
+  documents: DocumentRelateToManyForUpdateInput
+  contacts: ContactRelateToManyForUpdateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+  highlights: HighlightRelateToManyForUpdateInput
+  boards: BoardRelateToManyForUpdateInput
+  services: ServiceRelateToManyForUpdateInput
+  communities: CommunityRelateToManyForUpdateInput
+  districts: AssemblyDistrictRelateToManyForUpdateInput
+  parks: ParkRelateToManyForUpdateInput
+  trails: TrailRelateToManyForUpdateInput
+  facilities: FacilityRelateToManyForUpdateInput
+  orgUnits: OrgUnitRelateToManyForUpdateInput
+  publicNotices: PublicNoticeRelateToManyForUpdateInput
+  publish: String
+}
+
+input TopicRelateToOneForUpdateInput {
+  create: TopicCreateInput
+  connect: TopicWhereUniqueInput
+  disconnect: Boolean
+}
+
+input TopicDraftUpdateArgs {
+  where: TopicDraftWhereUniqueInput!
+  data: TopicDraftUpdateInput!
+}
+
+input TopicDraftCreateInput {
+  original: TopicRelateToOneForCreateInput
+  heroImage: String
+  title: String
+  description: String
+  publishAt: DateTime
+  unpublishAt: DateTime
+  reviewDate: DateTime
+  owner: UserRelateToOneForCreateInput
+  body: String
+  tags: TagRelateToManyForCreateInput
+  userGroups: UserGroupRelateToManyForCreateInput
+  actions: InternalLinkRelateToManyForCreateInput
+  documents: DocumentRelateToManyForCreateInput
+  contacts: ContactRelateToManyForCreateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+  highlights: HighlightRelateToManyForCreateInput
+  boards: BoardRelateToManyForCreateInput
+  services: ServiceRelateToManyForCreateInput
+  communities: CommunityRelateToManyForCreateInput
+  districts: AssemblyDistrictRelateToManyForCreateInput
+  parks: ParkRelateToManyForCreateInput
+  trails: TrailRelateToManyForCreateInput
+  facilities: FacilityRelateToManyForCreateInput
+  orgUnits: OrgUnitRelateToManyForCreateInput
+  publicNotices: PublicNoticeRelateToManyForCreateInput
+  publish: String
+}
+
+input TopicRelateToOneForCreateInput {
+  create: TopicCreateInput
+  connect: TopicWhereUniqueInput
+}
+
+type TopicVersion {
+  id: ID!
+  original: Topic
+  heroImage: String
+  title: String
+  description: String
+  publishAt: DateTime
+  unpublishAt: DateTime
+  reviewDate: DateTime
+  liveUrl: String
+  owner: User
+  body: String
+  tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
+  tagsCount(where: TagWhereInput! = {}): Int
+  userGroups(where: UserGroupWhereInput! = {}, orderBy: [UserGroupOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: UserGroupWhereUniqueInput): [UserGroup!]
+  userGroupsCount(where: UserGroupWhereInput! = {}): Int
+  actions(where: InternalLinkWhereInput! = {}, orderBy: [InternalLinkOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: InternalLinkWhereUniqueInput): [InternalLink!]
+  actionsCount(where: InternalLinkWhereInput! = {}): Int
+  documents(where: DocumentWhereInput! = {}, orderBy: [DocumentOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: DocumentWhereUniqueInput): [Document!]
+  documentsCount(where: DocumentWhereInput! = {}): Int
+  contacts(where: ContactWhereInput! = {}, orderBy: [ContactOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: ContactWhereUniqueInput): [Contact!]
+  contactsCount(where: ContactWhereInput! = {}): Int
+  createdAt: DateTime
+  updatedAt: DateTime
+  highlights(where: HighlightWhereInput! = {}, orderBy: [HighlightOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: HighlightWhereUniqueInput): [Highlight!]
+  highlightsCount(where: HighlightWhereInput! = {}): Int
+  boards(where: BoardWhereInput! = {}, orderBy: [BoardOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: BoardWhereUniqueInput): [Board!]
+  boardsCount(where: BoardWhereInput! = {}): Int
+  services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
+  servicesCount(where: ServiceWhereInput! = {}): Int
+  communities(where: CommunityWhereInput! = {}, orderBy: [CommunityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CommunityWhereUniqueInput): [Community!]
+  communitiesCount(where: CommunityWhereInput! = {}): Int
+  districts(where: AssemblyDistrictWhereInput! = {}, orderBy: [AssemblyDistrictOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AssemblyDistrictWhereUniqueInput): [AssemblyDistrict!]
+  districtsCount(where: AssemblyDistrictWhereInput! = {}): Int
+  parks(where: ParkWhereInput! = {}, orderBy: [ParkOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ParkWhereUniqueInput): [Park!]
+  parksCount(where: ParkWhereInput! = {}): Int
+  trails(where: TrailWhereInput! = {}, orderBy: [TrailOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TrailWhereUniqueInput): [Trail!]
+  trailsCount(where: TrailWhereInput! = {}): Int
+  facilities(where: FacilityWhereInput! = {}, orderBy: [FacilityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: FacilityWhereUniqueInput): [Facility!]
+  facilitiesCount(where: FacilityWhereInput! = {}): Int
+  orgUnits(where: OrgUnitWhereInput! = {}, orderBy: [OrgUnitOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OrgUnitWhereUniqueInput): [OrgUnit!]
+  orgUnitsCount(where: OrgUnitWhereInput! = {}): Int
+  publicNotices(where: PublicNoticeWhereInput! = {}, orderBy: [PublicNoticeOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PublicNoticeWhereUniqueInput): [PublicNotice!]
+  publicNoticesCount(where: PublicNoticeWhereInput! = {}): Int
+  isLive: Topic
+  republish: String
+}
+
+input TopicVersionWhereUniqueInput {
+  id: ID
+  isLive: TopicWhereUniqueInput
+}
+
+input TopicVersionWhereInput {
+  AND: [TopicVersionWhereInput!]
+  OR: [TopicVersionWhereInput!]
+  NOT: [TopicVersionWhereInput!]
+  id: IDFilter
+  original: TopicWhereInput
+  title: StringFilter
+  description: StringFilter
+  publishAt: DateTimeNullableFilter
+  unpublishAt: DateTimeNullableFilter
+  reviewDate: DateTimeNullableFilter
+  owner: UserWhereInput
+  body: MyStringFilter
+  tags: TagManyRelationFilter
+  userGroups: UserGroupManyRelationFilter
+  actions: InternalLinkManyRelationFilter
+  documents: DocumentManyRelationFilter
+  contacts: ContactManyRelationFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+  highlights: HighlightManyRelationFilter
+  boards: BoardManyRelationFilter
+  services: ServiceManyRelationFilter
+  communities: CommunityManyRelationFilter
+  districts: AssemblyDistrictManyRelationFilter
+  parks: ParkManyRelationFilter
+  trails: TrailManyRelationFilter
+  facilities: FacilityManyRelationFilter
+  orgUnits: OrgUnitManyRelationFilter
+  publicNotices: PublicNoticeManyRelationFilter
+  isLive: TopicWhereInput
+}
+
+input TopicVersionOrderByInput {
+  id: OrderDirection
+  heroImage: BlueHarvestImageOrderDirection
+  title: OrderDirection
+  description: OrderDirection
+  publishAt: OrderDirection
+  unpublishAt: OrderDirection
+  reviewDate: OrderDirection
+  body: MyOrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+  republish: OrderDirection
+}
+
+input TopicVersionUpdateInput {
+  original: TopicRelateToOneForUpdateInput
+  heroImage: String
+  title: String
+  description: String
+  publishAt: DateTime
+  unpublishAt: DateTime
+  reviewDate: DateTime
+  owner: UserRelateToOneForUpdateInput
+  body: String
+  tags: TagRelateToManyForUpdateInput
+  userGroups: UserGroupRelateToManyForUpdateInput
+  actions: InternalLinkRelateToManyForUpdateInput
+  documents: DocumentRelateToManyForUpdateInput
+  contacts: ContactRelateToManyForUpdateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+  highlights: HighlightRelateToManyForUpdateInput
+  boards: BoardRelateToManyForUpdateInput
+  services: ServiceRelateToManyForUpdateInput
+  communities: CommunityRelateToManyForUpdateInput
+  districts: AssemblyDistrictRelateToManyForUpdateInput
+  parks: ParkRelateToManyForUpdateInput
+  trails: TrailRelateToManyForUpdateInput
+  facilities: FacilityRelateToManyForUpdateInput
+  orgUnits: OrgUnitRelateToManyForUpdateInput
+  publicNotices: PublicNoticeRelateToManyForUpdateInput
+  isLive: TopicRelateToOneForUpdateInput
+  republish: String
+}
+
+input TopicVersionUpdateArgs {
+  where: TopicVersionWhereUniqueInput!
+  data: TopicVersionUpdateInput!
+}
+
+input TopicVersionCreateInput {
+  original: TopicRelateToOneForCreateInput
+  heroImage: String
+  title: String
+  description: String
+  publishAt: DateTime
+  unpublishAt: DateTime
+  reviewDate: DateTime
+  owner: UserRelateToOneForCreateInput
+  body: String
+  tags: TagRelateToManyForCreateInput
+  userGroups: UserGroupRelateToManyForCreateInput
+  actions: InternalLinkRelateToManyForCreateInput
+  documents: DocumentRelateToManyForCreateInput
+  contacts: ContactRelateToManyForCreateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+  highlights: HighlightRelateToManyForCreateInput
+  boards: BoardRelateToManyForCreateInput
+  services: ServiceRelateToManyForCreateInput
+  communities: CommunityRelateToManyForCreateInput
+  districts: AssemblyDistrictRelateToManyForCreateInput
+  parks: ParkRelateToManyForCreateInput
+  trails: TrailRelateToManyForCreateInput
+  facilities: FacilityRelateToManyForCreateInput
+  orgUnits: OrgUnitRelateToManyForCreateInput
+  publicNotices: PublicNoticeRelateToManyForCreateInput
+  isLive: TopicRelateToOneForCreateInput
   republish: String
 }
 
@@ -3209,6 +3967,8 @@ type OrgUnit {
   children(where: OrgUnitWhereInput! = {}, orderBy: [OrgUnitOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OrgUnitWhereUniqueInput): [OrgUnit!]
   childrenCount(where: OrgUnitWhereInput! = {}): Int
   parent: OrgUnit
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   status: String
   drafts(where: OrgUnitDraftWhereInput! = {}, orderBy: [OrgUnitDraftOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OrgUnitDraftWhereUniqueInput): [OrgUnitDraft!]
   draftsCount(where: OrgUnitDraftWhereInput! = {}): Int
@@ -3249,16 +4009,11 @@ input OrgUnitWhereInput {
   services: ServiceManyRelationFilter
   children: OrgUnitManyRelationFilter
   parent: OrgUnitWhereInput
+  topics: TopicManyRelationFilter
   status: StringFilter
   drafts: OrgUnitDraftManyRelationFilter
   versions: OrgUnitVersionManyRelationFilter
   currentVersion: OrgUnitVersionWhereInput
-}
-
-input OrgUnitManyRelationFilter {
-  every: OrgUnitWhereInput
-  some: OrgUnitWhereInput
-  none: OrgUnitWhereInput
 }
 
 input OrgUnitDraftManyRelationFilter {
@@ -3311,18 +4066,12 @@ input OrgUnitUpdateInput {
   services: ServiceRelateToManyForUpdateInput
   children: OrgUnitRelateToManyForUpdateInput
   parent: OrgUnitRelateToOneForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   status: String
   drafts: OrgUnitDraftRelateToManyForUpdateInput
   makeDrafts: String
   versions: OrgUnitVersionRelateToManyForUpdateInput
   currentVersion: OrgUnitVersionRelateToOneForUpdateInput
-}
-
-input OrgUnitRelateToManyForUpdateInput {
-  disconnect: [OrgUnitWhereUniqueInput!]
-  set: [OrgUnitWhereUniqueInput!]
-  create: [OrgUnitCreateInput!]
-  connect: [OrgUnitWhereUniqueInput!]
 }
 
 input OrgUnitRelateToOneForUpdateInput {
@@ -3377,16 +4126,12 @@ input OrgUnitCreateInput {
   services: ServiceRelateToManyForCreateInput
   children: OrgUnitRelateToManyForCreateInput
   parent: OrgUnitRelateToOneForCreateInput
+  topics: TopicRelateToManyForCreateInput
   status: String
   drafts: OrgUnitDraftRelateToManyForCreateInput
   makeDrafts: String
   versions: OrgUnitVersionRelateToManyForCreateInput
   currentVersion: OrgUnitVersionRelateToOneForCreateInput
-}
-
-input OrgUnitRelateToManyForCreateInput {
-  create: [OrgUnitCreateInput!]
-  connect: [OrgUnitWhereUniqueInput!]
 }
 
 input OrgUnitRelateToOneForCreateInput {
@@ -3439,6 +4184,8 @@ type OrgUnitDraft {
   children(where: OrgUnitWhereInput! = {}, orderBy: [OrgUnitOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OrgUnitWhereUniqueInput): [OrgUnit!]
   childrenCount(where: OrgUnitWhereInput! = {}): Int
   parent: OrgUnit
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   publish: String
 }
 
@@ -3470,6 +4217,7 @@ input OrgUnitDraftWhereInput {
   services: ServiceManyRelationFilter
   children: OrgUnitManyRelationFilter
   parent: OrgUnitWhereInput
+  topics: TopicManyRelationFilter
 }
 
 input OrgUnitDraftOrderByInput {
@@ -3508,6 +4256,7 @@ input OrgUnitDraftUpdateInput {
   services: ServiceRelateToManyForUpdateInput
   children: OrgUnitRelateToManyForUpdateInput
   parent: OrgUnitRelateToOneForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   publish: String
 }
 
@@ -3537,6 +4286,7 @@ input OrgUnitDraftCreateInput {
   services: ServiceRelateToManyForCreateInput
   children: OrgUnitRelateToManyForCreateInput
   parent: OrgUnitRelateToOneForCreateInput
+  topics: TopicRelateToManyForCreateInput
   publish: String
 }
 
@@ -3570,6 +4320,8 @@ type OrgUnitVersion {
   children(where: OrgUnitWhereInput! = {}, orderBy: [OrgUnitOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OrgUnitWhereUniqueInput): [OrgUnit!]
   childrenCount(where: OrgUnitWhereInput! = {}): Int
   parent: OrgUnit
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   isLive: OrgUnit
   republish: String
 }
@@ -3603,6 +4355,7 @@ input OrgUnitVersionWhereInput {
   services: ServiceManyRelationFilter
   children: OrgUnitManyRelationFilter
   parent: OrgUnitWhereInput
+  topics: TopicManyRelationFilter
   isLive: OrgUnitWhereInput
 }
 
@@ -3642,6 +4395,7 @@ input OrgUnitVersionUpdateInput {
   services: ServiceRelateToManyForUpdateInput
   children: OrgUnitRelateToManyForUpdateInput
   parent: OrgUnitRelateToOneForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   isLive: OrgUnitRelateToOneForUpdateInput
   republish: String
 }
@@ -3672,6 +4426,7 @@ input OrgUnitVersionCreateInput {
   services: ServiceRelateToManyForCreateInput
   children: OrgUnitRelateToManyForCreateInput
   parent: OrgUnitRelateToOneForCreateInput
+  topics: TopicRelateToManyForCreateInput
   isLive: OrgUnitRelateToOneForCreateInput
   republish: String
 }
@@ -3754,6 +4509,8 @@ type Park {
   trailsCount(where: TrailWhereInput! = {}): Int
   facilities(where: FacilityWhereInput! = {}, orderBy: [FacilityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: FacilityWhereUniqueInput): [Facility!]
   facilitiesCount(where: FacilityWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   status: String
   drafts(where: ParkDraftWhereInput! = {}, orderBy: [ParkDraftOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ParkDraftWhereUniqueInput): [ParkDraft!]
   draftsCount(where: ParkDraftWhereInput! = {}): Int
@@ -3795,22 +4552,11 @@ input ParkWhereInput {
   services: ServiceManyRelationFilter
   trails: TrailManyRelationFilter
   facilities: FacilityManyRelationFilter
+  topics: TopicManyRelationFilter
   status: StringFilter
   drafts: ParkDraftManyRelationFilter
   versions: ParkVersionManyRelationFilter
   currentVersion: ParkVersionWhereInput
-}
-
-input TrailManyRelationFilter {
-  every: TrailWhereInput
-  some: TrailWhereInput
-  none: TrailWhereInput
-}
-
-input FacilityManyRelationFilter {
-  every: FacilityWhereInput
-  some: FacilityWhereInput
-  none: FacilityWhereInput
 }
 
 input ParkDraftManyRelationFilter {
@@ -3863,25 +4609,12 @@ input ParkUpdateInput {
   services: ServiceRelateToManyForUpdateInput
   trails: TrailRelateToManyForUpdateInput
   facilities: FacilityRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   status: String
   drafts: ParkDraftRelateToManyForUpdateInput
   makeDrafts: String
   versions: ParkVersionRelateToManyForUpdateInput
   currentVersion: ParkVersionRelateToOneForUpdateInput
-}
-
-input TrailRelateToManyForUpdateInput {
-  disconnect: [TrailWhereUniqueInput!]
-  set: [TrailWhereUniqueInput!]
-  create: [TrailCreateInput!]
-  connect: [TrailWhereUniqueInput!]
-}
-
-input FacilityRelateToManyForUpdateInput {
-  disconnect: [FacilityWhereUniqueInput!]
-  set: [FacilityWhereUniqueInput!]
-  create: [FacilityCreateInput!]
-  connect: [FacilityWhereUniqueInput!]
 }
 
 input ParkDraftRelateToManyForUpdateInput {
@@ -3931,21 +4664,12 @@ input ParkCreateInput {
   services: ServiceRelateToManyForCreateInput
   trails: TrailRelateToManyForCreateInput
   facilities: FacilityRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   status: String
   drafts: ParkDraftRelateToManyForCreateInput
   makeDrafts: String
   versions: ParkVersionRelateToManyForCreateInput
   currentVersion: ParkVersionRelateToOneForCreateInput
-}
-
-input TrailRelateToManyForCreateInput {
-  create: [TrailCreateInput!]
-  connect: [TrailWhereUniqueInput!]
-}
-
-input FacilityRelateToManyForCreateInput {
-  create: [FacilityCreateInput!]
-  connect: [FacilityWhereUniqueInput!]
 }
 
 input ParkDraftRelateToManyForCreateInput {
@@ -3996,6 +4720,8 @@ type ParkDraft {
   trailsCount(where: TrailWhereInput! = {}): Int
   facilities(where: FacilityWhereInput! = {}, orderBy: [FacilityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: FacilityWhereUniqueInput): [Facility!]
   facilitiesCount(where: FacilityWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   publish: String
 }
 
@@ -4028,6 +4754,7 @@ input ParkDraftWhereInput {
   services: ServiceManyRelationFilter
   trails: TrailManyRelationFilter
   facilities: FacilityManyRelationFilter
+  topics: TopicManyRelationFilter
 }
 
 input ParkDraftOrderByInput {
@@ -4066,6 +4793,7 @@ input ParkDraftUpdateInput {
   services: ServiceRelateToManyForUpdateInput
   trails: TrailRelateToManyForUpdateInput
   facilities: FacilityRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   publish: String
 }
 
@@ -4096,6 +4824,7 @@ input ParkDraftCreateInput {
   services: ServiceRelateToManyForCreateInput
   trails: TrailRelateToManyForCreateInput
   facilities: FacilityRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   publish: String
 }
 
@@ -4132,6 +4861,8 @@ type ParkVersion {
   trailsCount(where: TrailWhereInput! = {}): Int
   facilities(where: FacilityWhereInput! = {}, orderBy: [FacilityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: FacilityWhereUniqueInput): [Facility!]
   facilitiesCount(where: FacilityWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   isLive: Park
   republish: String
 }
@@ -4166,6 +4897,7 @@ input ParkVersionWhereInput {
   services: ServiceManyRelationFilter
   trails: TrailManyRelationFilter
   facilities: FacilityManyRelationFilter
+  topics: TopicManyRelationFilter
   isLive: ParkWhereInput
 }
 
@@ -4205,6 +4937,7 @@ input ParkVersionUpdateInput {
   services: ServiceRelateToManyForUpdateInput
   trails: TrailRelateToManyForUpdateInput
   facilities: FacilityRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   isLive: ParkRelateToOneForUpdateInput
   republish: String
 }
@@ -4236,6 +4969,7 @@ input ParkVersionCreateInput {
   services: ServiceRelateToManyForCreateInput
   trails: TrailRelateToManyForCreateInput
   facilities: FacilityRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   isLive: ParkRelateToOneForCreateInput
   republish: String
 }
@@ -4281,6 +5015,8 @@ type PublicNotice {
   communitiesCount(where: CommunityWhereInput! = {}): Int
   assemblyDistricts(where: AssemblyDistrictWhereInput! = {}, orderBy: [AssemblyDistrictOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AssemblyDistrictWhereUniqueInput): [AssemblyDistrict!]
   assemblyDistrictsCount(where: AssemblyDistrictWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   status: String
   drafts(where: PublicNoticeDraftWhereInput! = {}, orderBy: [PublicNoticeDraftOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PublicNoticeDraftWhereUniqueInput): [PublicNoticeDraft!]
   draftsCount(where: PublicNoticeDraftWhereInput! = {}): Int
@@ -4327,16 +5063,11 @@ input PublicNoticeWhereInput {
   trails: TrailManyRelationFilter
   communities: CommunityManyRelationFilter
   assemblyDistricts: AssemblyDistrictManyRelationFilter
+  topics: TopicManyRelationFilter
   status: StringFilter
   drafts: PublicNoticeDraftManyRelationFilter
   versions: PublicNoticeVersionManyRelationFilter
   currentVersion: PublicNoticeVersionWhereInput
-}
-
-input ParkManyRelationFilter {
-  every: ParkWhereInput
-  some: ParkWhereInput
-  none: ParkWhereInput
 }
 
 input PublicNoticeDraftManyRelationFilter {
@@ -4397,18 +5128,12 @@ input PublicNoticeUpdateInput {
   trails: TrailRelateToManyForUpdateInput
   communities: CommunityRelateToManyForUpdateInput
   assemblyDistricts: AssemblyDistrictRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   status: String
   drafts: PublicNoticeDraftRelateToManyForUpdateInput
   makeDrafts: String
   versions: PublicNoticeVersionRelateToManyForUpdateInput
   currentVersion: PublicNoticeVersionRelateToOneForUpdateInput
-}
-
-input ParkRelateToManyForUpdateInput {
-  disconnect: [ParkWhereUniqueInput!]
-  set: [ParkWhereUniqueInput!]
-  create: [ParkCreateInput!]
-  connect: [ParkWhereUniqueInput!]
 }
 
 input PublicNoticeDraftRelateToManyForUpdateInput {
@@ -4463,16 +5188,12 @@ input PublicNoticeCreateInput {
   trails: TrailRelateToManyForCreateInput
   communities: CommunityRelateToManyForCreateInput
   assemblyDistricts: AssemblyDistrictRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   status: String
   drafts: PublicNoticeDraftRelateToManyForCreateInput
   makeDrafts: String
   versions: PublicNoticeVersionRelateToManyForCreateInput
   currentVersion: PublicNoticeVersionRelateToOneForCreateInput
-}
-
-input ParkRelateToManyForCreateInput {
-  create: [ParkCreateInput!]
-  connect: [ParkWhereUniqueInput!]
 }
 
 input PublicNoticeDraftRelateToManyForCreateInput {
@@ -4531,6 +5252,8 @@ type PublicNoticeDraft {
   communitiesCount(where: CommunityWhereInput! = {}): Int
   assemblyDistricts(where: AssemblyDistrictWhereInput! = {}, orderBy: [AssemblyDistrictOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AssemblyDistrictWhereUniqueInput): [AssemblyDistrict!]
   assemblyDistrictsCount(where: AssemblyDistrictWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   publish: String
 }
 
@@ -4568,6 +5291,7 @@ input PublicNoticeDraftWhereInput {
   trails: TrailManyRelationFilter
   communities: CommunityManyRelationFilter
   assemblyDistricts: AssemblyDistrictManyRelationFilter
+  topics: TopicManyRelationFilter
 }
 
 input PublicNoticeDraftOrderByInput {
@@ -4614,6 +5338,7 @@ input PublicNoticeDraftUpdateInput {
   trails: TrailRelateToManyForUpdateInput
   communities: CommunityRelateToManyForUpdateInput
   assemblyDistricts: AssemblyDistrictRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   publish: String
 }
 
@@ -4655,6 +5380,7 @@ input PublicNoticeDraftCreateInput {
   trails: TrailRelateToManyForCreateInput
   communities: CommunityRelateToManyForCreateInput
   assemblyDistricts: AssemblyDistrictRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   publish: String
 }
 
@@ -4704,6 +5430,8 @@ type PublicNoticeVersion {
   communitiesCount(where: CommunityWhereInput! = {}): Int
   assemblyDistricts(where: AssemblyDistrictWhereInput! = {}, orderBy: [AssemblyDistrictOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AssemblyDistrictWhereUniqueInput): [AssemblyDistrict!]
   assemblyDistrictsCount(where: AssemblyDistrictWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   isLive: PublicNotice
   republish: String
 }
@@ -4743,6 +5471,7 @@ input PublicNoticeVersionWhereInput {
   trails: TrailManyRelationFilter
   communities: CommunityManyRelationFilter
   assemblyDistricts: AssemblyDistrictManyRelationFilter
+  topics: TopicManyRelationFilter
   isLive: PublicNoticeWhereInput
 }
 
@@ -4790,6 +5519,7 @@ input PublicNoticeVersionUpdateInput {
   trails: TrailRelateToManyForUpdateInput
   communities: CommunityRelateToManyForUpdateInput
   assemblyDistricts: AssemblyDistrictRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   isLive: PublicNoticeRelateToOneForUpdateInput
   republish: String
 }
@@ -4826,6 +5556,7 @@ input PublicNoticeVersionCreateInput {
   trails: TrailRelateToManyForCreateInput
   communities: CommunityRelateToManyForCreateInput
   assemblyDistricts: AssemblyDistrictRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   isLive: PublicNoticeRelateToOneForCreateInput
   republish: String
 }
@@ -4866,6 +5597,8 @@ type Service {
   parksCount(where: ParkWhereInput! = {}): Int
   facilities(where: FacilityWhereInput! = {}, orderBy: [FacilityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: FacilityWhereUniqueInput): [Facility!]
   facilitiesCount(where: FacilityWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   editorNotes: String
   status: String
   drafts(where: ServiceDraftWhereInput! = {}, orderBy: [ServiceDraftOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ServiceDraftWhereUniqueInput): [ServiceDraft!]
@@ -4910,6 +5643,7 @@ input ServiceWhereInput {
   trails: TrailManyRelationFilter
   parks: ParkManyRelationFilter
   facilities: FacilityManyRelationFilter
+  topics: TopicManyRelationFilter
   editorNotes: StringFilter
   status: StringFilter
   drafts: ServiceDraftManyRelationFilter
@@ -4976,6 +5710,7 @@ input ServiceUpdateInput {
   trails: TrailRelateToManyForUpdateInput
   parks: ParkRelateToManyForUpdateInput
   facilities: FacilityRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   editorNotes: String
   status: String
   drafts: ServiceDraftRelateToManyForUpdateInput
@@ -5046,6 +5781,7 @@ input ServiceCreateInput {
   trails: TrailRelateToManyForCreateInput
   parks: ParkRelateToManyForCreateInput
   facilities: FacilityRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   editorNotes: String
   status: String
   drafts: ServiceDraftRelateToManyForCreateInput
@@ -5115,6 +5851,8 @@ type ServiceDraft {
   parksCount(where: ParkWhereInput! = {}): Int
   facilities(where: FacilityWhereInput! = {}, orderBy: [FacilityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: FacilityWhereUniqueInput): [Facility!]
   facilitiesCount(where: FacilityWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   editorNotes: String
   publish: String
 }
@@ -5150,6 +5888,7 @@ input ServiceDraftWhereInput {
   trails: TrailManyRelationFilter
   parks: ParkManyRelationFilter
   facilities: FacilityManyRelationFilter
+  topics: TopicManyRelationFilter
   editorNotes: StringFilter
 }
 
@@ -5192,6 +5931,7 @@ input ServiceDraftUpdateInput {
   trails: TrailRelateToManyForUpdateInput
   parks: ParkRelateToManyForUpdateInput
   facilities: FacilityRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   editorNotes: String
   publish: String
 }
@@ -5231,6 +5971,7 @@ input ServiceDraftCreateInput {
   trails: TrailRelateToManyForCreateInput
   parks: ParkRelateToManyForCreateInput
   facilities: FacilityRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   editorNotes: String
   publish: String
 }
@@ -5276,6 +6017,8 @@ type ServiceVersion {
   parksCount(where: ParkWhereInput! = {}): Int
   facilities(where: FacilityWhereInput! = {}, orderBy: [FacilityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: FacilityWhereUniqueInput): [Facility!]
   facilitiesCount(where: FacilityWhereInput! = {}): Int
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   editorNotes: String
   isLive: Service
   republish: String
@@ -5313,6 +6056,7 @@ input ServiceVersionWhereInput {
   trails: TrailManyRelationFilter
   parks: ParkManyRelationFilter
   facilities: FacilityManyRelationFilter
+  topics: TopicManyRelationFilter
   editorNotes: StringFilter
   isLive: ServiceWhereInput
 }
@@ -5356,6 +6100,7 @@ input ServiceVersionUpdateInput {
   trails: TrailRelateToManyForUpdateInput
   parks: ParkRelateToManyForUpdateInput
   facilities: FacilityRelateToManyForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   editorNotes: String
   isLive: ServiceRelateToOneForUpdateInput
   republish: String
@@ -5390,6 +6135,7 @@ input ServiceVersionCreateInput {
   trails: TrailRelateToManyForCreateInput
   parks: ParkRelateToManyForCreateInput
   facilities: FacilityRelateToManyForCreateInput
+  topics: TopicRelateToManyForCreateInput
   editorNotes: String
   isLive: ServiceRelateToOneForCreateInput
   republish: String
@@ -5478,6 +6224,8 @@ type Trail {
   services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
   servicesCount(where: ServiceWhereInput! = {}): Int
   park: Park
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   status: String
   drafts(where: TrailDraftWhereInput! = {}, orderBy: [TrailDraftOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TrailDraftWhereUniqueInput): [TrailDraft!]
   draftsCount(where: TrailDraftWhereInput! = {}): Int
@@ -5537,6 +6285,7 @@ input TrailWhereInput {
   elevationChange: StringFilter
   services: ServiceManyRelationFilter
   park: ParkWhereInput
+  topics: TopicManyRelationFilter
   status: StringFilter
   drafts: TrailDraftManyRelationFilter
   versions: TrailVersionManyRelationFilter
@@ -5631,6 +6380,7 @@ input TrailUpdateInput {
   elevationChange: String
   services: ServiceRelateToManyForUpdateInput
   park: ParkRelateToOneForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   status: String
   drafts: TrailDraftRelateToManyForUpdateInput
   makeDrafts: String
@@ -5703,6 +6453,7 @@ input TrailCreateInput {
   elevationChange: String
   services: ServiceRelateToManyForCreateInput
   park: ParkRelateToOneForCreateInput
+  topics: TopicRelateToManyForCreateInput
   status: String
   drafts: TrailDraftRelateToManyForCreateInput
   makeDrafts: String
@@ -5773,6 +6524,8 @@ type TrailDraft {
   services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
   servicesCount(where: ServiceWhereInput! = {}): Int
   park: Park
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   publish: String
 }
 
@@ -5823,6 +6576,7 @@ input TrailDraftWhereInput {
   elevationChange: StringFilter
   services: ServiceManyRelationFilter
   park: ParkWhereInput
+  topics: TopicManyRelationFilter
 }
 
 input TrailDraftOrderByInput {
@@ -5899,6 +6653,7 @@ input TrailDraftUpdateInput {
   elevationChange: String
   services: ServiceRelateToManyForUpdateInput
   park: ParkRelateToOneForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   publish: String
 }
 
@@ -5953,6 +6708,7 @@ input TrailDraftCreateInput {
   elevationChange: String
   services: ServiceRelateToManyForCreateInput
   park: ParkRelateToOneForCreateInput
+  topics: TopicRelateToManyForCreateInput
   publish: String
 }
 
@@ -6009,6 +6765,8 @@ type TrailVersion {
   services(where: ServiceWhereInput! = {}, orderBy: [ServiceOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ServiceWhereUniqueInput): [Service!]
   servicesCount(where: ServiceWhereInput! = {}): Int
   park: Park
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
   isLive: Trail
   republish: String
 }
@@ -6061,6 +6819,7 @@ input TrailVersionWhereInput {
   elevationChange: StringFilter
   services: ServiceManyRelationFilter
   park: ParkWhereInput
+  topics: TopicManyRelationFilter
   isLive: TrailWhereInput
 }
 
@@ -6138,6 +6897,7 @@ input TrailVersionUpdateInput {
   elevationChange: String
   services: ServiceRelateToManyForUpdateInput
   park: ParkRelateToOneForUpdateInput
+  topics: TopicRelateToManyForUpdateInput
   isLive: TrailRelateToOneForUpdateInput
   republish: String
 }
@@ -6187,6 +6947,7 @@ input TrailVersionCreateInput {
   elevationChange: String
   services: ServiceRelateToManyForCreateInput
   park: ParkRelateToOneForCreateInput
+  topics: TopicRelateToManyForCreateInput
   isLive: TrailRelateToOneForCreateInput
   republish: String
 }
@@ -6523,6 +7284,24 @@ type Mutation {
   updateFacilityVersions(data: [FacilityVersionUpdateArgs!]!): [FacilityVersion]
   deleteFacilityVersion(where: FacilityVersionWhereUniqueInput!): FacilityVersion
   deleteFacilityVersions(where: [FacilityVersionWhereUniqueInput!]!): [FacilityVersion]
+  createTopic(data: TopicCreateInput!): Topic
+  createTopics(data: [TopicCreateInput!]!): [Topic]
+  updateTopic(where: TopicWhereUniqueInput!, data: TopicUpdateInput!): Topic
+  updateTopics(data: [TopicUpdateArgs!]!): [Topic]
+  deleteTopic(where: TopicWhereUniqueInput!): Topic
+  deleteTopics(where: [TopicWhereUniqueInput!]!): [Topic]
+  createTopicDraft(data: TopicDraftCreateInput!): TopicDraft
+  createTopicDrafts(data: [TopicDraftCreateInput!]!): [TopicDraft]
+  updateTopicDraft(where: TopicDraftWhereUniqueInput!, data: TopicDraftUpdateInput!): TopicDraft
+  updateTopicDrafts(data: [TopicDraftUpdateArgs!]!): [TopicDraft]
+  deleteTopicDraft(where: TopicDraftWhereUniqueInput!): TopicDraft
+  deleteTopicDrafts(where: [TopicDraftWhereUniqueInput!]!): [TopicDraft]
+  createTopicVersion(data: TopicVersionCreateInput!): TopicVersion
+  createTopicVersions(data: [TopicVersionCreateInput!]!): [TopicVersion]
+  updateTopicVersion(where: TopicVersionWhereUniqueInput!, data: TopicVersionUpdateInput!): TopicVersion
+  updateTopicVersions(data: [TopicVersionUpdateArgs!]!): [TopicVersion]
+  deleteTopicVersion(where: TopicVersionWhereUniqueInput!): TopicVersion
+  deleteTopicVersions(where: [TopicVersionWhereUniqueInput!]!): [TopicVersion]
   createHighlight(data: HighlightCreateInput!): Highlight
   createHighlights(data: [HighlightCreateInput!]!): [Highlight]
   updateHighlight(where: HighlightWhereUniqueInput!, data: HighlightUpdateInput!): Highlight
@@ -6731,6 +7510,15 @@ type Query {
   facilityVersion(where: FacilityVersionWhereUniqueInput!): FacilityVersion
   facilityVersions(where: FacilityVersionWhereInput! = {}, orderBy: [FacilityVersionOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: FacilityVersionWhereUniqueInput): [FacilityVersion!]
   facilityVersionsCount(where: FacilityVersionWhereInput! = {}): Int
+  topic(where: TopicWhereUniqueInput!): Topic
+  topics(where: TopicWhereInput! = {}, orderBy: [TopicOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicWhereUniqueInput): [Topic!]
+  topicsCount(where: TopicWhereInput! = {}): Int
+  topicDraft(where: TopicDraftWhereUniqueInput!): TopicDraft
+  topicDrafts(where: TopicDraftWhereInput! = {}, orderBy: [TopicDraftOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicDraftWhereUniqueInput): [TopicDraft!]
+  topicDraftsCount(where: TopicDraftWhereInput! = {}): Int
+  topicVersion(where: TopicVersionWhereUniqueInput!): TopicVersion
+  topicVersions(where: TopicVersionWhereInput! = {}, orderBy: [TopicVersionOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TopicVersionWhereUniqueInput): [TopicVersion!]
+  topicVersionsCount(where: TopicVersionWhereInput! = {}): Int
   highlight(where: HighlightWhereUniqueInput!): Highlight
   highlights(where: HighlightWhereInput! = {}, orderBy: [HighlightOrderByInput!]! = [], take: Int! = 100, skip: Int! = 0, cursor: HighlightWhereUniqueInput): [Highlight!]
   highlightsCount(where: HighlightWhereInput! = {}): Int

--- a/apps/cms/schema.prisma
+++ b/apps/cms/schema.prisma
@@ -52,6 +52,7 @@ model AssemblyDistrict {
   termStart                                  DateTime?
   termEnd                                    DateTime?
   boards                                     Board[]                   @relation("AssemblyDistrict_boards")
+  topics                                     Topic[]                   @relation("AssemblyDistrict_topics")
   status                                     String                    @default("unpublished")
   drafts                                     AssemblyDistrictDraft[]   @relation("AssemblyDistrictDraft_original")
   makeDrafts                                 String?
@@ -63,6 +64,8 @@ model AssemblyDistrict {
   from_Community_districts                   Community[]               @relation("Community_districts")
   from_CommunityDraft_districts              CommunityDraft[]          @relation("CommunityDraft_districts")
   from_CommunityVersion_districts            CommunityVersion[]        @relation("CommunityVersion_districts")
+  from_TopicDraft_districts                  TopicDraft[]              @relation("TopicDraft_districts")
+  from_TopicVersion_districts                TopicVersion[]            @relation("TopicVersion_districts")
   from_PublicNotice_assemblyDistricts        PublicNotice[]            @relation("PublicNotice_assemblyDistricts")
   from_PublicNoticeDraft_assemblyDistricts   PublicNoticeDraft[]       @relation("PublicNoticeDraft_assemblyDistricts")
   from_PublicNoticeVersion_assemblyDistricts PublicNoticeVersion[]     @relation("PublicNoticeVersion_assemblyDistricts")
@@ -102,6 +105,7 @@ model AssemblyDistrictDraft {
   termStart   DateTime?
   termEnd     DateTime?
   boards      Board[]           @relation("AssemblyDistrictDraft_boards")
+  topics      Topic[]           @relation("AssemblyDistrictDraft_topics")
   publish     String?
 
   @@index([originalId])
@@ -140,6 +144,7 @@ model AssemblyDistrictVersion {
   termStart   DateTime?
   termEnd     DateTime?
   boards      Board[]           @relation("AssemblyDistrictVersion_boards")
+  topics      Topic[]           @relation("AssemblyDistrictVersion_topics")
   isLive      AssemblyDistrict? @relation("AssemblyDistrict_currentVersion")
   republish   String?
 
@@ -178,6 +183,7 @@ model Board {
   isActive                            Boolean                   @default(true)
   districts                           AssemblyDistrict[]        @relation("AssemblyDistrict_boards")
   communities                         Community[]               @relation("Board_communities")
+  topics                              Topic[]                   @relation("Board_topics")
   status                              String                    @default("unpublished")
   drafts                              BoardDraft[]              @relation("BoardDraft_original")
   makeDrafts                          String?
@@ -188,6 +194,8 @@ model Board {
   from_AssemblyDistrictVersion_boards AssemblyDistrictVersion[] @relation("AssemblyDistrictVersion_boards")
   from_CommunityDraft_boards          CommunityDraft[]          @relation("CommunityDraft_boards")
   from_CommunityVersion_boards        CommunityVersion[]        @relation("CommunityVersion_boards")
+  from_TopicDraft_boards              TopicDraft[]              @relation("TopicDraft_boards")
+  from_TopicVersion_boards            TopicVersion[]            @relation("TopicVersion_boards")
 
   @@index([ownerId])
   @@index([linkToAgendasId])
@@ -226,6 +234,7 @@ model BoardDraft {
   isActive                     Boolean            @default(true)
   districts                    AssemblyDistrict[] @relation("BoardDraft_districts")
   communities                  Community[]        @relation("BoardDraft_communities")
+  topics                       Topic[]            @relation("BoardDraft_topics")
   publish                      String?
 
   @@index([originalId])
@@ -266,6 +275,7 @@ model BoardVersion {
   isActive                     Boolean            @default(true)
   districts                    AssemblyDistrict[] @relation("BoardVersion_districts")
   communities                  Community[]        @relation("BoardVersion_communities")
+  topics                       Topic[]            @relation("BoardVersion_topics")
   isLive                       Board?             @relation("Board_currentVersion")
   republish                    String?
 
@@ -321,6 +331,7 @@ model Community {
   services                             Service[]             @relation("Community_services")
   districts                            AssemblyDistrict[]    @relation("Community_districts")
   boards                               Board[]               @relation("Board_communities")
+  topics                               Topic[]               @relation("Community_topics")
   status                               String                @default("unpublished")
   drafts                               CommunityDraft[]      @relation("CommunityDraft_original")
   makeDrafts                           String?
@@ -329,6 +340,8 @@ model Community {
   currentVersionId                     String?               @unique @map("currentVersion")
   from_BoardDraft_communities          BoardDraft[]          @relation("BoardDraft_communities")
   from_BoardVersion_communities        BoardVersion[]        @relation("BoardVersion_communities")
+  from_TopicDraft_communities          TopicDraft[]          @relation("TopicDraft_communities")
+  from_TopicVersion_communities        TopicVersion[]        @relation("TopicVersion_communities")
   from_PublicNotice_communities        PublicNotice[]        @relation("PublicNotice_communities")
   from_PublicNoticeDraft_communities   PublicNoticeDraft[]   @relation("PublicNoticeDraft_communities")
   from_PublicNoticeVersion_communities PublicNoticeVersion[] @relation("PublicNoticeVersion_communities")
@@ -361,6 +374,7 @@ model CommunityDraft {
   services    Service[]          @relation("CommunityDraft_services")
   districts   AssemblyDistrict[] @relation("CommunityDraft_districts")
   boards      Board[]            @relation("CommunityDraft_boards")
+  topics      Topic[]            @relation("CommunityDraft_topics")
   publish     String?
 
   @@index([originalId])
@@ -390,6 +404,7 @@ model CommunityVersion {
   services    Service[]          @relation("CommunityVersion_services")
   districts   AssemblyDistrict[] @relation("CommunityVersion_districts")
   boards      Board[]            @relation("CommunityVersion_boards")
+  topics      Topic[]            @relation("CommunityVersion_topics")
   isLive      Community?         @relation("Community_currentVersion")
   republish   String?
 
@@ -416,6 +431,9 @@ model Contact {
   from_Facility_contacts                Facility[]                @relation("Facility_contacts")
   from_FacilityDraft_contacts           FacilityDraft[]           @relation("FacilityDraft_contacts")
   from_FacilityVersion_contacts         FacilityVersion[]         @relation("FacilityVersion_contacts")
+  from_Topic_contacts                   Topic[]                   @relation("Topic_contacts")
+  from_TopicDraft_contacts              TopicDraft[]              @relation("TopicDraft_contacts")
+  from_TopicVersion_contacts            TopicVersion[]            @relation("TopicVersion_contacts")
   from_OrgUnit_contacts                 OrgUnit[]                 @relation("OrgUnit_contacts")
   from_OrgUnitDraft_contacts            OrgUnitDraft[]            @relation("OrgUnitDraft_contacts")
   from_OrgUnitVersion_contacts          OrgUnitVersion[]          @relation("OrgUnitVersion_contacts")
@@ -460,6 +478,9 @@ model Document {
   from_Facility_documents                Facility[]                @relation("Facility_documents")
   from_FacilityDraft_documents           FacilityDraft[]           @relation("FacilityDraft_documents")
   from_FacilityVersion_documents         FacilityVersion[]         @relation("FacilityVersion_documents")
+  from_Topic_documents                   Topic[]                   @relation("Topic_documents")
+  from_TopicDraft_documents              TopicDraft[]              @relation("TopicDraft_documents")
+  from_TopicVersion_documents            TopicVersion[]            @relation("TopicVersion_documents")
   from_OrgUnit_documents                 OrgUnit[]                 @relation("OrgUnit_documents")
   from_OrgUnitDraft_documents            OrgUnitDraft[]            @relation("OrgUnitDraft_documents")
   from_OrgUnitVersion_documents          OrgUnitVersion[]          @relation("OrgUnitVersion_documents")
@@ -542,12 +563,15 @@ model Facility {
   services                            Service[]             @relation("Facility_services")
   park                                Park?                 @relation("Facility_park", fields: [parkId], references: [id])
   parkId                              String?               @map("park")
+  topics                              Topic[]               @relation("Facility_topics")
   status                              String                @default("unpublished")
   drafts                              FacilityDraft[]       @relation("FacilityDraft_original")
   makeDrafts                          String?
   versions                            FacilityVersion[]     @relation("FacilityVersion_original")
   currentVersion                      FacilityVersion?      @relation("Facility_currentVersion", fields: [currentVersionId], references: [id])
   currentVersionId                    String?               @unique @map("currentVersion")
+  from_TopicDraft_facilities          TopicDraft[]          @relation("TopicDraft_facilities")
+  from_TopicVersion_facilities        TopicVersion[]        @relation("TopicVersion_facilities")
   from_ParkDraft_facilities           ParkDraft[]           @relation("ParkDraft_facilities")
   from_ParkVersion_facilities         ParkVersion[]         @relation("ParkVersion_facilities")
   from_PublicNotice_facilities        PublicNotice[]        @relation("PublicNotice_facilities")
@@ -587,6 +611,7 @@ model FacilityDraft {
   services    Service[]       @relation("FacilityDraft_services")
   park        Park?           @relation("FacilityDraft_park", fields: [parkId], references: [id])
   parkId      String?         @map("park")
+  topics      Topic[]         @relation("FacilityDraft_topics")
   publish     String?
 
   @@index([originalId])
@@ -621,6 +646,7 @@ model FacilityVersion {
   services    Service[]       @relation("FacilityVersion_services")
   park        Park?           @relation("FacilityVersion_park", fields: [parkId], references: [id])
   parkId      String?         @map("park")
+  topics      Topic[]         @relation("FacilityVersion_topics")
   isLive      Facility?       @relation("Facility_currentVersion")
   republish   String?
 
@@ -630,23 +656,156 @@ model FacilityVersion {
   @@index([parkId])
 }
 
+model Topic {
+  id                                  String                    @id @default(cuid())
+  heroImage                           String?
+  title                               String                    @unique @default("")
+  description                         String                    @default("")
+  publishAt                           DateTime?
+  unpublishAt                         DateTime?
+  reviewDate                          DateTime?
+  slug                                String                    @unique @default("")
+  owner                               User?                     @relation("Topic_owner", fields: [ownerId], references: [id])
+  ownerId                             String?                   @map("owner")
+  body                                String?
+  tags                                Tag[]                     @relation("Topic_tags")
+  userGroups                          UserGroup[]               @relation("Topic_userGroups")
+  actions                             InternalLink[]            @relation("Topic_actions")
+  documents                           Document[]                @relation("Topic_documents")
+  contacts                            Contact[]                 @relation("Topic_contacts")
+  createdAt                           DateTime?                 @default(now())
+  updatedAt                           DateTime?                 @default(now()) @updatedAt
+  highlights                          Highlight[]               @relation("Topic_highlights")
+  boards                              Board[]                   @relation("Board_topics")
+  services                            Service[]                 @relation("Service_topics")
+  communities                         Community[]               @relation("Community_topics")
+  districts                           AssemblyDistrict[]        @relation("AssemblyDistrict_topics")
+  parks                               Park[]                    @relation("Park_topics")
+  trails                              Trail[]                   @relation("Topic_trails")
+  facilities                          Facility[]                @relation("Facility_topics")
+  orgUnits                            OrgUnit[]                 @relation("OrgUnit_topics")
+  publicNotices                       PublicNotice[]            @relation("PublicNotice_topics")
+  status                              String                    @default("unpublished")
+  drafts                              TopicDraft[]              @relation("TopicDraft_original")
+  makeDrafts                          String?
+  versions                            TopicVersion[]            @relation("TopicVersion_original")
+  currentVersion                      TopicVersion?             @relation("Topic_currentVersion", fields: [currentVersionId], references: [id])
+  currentVersionId                    String?                   @unique @map("currentVersion")
+  from_AssemblyDistrictDraft_topics   AssemblyDistrictDraft[]   @relation("AssemblyDistrictDraft_topics")
+  from_AssemblyDistrictVersion_topics AssemblyDistrictVersion[] @relation("AssemblyDistrictVersion_topics")
+  from_BoardDraft_topics              BoardDraft[]              @relation("BoardDraft_topics")
+  from_BoardVersion_topics            BoardVersion[]            @relation("BoardVersion_topics")
+  from_CommunityDraft_topics          CommunityDraft[]          @relation("CommunityDraft_topics")
+  from_CommunityVersion_topics        CommunityVersion[]        @relation("CommunityVersion_topics")
+  from_FacilityDraft_topics           FacilityDraft[]           @relation("FacilityDraft_topics")
+  from_FacilityVersion_topics         FacilityVersion[]         @relation("FacilityVersion_topics")
+  from_OrgUnitDraft_topics            OrgUnitDraft[]            @relation("OrgUnitDraft_topics")
+  from_OrgUnitVersion_topics          OrgUnitVersion[]          @relation("OrgUnitVersion_topics")
+  from_ParkDraft_topics               ParkDraft[]               @relation("ParkDraft_topics")
+  from_ParkVersion_topics             ParkVersion[]             @relation("ParkVersion_topics")
+  from_PublicNoticeDraft_topics       PublicNoticeDraft[]       @relation("PublicNoticeDraft_topics")
+  from_PublicNoticeVersion_topics     PublicNoticeVersion[]     @relation("PublicNoticeVersion_topics")
+  from_ServiceDraft_topics            ServiceDraft[]            @relation("ServiceDraft_topics")
+  from_ServiceVersion_topics          ServiceVersion[]          @relation("ServiceVersion_topics")
+  from_TrailDraft_topics              TrailDraft[]              @relation("TrailDraft_topics")
+  from_TrailVersion_topics            TrailVersion[]            @relation("TrailVersion_topics")
+
+  @@index([ownerId])
+}
+
+model TopicDraft {
+  id            String             @id @default(cuid())
+  original      Topic?             @relation("TopicDraft_original", fields: [originalId], references: [id])
+  originalId    String?            @map("original")
+  heroImage     String?
+  title         String             @default("")
+  description   String             @default("")
+  publishAt     DateTime?
+  unpublishAt   DateTime?
+  reviewDate    DateTime?
+  owner         User?              @relation("TopicDraft_owner", fields: [ownerId], references: [id])
+  ownerId       String?            @map("owner")
+  body          String?
+  tags          Tag[]              @relation("TopicDraft_tags")
+  userGroups    UserGroup[]        @relation("TopicDraft_userGroups")
+  actions       InternalLink[]     @relation("TopicDraft_actions")
+  documents     Document[]         @relation("TopicDraft_documents")
+  contacts      Contact[]          @relation("TopicDraft_contacts")
+  createdAt     DateTime?          @default(now())
+  updatedAt     DateTime?          @default(now()) @updatedAt
+  highlights    Highlight[]        @relation("TopicDraft_highlights")
+  boards        Board[]            @relation("TopicDraft_boards")
+  services      Service[]          @relation("TopicDraft_services")
+  communities   Community[]        @relation("TopicDraft_communities")
+  districts     AssemblyDistrict[] @relation("TopicDraft_districts")
+  parks         Park[]             @relation("TopicDraft_parks")
+  trails        Trail[]            @relation("TopicDraft_trails")
+  facilities    Facility[]         @relation("TopicDraft_facilities")
+  orgUnits      OrgUnit[]          @relation("TopicDraft_orgUnits")
+  publicNotices PublicNotice[]     @relation("TopicDraft_publicNotices")
+  publish       String?
+
+  @@index([originalId])
+  @@index([ownerId])
+}
+
+model TopicVersion {
+  id            String             @id @default(cuid())
+  original      Topic?             @relation("TopicVersion_original", fields: [originalId], references: [id])
+  originalId    String?            @map("original")
+  heroImage     String?
+  title         String             @default("")
+  description   String             @default("")
+  publishAt     DateTime?
+  unpublishAt   DateTime?
+  reviewDate    DateTime?
+  owner         User?              @relation("TopicVersion_owner", fields: [ownerId], references: [id])
+  ownerId       String?            @map("owner")
+  body          String?
+  tags          Tag[]              @relation("TopicVersion_tags")
+  userGroups    UserGroup[]        @relation("TopicVersion_userGroups")
+  actions       InternalLink[]     @relation("TopicVersion_actions")
+  documents     Document[]         @relation("TopicVersion_documents")
+  contacts      Contact[]          @relation("TopicVersion_contacts")
+  createdAt     DateTime?          @default(now())
+  updatedAt     DateTime?          @default(now()) @updatedAt
+  highlights    Highlight[]        @relation("TopicVersion_highlights")
+  boards        Board[]            @relation("TopicVersion_boards")
+  services      Service[]          @relation("TopicVersion_services")
+  communities   Community[]        @relation("TopicVersion_communities")
+  districts     AssemblyDistrict[] @relation("TopicVersion_districts")
+  parks         Park[]             @relation("TopicVersion_parks")
+  trails        Trail[]            @relation("TopicVersion_trails")
+  facilities    Facility[]         @relation("TopicVersion_facilities")
+  orgUnits      OrgUnit[]          @relation("TopicVersion_orgUnits")
+  publicNotices PublicNotice[]     @relation("TopicVersion_publicNotices")
+  isLive        Topic?             @relation("Topic_currentVersion")
+  republish     String?
+
+  @@index([originalId])
+  @@index([ownerId])
+}
+
 model Highlight {
-  id                           String        @id @default(cuid())
-  title                        String        @unique @default("")
+  id                           String         @id @default(cuid())
+  title                        String         @unique @default("")
   image                        String?
-  message                      String        @default("")
-  linkedItem                   InternalLink? @relation("Highlight_linkedItem", fields: [linkedItemId], references: [id])
-  linkedItemId                 String?       @map("linkedItem")
-  editorNotes                  String        @default("")
-  createdAt                    DateTime?     @default(now())
-  updatedAt                    DateTime?     @default(now()) @updatedAt
-  from_HomePage_toolbeltOne    HomePage[]    @relation("HomePage_toolbeltOne")
-  from_HomePage_toolbeltTwo    HomePage[]    @relation("HomePage_toolbeltTwo")
-  from_HomePage_toolbeltThree  HomePage[]    @relation("HomePage_toolbeltThree")
-  from_HomePage_toolbeltFour   HomePage[]    @relation("HomePage_toolbeltFour")
-  from_HomePage_highlightOne   HomePage[]    @relation("HomePage_highlightOne")
-  from_HomePage_highlightTwo   HomePage[]    @relation("HomePage_highlightTwo")
-  from_HomePage_highlightThree HomePage[]    @relation("HomePage_highlightThree")
+  message                      String         @default("")
+  linkedItem                   InternalLink?  @relation("Highlight_linkedItem", fields: [linkedItemId], references: [id])
+  linkedItemId                 String?        @map("linkedItem")
+  editorNotes                  String         @default("")
+  createdAt                    DateTime?      @default(now())
+  updatedAt                    DateTime?      @default(now()) @updatedAt
+  from_Topic_highlights        Topic[]        @relation("Topic_highlights")
+  from_TopicDraft_highlights   TopicDraft[]   @relation("TopicDraft_highlights")
+  from_TopicVersion_highlights TopicVersion[] @relation("TopicVersion_highlights")
+  from_HomePage_toolbeltOne    HomePage[]     @relation("HomePage_toolbeltOne")
+  from_HomePage_toolbeltTwo    HomePage[]     @relation("HomePage_toolbeltTwo")
+  from_HomePage_toolbeltThree  HomePage[]     @relation("HomePage_toolbeltThree")
+  from_HomePage_toolbeltFour   HomePage[]     @relation("HomePage_toolbeltFour")
+  from_HomePage_highlightOne   HomePage[]     @relation("HomePage_highlightOne")
+  from_HomePage_highlightTwo   HomePage[]     @relation("HomePage_highlightTwo")
+  from_HomePage_highlightThree HomePage[]     @relation("HomePage_highlightThree")
 
   @@index([linkedItemId])
 }
@@ -714,6 +873,9 @@ model InternalLink {
   from_Facility_actions                Facility[]                @relation("Facility_actions")
   from_FacilityDraft_actions           FacilityDraft[]           @relation("FacilityDraft_actions")
   from_FacilityVersion_actions         FacilityVersion[]         @relation("FacilityVersion_actions")
+  from_Topic_actions                   Topic[]                   @relation("Topic_actions")
+  from_TopicDraft_actions              TopicDraft[]              @relation("TopicDraft_actions")
+  from_TopicVersion_actions            TopicVersion[]            @relation("TopicVersion_actions")
   from_Highlight_linkedItem            Highlight[]               @relation("Highlight_linkedItem")
   from_OrgUnit_actions                 OrgUnit[]                 @relation("OrgUnit_actions")
   from_OrgUnitDraft_actions            OrgUnitDraft[]            @relation("OrgUnitDraft_actions")
@@ -773,12 +935,15 @@ model OrgUnit {
   children                          OrgUnit[]             @relation("OrgUnit_parent")
   parent                            OrgUnit?              @relation("OrgUnit_parent", fields: [parentId], references: [id])
   parentId                          String?               @map("parent")
+  topics                            Topic[]               @relation("OrgUnit_topics")
   status                            String                @default("unpublished")
   drafts                            OrgUnitDraft[]        @relation("OrgUnitDraft_original")
   makeDrafts                        String?
   versions                          OrgUnitVersion[]      @relation("OrgUnitVersion_original")
   currentVersion                    OrgUnitVersion?       @relation("OrgUnit_currentVersion", fields: [currentVersionId], references: [id])
   currentVersionId                  String?               @unique @map("currentVersion")
+  from_TopicDraft_orgUnits          TopicDraft[]          @relation("TopicDraft_orgUnits")
+  from_TopicVersion_orgUnits        TopicVersion[]        @relation("TopicVersion_orgUnits")
   from_OrgUnitDraft_children        OrgUnitDraft[]        @relation("OrgUnitDraft_children")
   from_OrgUnitDraft_parent          OrgUnitDraft[]        @relation("OrgUnitDraft_parent")
   from_OrgUnitVersion_children      OrgUnitVersion[]      @relation("OrgUnitVersion_children")
@@ -818,6 +983,7 @@ model OrgUnitDraft {
   children    OrgUnit[]      @relation("OrgUnitDraft_children")
   parent      OrgUnit?       @relation("OrgUnitDraft_parent", fields: [parentId], references: [id])
   parentId    String?        @map("parent")
+  topics      Topic[]        @relation("OrgUnitDraft_topics")
   publish     String?
 
   @@index([originalId])
@@ -850,6 +1016,7 @@ model OrgUnitVersion {
   children    OrgUnit[]      @relation("OrgUnitVersion_children")
   parent      OrgUnit?       @relation("OrgUnitVersion_parent", fields: [parentId], references: [id])
   parentId    String?        @map("parent")
+  topics      Topic[]        @relation("OrgUnitVersion_topics")
   isLive      OrgUnit?       @relation("OrgUnit_currentVersion")
   republish   String?
 
@@ -896,6 +1063,7 @@ model Park {
   services                       Service[]             @relation("Park_services")
   trails                         Trail[]               @relation("Trail_park")
   facilities                     Facility[]            @relation("Facility_park")
+  topics                         Topic[]               @relation("Park_topics")
   status                         String                @default("unpublished")
   drafts                         ParkDraft[]           @relation("ParkDraft_original")
   makeDrafts                     String?
@@ -904,6 +1072,8 @@ model Park {
   currentVersionId               String?               @unique @map("currentVersion")
   from_FacilityDraft_park        FacilityDraft[]       @relation("FacilityDraft_park")
   from_FacilityVersion_park      FacilityVersion[]     @relation("FacilityVersion_park")
+  from_TopicDraft_parks          TopicDraft[]          @relation("TopicDraft_parks")
+  from_TopicVersion_parks        TopicVersion[]        @relation("TopicVersion_parks")
   from_PublicNotice_parks        PublicNotice[]        @relation("PublicNotice_parks")
   from_PublicNoticeDraft_parks   PublicNoticeDraft[]   @relation("PublicNoticeDraft_parks")
   from_PublicNoticeVersion_parks PublicNoticeVersion[] @relation("PublicNoticeVersion_parks")
@@ -942,6 +1112,7 @@ model ParkDraft {
   services    Service[]       @relation("ParkDraft_services")
   trails      Trail[]         @relation("ParkDraft_trails")
   facilities  Facility[]      @relation("ParkDraft_facilities")
+  topics      Topic[]         @relation("ParkDraft_topics")
   publish     String?
 
   @@index([originalId])
@@ -975,6 +1146,7 @@ model ParkVersion {
   services    Service[]       @relation("ParkVersion_services")
   trails      Trail[]         @relation("ParkVersion_trails")
   facilities  Facility[]      @relation("ParkVersion_facilities")
+  topics      Topic[]         @relation("ParkVersion_topics")
   isLive      Park?           @relation("Park_currentVersion")
   republish   String?
 
@@ -984,40 +1156,43 @@ model ParkVersion {
 }
 
 model PublicNotice {
-  id                String                @id @default(cuid())
-  heroImage         String?
-  title             String                @unique @default("")
-  description       String                @default("")
-  publishAt         DateTime?
-  unpublishAt       DateTime?
-  reviewDate        DateTime?
-  slug              String                @unique @default("")
-  owner             User?                 @relation("PublicNotice_owner", fields: [ownerId], references: [id])
-  ownerId           String?               @map("owner")
-  body              String?
-  tags              Tag[]                 @relation("PublicNotice_tags")
-  userGroups        UserGroup[]           @relation("PublicNotice_userGroups")
-  actions           InternalLink[]        @relation("PublicNotice_actions")
-  documents         Document[]            @relation("PublicNotice_documents")
-  contacts          Contact[]             @relation("PublicNotice_contacts")
-  createdAt         DateTime?             @default(now())
-  updatedAt         DateTime?             @default(now()) @updatedAt
-  urgency           Int                   @default(2)
-  effectiveDate     DateTime?
-  endDate           DateTime?
-  parks             Park[]                @relation("PublicNotice_parks")
-  services          Service[]             @relation("PublicNotice_services")
-  orgUnits          OrgUnit[]             @relation("PublicNotice_orgUnits")
-  facilities        Facility[]            @relation("PublicNotice_facilities")
-  trails            Trail[]               @relation("PublicNotice_trails")
-  communities       Community[]           @relation("PublicNotice_communities")
-  assemblyDistricts AssemblyDistrict[]    @relation("PublicNotice_assemblyDistricts")
-  status            String                @default("unpublished")
-  drafts            PublicNoticeDraft[]   @relation("PublicNoticeDraft_original")
-  makeDrafts        String?
-  versions          PublicNoticeVersion[] @relation("PublicNoticeVersion_original")
-  currentVersion    PublicNoticeVersion?  @relation("PublicNotice_currentVersion", fields: [currentVersionId], references: [id])
-  currentVersionId  String?               @unique @map("currentVersion")
+  id                              String                @id @default(cuid())
+  heroImage                       String?
+  title                           String                @unique @default("")
+  description                     String                @default("")
+  publishAt                       DateTime?
+  unpublishAt                     DateTime?
+  reviewDate                      DateTime?
+  slug                            String                @unique @default("")
+  owner                           User?                 @relation("PublicNotice_owner", fields: [ownerId], references: [id])
+  ownerId                         String?               @map("owner")
+  body                            String?
+  tags                            Tag[]                 @relation("PublicNotice_tags")
+  userGroups                      UserGroup[]           @relation("PublicNotice_userGroups")
+  actions                         InternalLink[]        @relation("PublicNotice_actions")
+  documents                       Document[]            @relation("PublicNotice_documents")
+  contacts                        Contact[]             @relation("PublicNotice_contacts")
+  createdAt                       DateTime?             @default(now())
+  updatedAt                       DateTime?             @default(now()) @updatedAt
+  urgency                         Int                   @default(2)
+  effectiveDate                   DateTime?
+  endDate                         DateTime?
+  parks                           Park[]                @relation("PublicNotice_parks")
+  services                        Service[]             @relation("PublicNotice_services")
+  orgUnits                        OrgUnit[]             @relation("PublicNotice_orgUnits")
+  facilities                      Facility[]            @relation("PublicNotice_facilities")
+  trails                          Trail[]               @relation("PublicNotice_trails")
+  communities                     Community[]           @relation("PublicNotice_communities")
+  assemblyDistricts               AssemblyDistrict[]    @relation("PublicNotice_assemblyDistricts")
+  topics                          Topic[]               @relation("PublicNotice_topics")
+  status                          String                @default("unpublished")
+  drafts                          PublicNoticeDraft[]   @relation("PublicNoticeDraft_original")
+  makeDrafts                      String?
+  versions                        PublicNoticeVersion[] @relation("PublicNoticeVersion_original")
+  currentVersion                  PublicNoticeVersion?  @relation("PublicNotice_currentVersion", fields: [currentVersionId], references: [id])
+  currentVersionId                String?               @unique @map("currentVersion")
+  from_TopicDraft_publicNotices   TopicDraft[]          @relation("TopicDraft_publicNotices")
+  from_TopicVersion_publicNotices TopicVersion[]        @relation("TopicVersion_publicNotices")
 
   @@index([ownerId])
 }
@@ -1052,6 +1227,7 @@ model PublicNoticeDraft {
   trails            Trail[]            @relation("PublicNoticeDraft_trails")
   communities       Community[]        @relation("PublicNoticeDraft_communities")
   assemblyDistricts AssemblyDistrict[] @relation("PublicNoticeDraft_assemblyDistricts")
+  topics            Topic[]            @relation("PublicNoticeDraft_topics")
   publish           String?
 
   @@index([originalId])
@@ -1088,6 +1264,7 @@ model PublicNoticeVersion {
   trails            Trail[]            @relation("PublicNoticeVersion_trails")
   communities       Community[]        @relation("PublicNoticeVersion_communities")
   assemblyDistricts AssemblyDistrict[] @relation("PublicNoticeVersion_assemblyDistricts")
+  topics            Topic[]            @relation("PublicNoticeVersion_topics")
   isLive            PublicNotice?      @relation("PublicNotice_currentVersion")
   republish         String?
 
@@ -1123,6 +1300,7 @@ model Service {
   trails                            Trail[]               @relation("Service_trails")
   parks                             Park[]                @relation("Park_services")
   facilities                        Facility[]            @relation("Facility_services")
+  topics                            Topic[]               @relation("Service_topics")
   editorNotes                       String                @default("")
   status                            String                @default("unpublished")
   drafts                            ServiceDraft[]        @relation("ServiceDraft_original")
@@ -1134,6 +1312,8 @@ model Service {
   from_CommunityVersion_services    CommunityVersion[]    @relation("CommunityVersion_services")
   from_FacilityDraft_services       FacilityDraft[]       @relation("FacilityDraft_services")
   from_FacilityVersion_services     FacilityVersion[]     @relation("FacilityVersion_services")
+  from_TopicDraft_services          TopicDraft[]          @relation("TopicDraft_services")
+  from_TopicVersion_services        TopicVersion[]        @relation("TopicVersion_services")
   from_OrgUnitDraft_services        OrgUnitDraft[]        @relation("OrgUnitDraft_services")
   from_OrgUnitVersion_services      OrgUnitVersion[]      @relation("OrgUnitVersion_services")
   from_ParkDraft_services           ParkDraft[]           @relation("ParkDraft_services")
@@ -1178,6 +1358,7 @@ model ServiceDraft {
   trails           Trail[]        @relation("ServiceDraft_trails")
   parks            Park[]         @relation("ServiceDraft_parks")
   facilities       Facility[]     @relation("ServiceDraft_facilities")
+  topics           Topic[]        @relation("ServiceDraft_topics")
   editorNotes      String         @default("")
   publish          String?
 
@@ -1216,6 +1397,7 @@ model ServiceVersion {
   trails           Trail[]        @relation("ServiceVersion_trails")
   parks            Park[]         @relation("ServiceVersion_parks")
   facilities       Facility[]     @relation("ServiceVersion_facilities")
+  topics           Topic[]        @relation("ServiceVersion_topics")
   editorNotes      String         @default("")
   isLive           Service?       @relation("Service_currentVersion")
   republish        String?
@@ -1243,6 +1425,9 @@ model Tag {
   from_Facility_tags                Facility[]                @relation("Facility_tags")
   from_FacilityDraft_tags           FacilityDraft[]           @relation("FacilityDraft_tags")
   from_FacilityVersion_tags         FacilityVersion[]         @relation("FacilityVersion_tags")
+  from_Topic_tags                   Topic[]                   @relation("Topic_tags")
+  from_TopicDraft_tags              TopicDraft[]              @relation("TopicDraft_tags")
+  from_TopicVersion_tags            TopicVersion[]            @relation("TopicVersion_tags")
   from_Image_tags                   Image[]                   @relation("Image_tags")
   from_OrgUnit_tags                 OrgUnit[]                 @relation("OrgUnit_tags")
   from_OrgUnitDraft_tags            OrgUnitDraft[]            @relation("OrgUnitDraft_tags")
@@ -1305,12 +1490,15 @@ model Trail {
   services                        Service[]             @relation("Service_trails")
   park                            Park?                 @relation("Trail_park", fields: [parkId], references: [id])
   parkId                          String?               @map("park")
+  topics                          Topic[]               @relation("Topic_trails")
   status                          String                @default("unpublished")
   drafts                          TrailDraft[]          @relation("TrailDraft_original")
   makeDrafts                      String?
   versions                        TrailVersion[]        @relation("TrailVersion_original")
   currentVersion                  TrailVersion?         @relation("Trail_currentVersion", fields: [currentVersionId], references: [id])
   currentVersionId                String?               @unique @map("currentVersion")
+  from_TopicDraft_trails          TopicDraft[]          @relation("TopicDraft_trails")
+  from_TopicVersion_trails        TopicVersion[]        @relation("TopicVersion_trails")
   from_ParkDraft_trails           ParkDraft[]           @relation("ParkDraft_trails")
   from_ParkVersion_trails         ParkVersion[]         @relation("ParkVersion_trails")
   from_PublicNotice_trails        PublicNotice[]        @relation("PublicNotice_trails")
@@ -1369,6 +1557,7 @@ model TrailDraft {
   services           Service[]      @relation("TrailDraft_services")
   park               Park?          @relation("TrailDraft_park", fields: [parkId], references: [id])
   parkId             String?        @map("park")
+  topics             Topic[]        @relation("TrailDraft_topics")
   publish            String?
 
   @@index([originalId])
@@ -1422,6 +1611,7 @@ model TrailVersion {
   services           Service[]      @relation("TrailVersion_services")
   park               Park?          @relation("TrailVersion_park", fields: [parkId], references: [id])
   parkId             String?        @map("park")
+  topics             Topic[]        @relation("TrailVersion_topics")
   isLive             Trail?         @relation("Trail_currentVersion")
   republish          String?
 
@@ -1469,6 +1659,9 @@ model User {
   from_Facility_owner                Facility[]                @relation("Facility_owner")
   from_FacilityDraft_owner           FacilityDraft[]           @relation("FacilityDraft_owner")
   from_FacilityVersion_owner         FacilityVersion[]         @relation("FacilityVersion_owner")
+  from_Topic_owner                   Topic[]                   @relation("Topic_owner")
+  from_TopicDraft_owner              TopicDraft[]              @relation("TopicDraft_owner")
+  from_TopicVersion_owner            TopicVersion[]            @relation("TopicVersion_owner")
   from_OrgUnit_owner                 OrgUnit[]                 @relation("OrgUnit_owner")
   from_OrgUnitDraft_owner            OrgUnitDraft[]            @relation("OrgUnitDraft_owner")
   from_OrgUnitVersion_owner          OrgUnitVersion[]          @relation("OrgUnitVersion_owner")
@@ -1508,6 +1701,9 @@ model UserGroup {
   from_Facility_userGroups                Facility[]                @relation("Facility_userGroups")
   from_FacilityDraft_userGroups           FacilityDraft[]           @relation("FacilityDraft_userGroups")
   from_FacilityVersion_userGroups         FacilityVersion[]         @relation("FacilityVersion_userGroups")
+  from_Topic_userGroups                   Topic[]                   @relation("Topic_userGroups")
+  from_TopicDraft_userGroups              TopicDraft[]              @relation("TopicDraft_userGroups")
+  from_TopicVersion_userGroups            TopicVersion[]            @relation("TopicVersion_userGroups")
   from_OrgUnit_userGroups                 OrgUnit[]                 @relation("OrgUnit_userGroups")
   from_OrgUnitDraft_userGroups            OrgUnitDraft[]            @relation("OrgUnitDraft_userGroups")
   from_OrgUnitVersion_userGroups          OrgUnitVersion[]          @relation("OrgUnitVersion_userGroups")

--- a/apps/cms/src/app/models/AssemblyDistrict.ts
+++ b/apps/cms/src/app/models/AssemblyDistrict.ts
@@ -125,6 +125,11 @@ export const {
         ref: !opts?.isDraft && !opts?.isVersion ? 'Board.districts' : 'Board',
         many: true,
       }),
+
+      topics: relationship({
+        ref: !opts?.isDraft && !opts?.isVersion ? 'Topic.districts' : 'Topic',
+        many: true,
+      }),
     };
   },
   {

--- a/apps/cms/src/app/models/Board.ts
+++ b/apps/cms/src/app/models/Board.ts
@@ -118,6 +118,11 @@ export const {
           hideCreate: true,
         },
       }),
+
+      topics: relationship({
+        ref: !opts?.isDraft && !opts?.isVersion ? 'Topic.boards' : 'Topic',
+        many: true,
+      }),
     };
   },
   {

--- a/apps/cms/src/app/models/Community.ts
+++ b/apps/cms/src/app/models/Community.ts
@@ -41,6 +41,11 @@ export const {
             : 'Board',
         many: true,
       }),
+
+      topics: relationship({
+        ref: !opts?.isDraft && !opts?.isVersion ? 'Topic.communities' : 'Topic',
+        many: true,
+      }),
     };
   },
   {

--- a/apps/cms/src/app/models/Facility.ts
+++ b/apps/cms/src/app/models/Facility.ts
@@ -39,6 +39,10 @@ export const {
         ref: !opts?.isDraft && !opts?.isVersion ? 'Park.facilities' : 'Park',
         many: false,
       }),
+      topics: relationship({
+        ref: !opts?.isDraft && !opts?.isVersion ? 'Topic.facilities' : 'Topic',
+        many: true,
+      }),
     };
   },
   {

--- a/apps/cms/src/app/models/OrgUnit.ts
+++ b/apps/cms/src/app/models/OrgUnit.ts
@@ -40,6 +40,10 @@ export const {
           !opts?.isDraft && !opts?.isVersion ? 'OrgUnit.children' : 'OrgUnit',
         many: false,
       }),
+      topics: relationship({
+        ref: !opts?.isDraft && !opts?.isVersion ? 'Topic.orgUnits' : 'Topic',
+        many: true,
+      }),
     };
   },
   {

--- a/apps/cms/src/app/models/Park.ts
+++ b/apps/cms/src/app/models/Park.ts
@@ -41,6 +41,10 @@ export const {
         ref: !opts?.isDraft && !opts?.isVersion ? 'Facility.park' : 'Facility',
         many: true,
       }),
+      topics: relationship({
+        ref: !opts?.isDraft && !opts?.isVersion ? 'Topic.parks' : 'Topic',
+        many: true,
+      }),
     };
   },
   {

--- a/apps/cms/src/app/models/PublicNotice.ts
+++ b/apps/cms/src/app/models/PublicNotice.ts
@@ -84,6 +84,11 @@ export const {
         ref: 'AssemblyDistrict',
         many: true,
       }),
+      topics: relationship({
+        ref:
+          !opts?.isDraft && !opts?.isVersion ? 'Topic.publicNotices' : 'Topic',
+        many: true,
+      }),
     };
   },
   {

--- a/apps/cms/src/app/models/Service.ts
+++ b/apps/cms/src/app/models/Service.ts
@@ -94,6 +94,11 @@ export const {
         },
       }),
 
+      topics: relationship({
+        ref: !opts?.isDraft && !opts?.isVersion ? 'Topic.services' : 'Topic',
+        many: true,
+      }),
+
       editorNotes: text({
         ui: {
           displayMode: 'textarea',

--- a/apps/cms/src/app/models/Topic.ts
+++ b/apps/cms/src/app/models/Topic.ts
@@ -20,53 +20,60 @@ export const {
 
       ui: {
         displayMode: 'cards',
-        cardFields: ['title', 'description', 'image', 'message', 'linkedItem'],
+        cardFields: ['title', 'image', 'message', 'linkedItem'],
         inlineConnect: false,
       },
     }),
 
     boards: relationship({
-      ref: 'Board.topics',
+      ref: !opts?.isDraft && !opts?.isVersion ? 'Board.topics' : 'Board',
       many: true,
     }),
 
     services: relationship({
-      ref: 'Service.topics',
+      ref: !opts?.isDraft && !opts?.isVersion ? 'Service.topics' : 'Service',
       many: true,
     }),
 
     communities: relationship({
-      ref: 'Community.topics',
+      ref:
+        !opts?.isDraft && !opts?.isVersion ? 'Community.topics' : 'Community',
       many: true,
     }),
 
     districts: relationship({
-      ref: 'District.topics',
+      ref:
+        !opts?.isDraft && !opts?.isVersion
+          ? 'AssemblyDistrict.topics'
+          : 'AssemblyDistrict',
       many: true,
     }),
 
     parks: relationship({
-      ref: 'Park.topics',
+      ref: !opts?.isDraft && !opts?.isVersion ? 'Park.topics' : 'Park',
       many: true,
     }),
 
     trails: relationship({
-      ref: 'Trail.topics',
+      ref: !opts?.isDraft && !opts?.isVersion ? 'Trail.topics' : 'Trail',
       many: true,
     }),
 
     facilities: relationship({
-      ref: 'Facility.topics',
+      ref: !opts?.isDraft && !opts?.isVersion ? 'Facility.topics' : 'Facility',
       many: true,
     }),
 
-    departments: relationship({
-      ref: 'OrgUnit.topics',
+    orgUnits: relationship({
+      ref: !opts?.isDraft && !opts?.isVersion ? 'OrgUnit.topics' : 'OrgUnit',
       many: true,
     }),
 
     publicNotices: relationship({
-      ref: 'PublicNotice.topics',
+      ref:
+        !opts?.isDraft && !opts?.isVersion
+          ? 'PublicNotice.topics'
+          : 'PublicNotice',
       many: true,
     }),
   };

--- a/apps/cms/src/app/models/Trail.ts
+++ b/apps/cms/src/app/models/Trail.ts
@@ -68,6 +68,10 @@ export const {
         ref: opts?.isDraft || opts?.isVersion ? 'Park' : 'Park.trails',
         many: false,
       }),
+      topics: relationship({
+        ref: !opts?.isDraft && !opts?.isVersion ? 'Topic.trails' : 'Topic',
+        many: true,
+      }),
     };
   },
   {

--- a/apps/cms/src/app/models/index.ts
+++ b/apps/cms/src/app/models/index.ts
@@ -17,7 +17,7 @@ import * as OrgUnitModels from './OrgUnit';
 import { OperatingHour } from './OperatingHour';
 import * as ParkModels from './Park';
 import * as PublicNoticeModels from './PublicNotice';
-// import * as Topic from './Topic';
+import * as Topic from './Topic';
 import * as ServiceModels from './Service';
 import { Tag } from './Tag';
 import * as TrailModels from './Trail';
@@ -37,7 +37,7 @@ export const lists = {
   DocumentCollection,
   ExternalLink,
   ...FacilityModels,
-  // ...Topic,
+  ...Topic,
   Highlight,
   HomePage,
   Image,

--- a/apps/cms/src/components/CustomNavigation.tsx
+++ b/apps/cms/src/components/CustomNavigation.tsx
@@ -56,7 +56,7 @@ export function CustomNavigation({
     /HomePage|BoardPage/gi.test(list.key),
   );
   const pageLists = lists.filter((list) =>
-    /Service|Community|AssemblyDistrict|OrgUnit|Park|Facility|Trail|PublicNotice|Board/gi.test(
+    /Service|Community|AssemblyDistrict|OrgUnit|Park|Facility|Trail|PublicNotice|Board|Topic/gi.test(
       list.key,
     ),
   );


### PR DESCRIPTION
This pull request introduces a new `Topic` model and integrates it across various existing models in the `apps/cms/schema.prisma` file. The changes include adding relations to the `Topic` model, creating draft and version models for `Topic`, and updating related models to include references to `Topic`. Below is a breakdown of the most significant changes:

### Addition of the `Topic` Model
* A new `Topic` model has been added, including fields such as `id`, `title`, `description`, `status`, and various relationships to other models like `Board`, `Community`, `Facility`, and more. This model supports draft and versioning functionality.

### Draft and Version Models for `Topic`
* Two new models, `TopicDraft` and `TopicVersion`, have been introduced to support draft management and versioning for `Topic`. These models mirror the structure of `Topic` and include additional fields for tracking their relation to the original `Topic`. (F6ca5778L630R796)

### Integration with Existing Models
* Relationships to the `Topic` model have been added to several existing models, including `AssemblyDistrict`, `Board`, `Community`, `Facility`, `Contact`, `Document`, and `Highlight`. Each of these models now includes references to `Topic`, `TopicDraft`, and `TopicVersion` where applicable. [[1]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5R55) [[2]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5R186) [[3]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5R334) [[4]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5R566-R574) [[5]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5R434-R436) [[6]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5R481-R483) [[7]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5R799-R801)

### Draft and Version Relationships in Existing Models
* The draft and version models of existing entities (e.g., `BoardDraft`, `CommunityVersion`, `FacilityDraft`) have been updated to include relationships to `TopicDraft` and `TopicVersion`. This ensures that the `Topic` model is fully integrated into the draft and versioning workflows of related entities. [[1]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5R237) [[2]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5R377) [[3]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5R614)

### Indexing and Default Values
* New indexes and default values have been added to support the `Topic` model and its related entities, ensuring efficient querying and maintaining data integrity. For example, unique constraints on fields like `title` and `slug` in the `Topic` model.

These changes collectively enable the introduction of a `Topic` entity, which can be associated with various other entities in the system while supporting draft and versioning capabilities.