### PR TITLE
Add graphql codegen

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-  "cSpell.words": ["bullmq", "commonmark", "Keymap", "milkdown", "prosemirror"]
+  "cSpell.words": [
+    "bullmq",
+    "Codegen",
+    "commonmark",
+    "Keymap",
+    "milkdown",
+    "prosemirror"
+  ]
 }

--- a/apps/cms/codegen.ts
+++ b/apps/cms/codegen.ts
@@ -1,0 +1,22 @@
+import type { CodegenConfig } from '@graphql-codegen/cli';
+
+const config: CodegenConfig = {
+  schema: './schema.graphql',
+  documents: ['./src/**/*.{ts,tsx,graphql}', './admin/**/*.{ts,tsx,graphql}'],
+  ignoreNoDocuments: true,
+  generates: {
+    './src/graphql/': {
+      preset: 'client',
+      presetConfig: {
+        gqlTagName: 'gql',
+        gqlImport: '@keystone-6/core/admin-ui/apollo#gql',
+        documentMode: 'documentNode',
+      },
+      config: {
+        addTypename: true,
+      },
+    },
+  },
+};
+
+export default config;

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -19,7 +19,9 @@
     "migration:resolve": "keystone prisma migrate resolve --rolled-back \"20250320194427_create_internal_links_and_updated_external_links\"",
     "migration:status": "keystone prisma migrate status",
     "start:publish-worker": "tsx ./src/queues/workers/publishWorker.ts",
-    "db:seed": "tsx ./seed-data.ts"
+    "db:seed": "tsx ./seed-data.ts",
+    "codegen": "pnpm exec graphql-codegen --config ./codegen.ts",
+    "codegen:watch": "pnpm exec graphql-codegen --config ./codegen.ts --watch"
   },
   "dependencies": {
     "@graphql-tools/schema": "^10.0.23",
@@ -61,6 +63,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^9.8.0",
+    "@graphql-codegen/cli": "^5.0.7",
     "@iconify/json": "^2.2.345",
     "@iconify/tailwind4": "^1.0.6",
     "@tailwindcss/postcss": "^4.1.8",

--- a/apps/cms/src/components/customFields/link/views.tsx
+++ b/apps/cms/src/components/customFields/link/views.tsx
@@ -17,15 +17,24 @@ import {
   type FieldProps,
 } from '@keystone-6/core/types';
 
-import { gql, useQuery } from '@keystone-6/core/admin-ui/apollo';
+import {
+  gql,
+  TypedDocumentNode,
+  useQuery,
+} from '@keystone-6/core/admin-ui/apollo';
 import { StylesConfig } from 'react-select';
+import {
+  QueryMode,
+  type GetServicesQuery,
+  type GetServicesQueryVariables,
+} from '../../../graphql/graphql';
 
 export function Field({
   field,
   value,
   onChange,
 }: FieldProps<typeof controller>) {
-  const { data, refetch } = useQuery(
+  const query: TypedDocumentNode<GetServicesQuery, GetServicesQueryVariables> =
     gql`
       query GetServices($where: ServiceWhereInput!) {
         services(where: $where) {
@@ -34,35 +43,37 @@ export function Field({
           id
         }
       }
-    `,
-    {
-      variables: {
-        where: {
-          title: {
-            contains: value || '',
-            mode: 'insensitive',
-          },
+    `;
+
+  const { data, refetch } = useQuery(query, {
+    variables: {
+      where: {
+        title: {
+          contains: value || '',
+          mode: QueryMode.Insensitive,
         },
       },
     },
-  );
+  });
 
   async function handleChange(newValue: string) {
     await refetch({
       where: {
         title: {
           contains: newValue || '',
-          mode: 'insensitive',
+          mode: QueryMode.Insensitive,
         },
       },
     });
 
-    return data?.services?.map((service: any) => {
-      return {
-        label: service.title,
-        value: `/service/${service.slug}`,
-      };
-    });
+    return (
+      data?.services?.map((service: any) => {
+        return {
+          label: service.title,
+          value: `/service/${service.slug}`,
+        };
+      }) ?? []
+    );
   }
 
   type Option = { label: string | null; value: string | null };

--- a/apps/cms/src/components/mdEditor/components/Editor/features/DocCollection/DocCollectionView.tsx
+++ b/apps/cms/src/components/mdEditor/components/Editor/features/DocCollection/DocCollectionView.tsx
@@ -1,36 +1,46 @@
 import React, { useEffect } from 'react';
 import { useNodeViewContext } from '@prosemirror-adapter/react';
-import { gql, useQuery } from '@keystone-6/core/admin-ui/apollo';
+import {
+  gql,
+  TypedDocumentNode,
+  useQuery,
+} from '@keystone-6/core/admin-ui/apollo';
+import {
+  type DocumentCollectionQuery,
+  type DocumentCollectionQueryVariables,
+} from '../../../../../../graphql/graphql';
 
 export function DocCollectionView() {
   const { contentRef, node } = useNodeViewContext();
 
-  const { data, loading, refetch } = useQuery(
-    gql`
-      query DocumentCollection($where: DocumentCollectionWhereUniqueInput!) {
-        documentCollection(where: $where) {
+  const query: TypedDocumentNode<
+    DocumentCollectionQuery,
+    DocumentCollectionQueryVariables
+  > = gql`
+    query DocumentCollection($where: DocumentCollectionWhereUniqueInput!) {
+      documentCollection(where: $where) {
+        id
+        title
+        documents {
           id
           title
-          documents {
-            id
-            title
-            file {
-              filename
-              filesize
-              url
-            }
+          file {
+            filename
+            filesize
+            url
           }
         }
       }
-    `,
-    {
-      variables: {
-        where: {
-          id: node?.attrs?.id || '',
-        },
+    }
+  `;
+
+  const { data, loading, refetch } = useQuery(query, {
+    variables: {
+      where: {
+        id: node?.attrs?.id || '',
       },
     },
-  );
+  });
 
   useEffect(() => {
     refetch();
@@ -43,13 +53,13 @@ export function DocCollectionView() {
       ) : data ? (
         <div ref={contentRef} className="my-4 overflow-hidden border shadow-xs">
           <div className="flex justify-between border-b bg-zinc-100 p-2">
-            <span className="text-2xl">{data.documentCollection.title}</span>{' '}
-            <a href={`/document-collections/${data.documentCollection.id}`}>
+            <span className="text-2xl">{data.documentCollection?.title}</span>{' '}
+            <a href={`/document-collections/${data.documentCollection?.id}`}>
               Manage collection
             </a>
           </div>
           <ul>
-            {data.documentCollection.documents.map((doc, index) => (
+            {data.documentCollection?.documents?.map((doc, index) => (
               <li
                 className={`p-2 ${index % 2 === 0 ? 'bg-white' : 'bg-zinc-50'}`}
                 key={doc.id}

--- a/apps/cms/src/components/mdEditor/components/Editor/features/DocCollection/DocuCollectonSearchView.tsx
+++ b/apps/cms/src/components/mdEditor/components/Editor/features/DocCollection/DocuCollectonSearchView.tsx
@@ -10,7 +10,16 @@ import {
   ComboboxOptions,
 } from '@headlessui/react';
 import clsx from 'clsx';
-import { gql, useQuery } from '@keystone-6/core/admin-ui/apollo';
+import {
+  gql,
+  TypedDocumentNode,
+  useQuery,
+} from '@keystone-6/core/admin-ui/apollo';
+import {
+  DocumentCollectionsQuery,
+  DocumentCollectionsQueryVariables,
+  QueryMode,
+} from '../../../../../../graphql/graphql';
 
 export function DocCollectionSearchView() {
   const content = useRef<HTMLDivElement>(null);
@@ -24,40 +33,42 @@ export function DocCollectionSearchView() {
     title: string;
     id: string;
   } | null>();
-  const { data, refetch } = useQuery(
-    gql`
-      query DocumentCollections($where: DocumentCollectionWhereInput!) {
-        documentCollections(where: $where) {
-          id
-          title
-        }
+
+  const query: TypedDocumentNode<
+    DocumentCollectionsQuery,
+    DocumentCollectionsQueryVariables
+  > = gql`
+    query DocumentCollections($where: DocumentCollectionWhereInput!) {
+      documentCollections(where: $where) {
+        id
+        title
       }
-    `,
-    {
-      variables: {
-        where: {
-          OR: [
-            {
-              title: {
-                contains: search,
-                mode: 'insensitive',
-              },
+    }
+  `;
+  const { data, refetch } = useQuery(query, {
+    variables: {
+      where: {
+        OR: [
+          {
+            title: {
+              contains: search,
+              mode: QueryMode.Insensitive,
             },
-            {
-              tags: {
-                some: {
-                  name: {
-                    contains: search,
-                    mode: 'insensitive',
-                  },
+          },
+          {
+            tags: {
+              some: {
+                name: {
+                  contains: search,
+                  mode: QueryMode.Insensitive,
                 },
               },
             },
-          ],
-        },
+          },
+        ],
       },
     },
-  );
+  });
 
   let timeout: NodeJS.Timeout;
   function handleSearch(e: React.ChangeEvent<HTMLInputElement>) {

--- a/apps/cms/src/components/mdEditor/components/Editor/features/internalLinks/hooks/useInternalSearchQuery.tsx
+++ b/apps/cms/src/components/mdEditor/components/Editor/features/internalLinks/hooks/useInternalSearchQuery.tsx
@@ -1,70 +1,76 @@
-import { gql, useQuery } from '@keystone-6/core/admin-ui/apollo';
+import {
+  gql,
+  TypedDocumentNode,
+  useQuery,
+} from '@keystone-6/core/admin-ui/apollo';
 import { useState } from 'react';
+import {
+  LinkSearchQuery,
+  LinkSearchQueryVariables,
+} from '../../../../../../../graphql/graphql';
 
 export function useInternalSearchQuery() {
   const [query, setQuery] = useState<string>('');
-  const result = useQuery<{
-    internalSearch: { __typename: string; title: string; id: string }[];
-  }>(
-    gql`
-      query LinkSearch($query: String) {
-        internalSearch(query: $query) {
-          __typename
-          ... on AssemblyDistrict {
-            id
-            title
-          }
-          ... on Board {
-            id
-            title
-          }
-          ... on BoardPage {
-            id
-            title
-          }
-          ... on Community {
-            id
-            title
-          }
-          ... on Facility {
-            id
-            title
-          }
-          ... on HomePage {
-            id
-            title
-          }
-          ... on OrgUnit {
-            id
-            title
-          }
-          ... on Park {
-            id
-            title
-          }
-          ... on PublicNotice {
-            id
-            title
-          }
-          ... on Service {
-            id
-            title
-          }
-          ... on Trail {
-            id
-            title
-          }
-          ... on Url {
-            id
-            title
-          }
+
+  const q: TypedDocumentNode<LinkSearchQuery, LinkSearchQueryVariables> = gql`
+    query LinkSearch($query: String) {
+      internalSearch(query: $query) {
+        __typename
+        ... on AssemblyDistrict {
+          id
+          title
+        }
+        ... on Board {
+          id
+          title
+        }
+        ... on BoardPage {
+          id
+          title
+        }
+        ... on Community {
+          id
+          title
+        }
+        ... on Facility {
+          id
+          title
+        }
+        ... on HomePage {
+          id
+          title
+        }
+        ... on OrgUnit {
+          id
+          title
+        }
+        ... on Park {
+          id
+          title
+        }
+        ... on PublicNotice {
+          id
+          title
+        }
+        ... on Service {
+          id
+          title
+        }
+        ... on Trail {
+          id
+          title
+        }
+        ... on Url {
+          id
+          title
         }
       }
-    `,
-    {
-      variables: { query },
-    },
-  );
+    }
+  `;
+
+  const result = useQuery(q, {
+    variables: { query },
+  });
 
   return { query, setQuery, ...result };
 }

--- a/apps/cms/src/graphql/fragment-masking.ts
+++ b/apps/cms/src/graphql/fragment-masking.ts
@@ -1,0 +1,87 @@
+/* eslint-disable */
+import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
+import { FragmentDefinitionNode } from 'graphql';
+import { Incremental } from './graphql';
+
+
+export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>> = TDocumentType extends DocumentTypeDecoration<
+  infer TType,
+  any
+>
+  ? [TType] extends [{ ' $fragmentName'?: infer TKey }]
+    ? TKey extends string
+      ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
+      : never
+    : never
+  : never;
+
+// return non-nullable if `fragmentType` is non-nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>
+): TType;
+// return nullable if `fragmentType` is undefined
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | undefined
+): TType | undefined;
+// return nullable if `fragmentType` is nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null
+): TType | null;
+// return nullable if `fragmentType` is nullable or undefined
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null | undefined
+): TType | null | undefined;
+// return array of non-nullable if `fragmentType` is array of non-nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>>
+): Array<TType>;
+// return array of nullable if `fragmentType` is array of nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+): Array<TType> | null | undefined;
+// return readonly array of non-nullable if `fragmentType` is array of non-nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
+): ReadonlyArray<TType>;
+// return readonly array of nullable if `fragmentType` is array of nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+): ReadonlyArray<TType> | null | undefined;
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | Array<FragmentType<DocumentTypeDecoration<TType, any>>> | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+): TType | Array<TType> | ReadonlyArray<TType> | null | undefined {
+  return fragmentType as any;
+}
+
+
+export function makeFragmentData<
+  F extends DocumentTypeDecoration<any, any>,
+  FT extends ResultOf<F>
+>(data: FT, _fragment: F): FragmentType<F> {
+  return data as FragmentType<F>;
+}
+export function isFragmentReady<TQuery, TFrag>(
+  queryNode: DocumentTypeDecoration<TQuery, any>,
+  fragmentNode: TypedDocumentNode<TFrag>,
+  data: FragmentType<TypedDocumentNode<Incremental<TFrag>, any>> | null | undefined
+): data is FragmentType<typeof fragmentNode> {
+  const deferredFields = (queryNode as { __meta__?: { deferredFields: Record<string, (keyof TFrag)[]> } }).__meta__
+    ?.deferredFields;
+
+  if (!deferredFields) return true;
+
+  const fragDef = fragmentNode.definitions[0] as FragmentDefinitionNode | undefined;
+  const fragName = fragDef?.name?.value;
+
+  const fields = (fragName && deferredFields[fragName]) || [];
+  return fields.length > 0 && fields.every(field => data && field in data);
+}

--- a/apps/cms/src/graphql/gql.ts
+++ b/apps/cms/src/graphql/gql.ts
@@ -1,0 +1,88 @@
+/* eslint-disable */
+import * as types from './graphql';
+import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+
+/**
+ * Map of all GraphQL operations in the project.
+ *
+ * This map has several performance disadvantages:
+ * 1. It is not tree-shakeable, so it will include all operations in the project.
+ * 2. It is not minifiable, so the string of a GraphQL query will be multiple times inside the bundle.
+ * 3. It does not support dead code elimination, so it will add unused operations.
+ *
+ * Therefore it is highly recommended to use the babel or swc plugin for production.
+ * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
+ */
+type Documents = {
+    "\n  mutation CreateDocuments($data: [DocumentCreateInput!]!) {\n    createDocuments(data: $data) {\n      id\n      title\n      file {\n        filename\n        filesize\n        url\n      }\n      tags {\n        id\n        name\n      }\n    }\n  }\n": typeof types.CreateDocumentsDocument,
+    "\n  query Tags {\n    tags {\n      id\n      name\n    }\n  }\n": typeof types.TagsDocument,
+    "\n  query Query {\n    documentCollections {\n      id\n      title\n    }\n  }\n": typeof types.QueryDocument,
+    "\n      query GetServices($where: ServiceWhereInput!) {\n        services(where: $where) {\n          title\n          slug\n          id\n        }\n      }\n    ": typeof types.GetServicesDocument,
+    "\n      query DocumentCollection($where: DocumentCollectionWhereUniqueInput!) {\n        documentCollection(where: $where) {\n          id\n          title\n          documents {\n            id\n            title\n            file {\n              filename\n              filesize\n              url\n            }\n          }\n        }\n      }\n    ": typeof types.DocumentCollectionDocument,
+    "\n      query DocumentCollections($where: DocumentCollectionWhereInput!) {\n        documentCollections(where: $where) {\n          id\n          title\n        }\n      }\n    ": typeof types.DocumentCollectionsDocument,
+    "\n      query GetInternalLink($id: ID!, $type: String!) {\n        getInternalLink(id: $id, type: $type) {\n          __typename\n          ... on AssemblyDistrict {\n            title\n          }\n          ... on Board {\n            title\n          }\n          ... on BoardPage {\n            title\n          }\n          ... on Community {\n            title\n          }\n          ... on Facility {\n            title\n          }\n          ... on HomePage {\n            title\n          }\n          ... on OrgUnit {\n            title\n          }\n          ... on Park {\n            title\n          }\n          ... on PublicNotice {\n            title\n          }\n          ... on Service {\n            title\n          }\n          ... on Trail {\n            title\n          }\n          ... on Url {\n            title\n          }\n        }\n      }\n    ": typeof types.GetInternalLinkDocument,
+    "\n      query LinkSearch($query: String) {\n        internalSearch(query: $query) {\n          __typename\n          ... on AssemblyDistrict {\n            id\n            title\n          }\n          ... on Board {\n            id\n            title\n          }\n          ... on BoardPage {\n            id\n            title\n          }\n          ... on Community {\n            id\n            title\n          }\n          ... on Facility {\n            id\n            title\n          }\n          ... on HomePage {\n            id\n            title\n          }\n          ... on OrgUnit {\n            id\n            title\n          }\n          ... on Park {\n            id\n            title\n          }\n          ... on PublicNotice {\n            id\n            title\n          }\n          ... on Service {\n            id\n            title\n          }\n          ... on Trail {\n            id\n            title\n          }\n          ... on Url {\n            id\n            title\n          }\n        }\n      }\n    ": typeof types.LinkSearchDocument,
+};
+const documents: Documents = {
+    "\n  mutation CreateDocuments($data: [DocumentCreateInput!]!) {\n    createDocuments(data: $data) {\n      id\n      title\n      file {\n        filename\n        filesize\n        url\n      }\n      tags {\n        id\n        name\n      }\n    }\n  }\n": types.CreateDocumentsDocument,
+    "\n  query Tags {\n    tags {\n      id\n      name\n    }\n  }\n": types.TagsDocument,
+    "\n  query Query {\n    documentCollections {\n      id\n      title\n    }\n  }\n": types.QueryDocument,
+    "\n      query GetServices($where: ServiceWhereInput!) {\n        services(where: $where) {\n          title\n          slug\n          id\n        }\n      }\n    ": types.GetServicesDocument,
+    "\n      query DocumentCollection($where: DocumentCollectionWhereUniqueInput!) {\n        documentCollection(where: $where) {\n          id\n          title\n          documents {\n            id\n            title\n            file {\n              filename\n              filesize\n              url\n            }\n          }\n        }\n      }\n    ": types.DocumentCollectionDocument,
+    "\n      query DocumentCollections($where: DocumentCollectionWhereInput!) {\n        documentCollections(where: $where) {\n          id\n          title\n        }\n      }\n    ": types.DocumentCollectionsDocument,
+    "\n      query GetInternalLink($id: ID!, $type: String!) {\n        getInternalLink(id: $id, type: $type) {\n          __typename\n          ... on AssemblyDistrict {\n            title\n          }\n          ... on Board {\n            title\n          }\n          ... on BoardPage {\n            title\n          }\n          ... on Community {\n            title\n          }\n          ... on Facility {\n            title\n          }\n          ... on HomePage {\n            title\n          }\n          ... on OrgUnit {\n            title\n          }\n          ... on Park {\n            title\n          }\n          ... on PublicNotice {\n            title\n          }\n          ... on Service {\n            title\n          }\n          ... on Trail {\n            title\n          }\n          ... on Url {\n            title\n          }\n        }\n      }\n    ": types.GetInternalLinkDocument,
+    "\n      query LinkSearch($query: String) {\n        internalSearch(query: $query) {\n          __typename\n          ... on AssemblyDistrict {\n            id\n            title\n          }\n          ... on Board {\n            id\n            title\n          }\n          ... on BoardPage {\n            id\n            title\n          }\n          ... on Community {\n            id\n            title\n          }\n          ... on Facility {\n            id\n            title\n          }\n          ... on HomePage {\n            id\n            title\n          }\n          ... on OrgUnit {\n            id\n            title\n          }\n          ... on Park {\n            id\n            title\n          }\n          ... on PublicNotice {\n            id\n            title\n          }\n          ... on Service {\n            id\n            title\n          }\n          ... on Trail {\n            id\n            title\n          }\n          ... on Url {\n            id\n            title\n          }\n        }\n      }\n    ": types.LinkSearchDocument,
+};
+
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ *
+ *
+ * @example
+ * ```ts
+ * const query = gql(`query GetUser($id: ID!) { user(id: $id) { name } }`);
+ * ```
+ *
+ * The query argument is unknown!
+ * Please regenerate the types.
+ */
+export function gql(source: string): unknown;
+
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function gql(source: "\n  mutation CreateDocuments($data: [DocumentCreateInput!]!) {\n    createDocuments(data: $data) {\n      id\n      title\n      file {\n        filename\n        filesize\n        url\n      }\n      tags {\n        id\n        name\n      }\n    }\n  }\n"): (typeof documents)["\n  mutation CreateDocuments($data: [DocumentCreateInput!]!) {\n    createDocuments(data: $data) {\n      id\n      title\n      file {\n        filename\n        filesize\n        url\n      }\n      tags {\n        id\n        name\n      }\n    }\n  }\n"];
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function gql(source: "\n  query Tags {\n    tags {\n      id\n      name\n    }\n  }\n"): (typeof documents)["\n  query Tags {\n    tags {\n      id\n      name\n    }\n  }\n"];
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function gql(source: "\n  query Query {\n    documentCollections {\n      id\n      title\n    }\n  }\n"): (typeof documents)["\n  query Query {\n    documentCollections {\n      id\n      title\n    }\n  }\n"];
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function gql(source: "\n      query GetServices($where: ServiceWhereInput!) {\n        services(where: $where) {\n          title\n          slug\n          id\n        }\n      }\n    "): (typeof documents)["\n      query GetServices($where: ServiceWhereInput!) {\n        services(where: $where) {\n          title\n          slug\n          id\n        }\n      }\n    "];
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function gql(source: "\n      query DocumentCollection($where: DocumentCollectionWhereUniqueInput!) {\n        documentCollection(where: $where) {\n          id\n          title\n          documents {\n            id\n            title\n            file {\n              filename\n              filesize\n              url\n            }\n          }\n        }\n      }\n    "): (typeof documents)["\n      query DocumentCollection($where: DocumentCollectionWhereUniqueInput!) {\n        documentCollection(where: $where) {\n          id\n          title\n          documents {\n            id\n            title\n            file {\n              filename\n              filesize\n              url\n            }\n          }\n        }\n      }\n    "];
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function gql(source: "\n      query DocumentCollections($where: DocumentCollectionWhereInput!) {\n        documentCollections(where: $where) {\n          id\n          title\n        }\n      }\n    "): (typeof documents)["\n      query DocumentCollections($where: DocumentCollectionWhereInput!) {\n        documentCollections(where: $where) {\n          id\n          title\n        }\n      }\n    "];
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function gql(source: "\n      query GetInternalLink($id: ID!, $type: String!) {\n        getInternalLink(id: $id, type: $type) {\n          __typename\n          ... on AssemblyDistrict {\n            title\n          }\n          ... on Board {\n            title\n          }\n          ... on BoardPage {\n            title\n          }\n          ... on Community {\n            title\n          }\n          ... on Facility {\n            title\n          }\n          ... on HomePage {\n            title\n          }\n          ... on OrgUnit {\n            title\n          }\n          ... on Park {\n            title\n          }\n          ... on PublicNotice {\n            title\n          }\n          ... on Service {\n            title\n          }\n          ... on Trail {\n            title\n          }\n          ... on Url {\n            title\n          }\n        }\n      }\n    "): (typeof documents)["\n      query GetInternalLink($id: ID!, $type: String!) {\n        getInternalLink(id: $id, type: $type) {\n          __typename\n          ... on AssemblyDistrict {\n            title\n          }\n          ... on Board {\n            title\n          }\n          ... on BoardPage {\n            title\n          }\n          ... on Community {\n            title\n          }\n          ... on Facility {\n            title\n          }\n          ... on HomePage {\n            title\n          }\n          ... on OrgUnit {\n            title\n          }\n          ... on Park {\n            title\n          }\n          ... on PublicNotice {\n            title\n          }\n          ... on Service {\n            title\n          }\n          ... on Trail {\n            title\n          }\n          ... on Url {\n            title\n          }\n        }\n      }\n    "];
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function gql(source: "\n      query LinkSearch($query: String) {\n        internalSearch(query: $query) {\n          __typename\n          ... on AssemblyDistrict {\n            id\n            title\n          }\n          ... on Board {\n            id\n            title\n          }\n          ... on BoardPage {\n            id\n            title\n          }\n          ... on Community {\n            id\n            title\n          }\n          ... on Facility {\n            id\n            title\n          }\n          ... on HomePage {\n            id\n            title\n          }\n          ... on OrgUnit {\n            id\n            title\n          }\n          ... on Park {\n            id\n            title\n          }\n          ... on PublicNotice {\n            id\n            title\n          }\n          ... on Service {\n            id\n            title\n          }\n          ... on Trail {\n            id\n            title\n          }\n          ... on Url {\n            id\n            title\n          }\n        }\n      }\n    "): (typeof documents)["\n      query LinkSearch($query: String) {\n        internalSearch(query: $query) {\n          __typename\n          ... on AssemblyDistrict {\n            id\n            title\n          }\n          ... on Board {\n            id\n            title\n          }\n          ... on BoardPage {\n            id\n            title\n          }\n          ... on Community {\n            id\n            title\n          }\n          ... on Facility {\n            id\n            title\n          }\n          ... on HomePage {\n            id\n            title\n          }\n          ... on OrgUnit {\n            id\n            title\n          }\n          ... on Park {\n            id\n            title\n          }\n          ... on PublicNotice {\n            id\n            title\n          }\n          ... on Service {\n            id\n            title\n          }\n          ... on Trail {\n            id\n            title\n          }\n          ... on Url {\n            id\n            title\n          }\n        }\n      }\n    "];
+
+export function gql(source: string) {
+  return (documents as any)[source] ?? {};
+}
+
+export type DocumentType<TDocumentNode extends DocumentNode<any, any>> = TDocumentNode extends DocumentNode<  infer TType,  any>  ? TType  : never;

--- a/apps/cms/src/graphql/graphql.ts
+++ b/apps/cms/src/graphql/graphql.ts
@@ -1,0 +1,14655 @@
+/* eslint-disable */
+import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  DateTime: { input: any; output: any; }
+  /** The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
+  JSON: { input: any; output: any; }
+  /** The `Upload` scalar type represents a file upload. */
+  Upload: { input: any; output: any; }
+};
+
+export type Alert = {
+  __typename?: 'Alert';
+  body?: Maybe<Scalars['String']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  editorNotes?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  title?: Maybe<Scalars['String']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  urgency?: Maybe<Scalars['Int']['output']>;
+};
+
+export type AlertCreateInput = {
+  body?: InputMaybe<Scalars['String']['input']>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  editorNotes?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  urgency?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type AlertOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  editorNotes?: InputMaybe<OrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+  urgency?: InputMaybe<OrderDirection>;
+};
+
+export type AlertUpdateArgs = {
+  data: AlertUpdateInput;
+  where: AlertWhereUniqueInput;
+};
+
+export type AlertUpdateInput = {
+  body?: InputMaybe<Scalars['String']['input']>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  editorNotes?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  urgency?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type AlertWhereInput = {
+  AND?: InputMaybe<Array<AlertWhereInput>>;
+  NOT?: InputMaybe<Array<AlertWhereInput>>;
+  OR?: InputMaybe<Array<AlertWhereInput>>;
+  body?: InputMaybe<MyStringFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  editorNotes?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  title?: InputMaybe<StringFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  urgency?: InputMaybe<IntFilter>;
+};
+
+export type AlertWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type AssemblyDistrict = {
+  __typename?: 'AssemblyDistrict';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  address?: Maybe<Scalars['String']['output']>;
+  bio?: Maybe<Scalars['String']['output']>;
+  boards?: Maybe<Array<Board>>;
+  boardsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  currentVersion?: Maybe<AssemblyDistrictVersion>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  drafts?: Maybe<Array<AssemblyDistrictDraft>>;
+  draftsCount?: Maybe<Scalars['Int']['output']>;
+  email?: Maybe<Scalars['String']['output']>;
+  fax?: Maybe<Scalars['String']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  makeDrafts?: Maybe<Scalars['String']['output']>;
+  memberName?: Maybe<Scalars['String']['output']>;
+  owner?: Maybe<User>;
+  phone?: Maybe<Scalars['String']['output']>;
+  photo?: Maybe<Image>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  termEnd?: Maybe<Scalars['DateTime']['output']>;
+  termStart?: Maybe<Scalars['DateTime']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+  versions?: Maybe<Array<AssemblyDistrictVersion>>;
+  versionsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type AssemblyDistrictActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type AssemblyDistrictActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type AssemblyDistrictBoardsArgs = {
+  cursor?: InputMaybe<BoardWhereUniqueInput>;
+  orderBy?: Array<BoardOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: BoardWhereInput;
+};
+
+
+export type AssemblyDistrictBoardsCountArgs = {
+  where?: BoardWhereInput;
+};
+
+
+export type AssemblyDistrictContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type AssemblyDistrictContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type AssemblyDistrictDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type AssemblyDistrictDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type AssemblyDistrictDraftsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictDraftWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictDraftWhereInput;
+};
+
+
+export type AssemblyDistrictDraftsCountArgs = {
+  where?: AssemblyDistrictDraftWhereInput;
+};
+
+
+export type AssemblyDistrictTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type AssemblyDistrictTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type AssemblyDistrictTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type AssemblyDistrictTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type AssemblyDistrictUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type AssemblyDistrictUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+
+export type AssemblyDistrictVersionsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictVersionWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictVersionWhereInput;
+};
+
+
+export type AssemblyDistrictVersionsCountArgs = {
+  where?: AssemblyDistrictVersionWhereInput;
+};
+
+export type AssemblyDistrictCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  address?: InputMaybe<Scalars['String']['input']>;
+  bio?: InputMaybe<Scalars['String']['input']>;
+  boards?: InputMaybe<BoardRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<AssemblyDistrictVersionRelateToOneForCreateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  drafts?: InputMaybe<AssemblyDistrictDraftRelateToManyForCreateInput>;
+  email?: InputMaybe<Scalars['String']['input']>;
+  fax?: InputMaybe<Scalars['String']['input']>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  memberName?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  phone?: InputMaybe<Scalars['String']['input']>;
+  photo?: InputMaybe<ImageRelateToOneForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  termEnd?: InputMaybe<Scalars['DateTime']['input']>;
+  termStart?: InputMaybe<Scalars['DateTime']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+  versions?: InputMaybe<AssemblyDistrictVersionRelateToManyForCreateInput>;
+};
+
+export type AssemblyDistrictDraft = {
+  __typename?: 'AssemblyDistrictDraft';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  address?: Maybe<Scalars['String']['output']>;
+  bio?: Maybe<Scalars['String']['output']>;
+  boards?: Maybe<Array<Board>>;
+  boardsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  email?: Maybe<Scalars['String']['output']>;
+  fax?: Maybe<Scalars['String']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  memberName?: Maybe<Scalars['String']['output']>;
+  original?: Maybe<AssemblyDistrict>;
+  owner?: Maybe<User>;
+  phone?: Maybe<Scalars['String']['output']>;
+  photo?: Maybe<Image>;
+  publish?: Maybe<Scalars['String']['output']>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  termEnd?: Maybe<Scalars['DateTime']['output']>;
+  termStart?: Maybe<Scalars['DateTime']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type AssemblyDistrictDraftActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type AssemblyDistrictDraftActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type AssemblyDistrictDraftBoardsArgs = {
+  cursor?: InputMaybe<BoardWhereUniqueInput>;
+  orderBy?: Array<BoardOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: BoardWhereInput;
+};
+
+
+export type AssemblyDistrictDraftBoardsCountArgs = {
+  where?: BoardWhereInput;
+};
+
+
+export type AssemblyDistrictDraftContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type AssemblyDistrictDraftContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type AssemblyDistrictDraftDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type AssemblyDistrictDraftDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type AssemblyDistrictDraftTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type AssemblyDistrictDraftTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type AssemblyDistrictDraftTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type AssemblyDistrictDraftTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type AssemblyDistrictDraftUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type AssemblyDistrictDraftUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type AssemblyDistrictDraftCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  address?: InputMaybe<Scalars['String']['input']>;
+  bio?: InputMaybe<Scalars['String']['input']>;
+  boards?: InputMaybe<BoardRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  email?: InputMaybe<Scalars['String']['input']>;
+  fax?: InputMaybe<Scalars['String']['input']>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  memberName?: InputMaybe<Scalars['String']['input']>;
+  original?: InputMaybe<AssemblyDistrictRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  phone?: InputMaybe<Scalars['String']['input']>;
+  photo?: InputMaybe<ImageRelateToOneForCreateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  termEnd?: InputMaybe<Scalars['DateTime']['input']>;
+  termStart?: InputMaybe<Scalars['DateTime']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type AssemblyDistrictDraftManyRelationFilter = {
+  every?: InputMaybe<AssemblyDistrictDraftWhereInput>;
+  none?: InputMaybe<AssemblyDistrictDraftWhereInput>;
+  some?: InputMaybe<AssemblyDistrictDraftWhereInput>;
+};
+
+export type AssemblyDistrictDraftOrderByInput = {
+  address?: InputMaybe<OrderDirection>;
+  bio?: InputMaybe<OrderDirection>;
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  email?: InputMaybe<OrderDirection>;
+  fax?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  memberName?: InputMaybe<OrderDirection>;
+  phone?: InputMaybe<OrderDirection>;
+  publish?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  termEnd?: InputMaybe<OrderDirection>;
+  termStart?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type AssemblyDistrictDraftRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<AssemblyDistrictDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<AssemblyDistrictDraftCreateInput>>;
+};
+
+export type AssemblyDistrictDraftRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<AssemblyDistrictDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<AssemblyDistrictDraftCreateInput>>;
+  disconnect?: InputMaybe<Array<AssemblyDistrictDraftWhereUniqueInput>>;
+  set?: InputMaybe<Array<AssemblyDistrictDraftWhereUniqueInput>>;
+};
+
+export type AssemblyDistrictDraftUpdateArgs = {
+  data: AssemblyDistrictDraftUpdateInput;
+  where: AssemblyDistrictDraftWhereUniqueInput;
+};
+
+export type AssemblyDistrictDraftUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  address?: InputMaybe<Scalars['String']['input']>;
+  bio?: InputMaybe<Scalars['String']['input']>;
+  boards?: InputMaybe<BoardRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  email?: InputMaybe<Scalars['String']['input']>;
+  fax?: InputMaybe<Scalars['String']['input']>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  memberName?: InputMaybe<Scalars['String']['input']>;
+  original?: InputMaybe<AssemblyDistrictRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  phone?: InputMaybe<Scalars['String']['input']>;
+  photo?: InputMaybe<ImageRelateToOneForUpdateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  termEnd?: InputMaybe<Scalars['DateTime']['input']>;
+  termStart?: InputMaybe<Scalars['DateTime']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type AssemblyDistrictDraftWhereInput = {
+  AND?: InputMaybe<Array<AssemblyDistrictDraftWhereInput>>;
+  NOT?: InputMaybe<Array<AssemblyDistrictDraftWhereInput>>;
+  OR?: InputMaybe<Array<AssemblyDistrictDraftWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  address?: InputMaybe<StringFilter>;
+  bio?: InputMaybe<StringFilter>;
+  boards?: InputMaybe<BoardManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  email?: InputMaybe<StringNullableFilter>;
+  fax?: InputMaybe<StringNullableFilter>;
+  id?: InputMaybe<IdFilter>;
+  memberName?: InputMaybe<StringFilter>;
+  original?: InputMaybe<AssemblyDistrictWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  phone?: InputMaybe<StringNullableFilter>;
+  photo?: InputMaybe<ImageWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  termEnd?: InputMaybe<DateTimeNullableFilter>;
+  termStart?: InputMaybe<DateTimeNullableFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type AssemblyDistrictDraftWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type AssemblyDistrictManyRelationFilter = {
+  every?: InputMaybe<AssemblyDistrictWhereInput>;
+  none?: InputMaybe<AssemblyDistrictWhereInput>;
+  some?: InputMaybe<AssemblyDistrictWhereInput>;
+};
+
+export type AssemblyDistrictOrderByInput = {
+  address?: InputMaybe<OrderDirection>;
+  bio?: InputMaybe<OrderDirection>;
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  email?: InputMaybe<OrderDirection>;
+  fax?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  makeDrafts?: InputMaybe<OrderDirection>;
+  memberName?: InputMaybe<OrderDirection>;
+  phone?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  slug?: InputMaybe<OrderDirection>;
+  status?: InputMaybe<OrderDirection>;
+  termEnd?: InputMaybe<OrderDirection>;
+  termStart?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type AssemblyDistrictRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<AssemblyDistrictWhereUniqueInput>>;
+  create?: InputMaybe<Array<AssemblyDistrictCreateInput>>;
+};
+
+export type AssemblyDistrictRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<AssemblyDistrictWhereUniqueInput>>;
+  create?: InputMaybe<Array<AssemblyDistrictCreateInput>>;
+  disconnect?: InputMaybe<Array<AssemblyDistrictWhereUniqueInput>>;
+  set?: InputMaybe<Array<AssemblyDistrictWhereUniqueInput>>;
+};
+
+export type AssemblyDistrictRelateToOneForCreateInput = {
+  connect?: InputMaybe<AssemblyDistrictWhereUniqueInput>;
+  create?: InputMaybe<AssemblyDistrictCreateInput>;
+};
+
+export type AssemblyDistrictRelateToOneForUpdateInput = {
+  connect?: InputMaybe<AssemblyDistrictWhereUniqueInput>;
+  create?: InputMaybe<AssemblyDistrictCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type AssemblyDistrictUpdateArgs = {
+  data: AssemblyDistrictUpdateInput;
+  where: AssemblyDistrictWhereUniqueInput;
+};
+
+export type AssemblyDistrictUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  address?: InputMaybe<Scalars['String']['input']>;
+  bio?: InputMaybe<Scalars['String']['input']>;
+  boards?: InputMaybe<BoardRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<AssemblyDistrictVersionRelateToOneForUpdateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  drafts?: InputMaybe<AssemblyDistrictDraftRelateToManyForUpdateInput>;
+  email?: InputMaybe<Scalars['String']['input']>;
+  fax?: InputMaybe<Scalars['String']['input']>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  memberName?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  phone?: InputMaybe<Scalars['String']['input']>;
+  photo?: InputMaybe<ImageRelateToOneForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  termEnd?: InputMaybe<Scalars['DateTime']['input']>;
+  termStart?: InputMaybe<Scalars['DateTime']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+  versions?: InputMaybe<AssemblyDistrictVersionRelateToManyForUpdateInput>;
+};
+
+export type AssemblyDistrictVersion = {
+  __typename?: 'AssemblyDistrictVersion';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  address?: Maybe<Scalars['String']['output']>;
+  bio?: Maybe<Scalars['String']['output']>;
+  boards?: Maybe<Array<Board>>;
+  boardsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  email?: Maybe<Scalars['String']['output']>;
+  fax?: Maybe<Scalars['String']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  isLive?: Maybe<AssemblyDistrict>;
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  memberName?: Maybe<Scalars['String']['output']>;
+  original?: Maybe<AssemblyDistrict>;
+  owner?: Maybe<User>;
+  phone?: Maybe<Scalars['String']['output']>;
+  photo?: Maybe<Image>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  republish?: Maybe<Scalars['String']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  termEnd?: Maybe<Scalars['DateTime']['output']>;
+  termStart?: Maybe<Scalars['DateTime']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type AssemblyDistrictVersionActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type AssemblyDistrictVersionActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type AssemblyDistrictVersionBoardsArgs = {
+  cursor?: InputMaybe<BoardWhereUniqueInput>;
+  orderBy?: Array<BoardOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: BoardWhereInput;
+};
+
+
+export type AssemblyDistrictVersionBoardsCountArgs = {
+  where?: BoardWhereInput;
+};
+
+
+export type AssemblyDistrictVersionContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type AssemblyDistrictVersionContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type AssemblyDistrictVersionDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type AssemblyDistrictVersionDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type AssemblyDistrictVersionTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type AssemblyDistrictVersionTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type AssemblyDistrictVersionTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type AssemblyDistrictVersionTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type AssemblyDistrictVersionUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type AssemblyDistrictVersionUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type AssemblyDistrictVersionCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  address?: InputMaybe<Scalars['String']['input']>;
+  bio?: InputMaybe<Scalars['String']['input']>;
+  boards?: InputMaybe<BoardRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  email?: InputMaybe<Scalars['String']['input']>;
+  fax?: InputMaybe<Scalars['String']['input']>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  isLive?: InputMaybe<AssemblyDistrictRelateToOneForCreateInput>;
+  memberName?: InputMaybe<Scalars['String']['input']>;
+  original?: InputMaybe<AssemblyDistrictRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  phone?: InputMaybe<Scalars['String']['input']>;
+  photo?: InputMaybe<ImageRelateToOneForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  termEnd?: InputMaybe<Scalars['DateTime']['input']>;
+  termStart?: InputMaybe<Scalars['DateTime']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type AssemblyDistrictVersionManyRelationFilter = {
+  every?: InputMaybe<AssemblyDistrictVersionWhereInput>;
+  none?: InputMaybe<AssemblyDistrictVersionWhereInput>;
+  some?: InputMaybe<AssemblyDistrictVersionWhereInput>;
+};
+
+export type AssemblyDistrictVersionOrderByInput = {
+  address?: InputMaybe<OrderDirection>;
+  bio?: InputMaybe<OrderDirection>;
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  email?: InputMaybe<OrderDirection>;
+  fax?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  memberName?: InputMaybe<OrderDirection>;
+  phone?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  republish?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  termEnd?: InputMaybe<OrderDirection>;
+  termStart?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type AssemblyDistrictVersionRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<AssemblyDistrictVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<AssemblyDistrictVersionCreateInput>>;
+};
+
+export type AssemblyDistrictVersionRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<AssemblyDistrictVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<AssemblyDistrictVersionCreateInput>>;
+  disconnect?: InputMaybe<Array<AssemblyDistrictVersionWhereUniqueInput>>;
+  set?: InputMaybe<Array<AssemblyDistrictVersionWhereUniqueInput>>;
+};
+
+export type AssemblyDistrictVersionRelateToOneForCreateInput = {
+  connect?: InputMaybe<AssemblyDistrictVersionWhereUniqueInput>;
+  create?: InputMaybe<AssemblyDistrictVersionCreateInput>;
+};
+
+export type AssemblyDistrictVersionRelateToOneForUpdateInput = {
+  connect?: InputMaybe<AssemblyDistrictVersionWhereUniqueInput>;
+  create?: InputMaybe<AssemblyDistrictVersionCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type AssemblyDistrictVersionUpdateArgs = {
+  data: AssemblyDistrictVersionUpdateInput;
+  where: AssemblyDistrictVersionWhereUniqueInput;
+};
+
+export type AssemblyDistrictVersionUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  address?: InputMaybe<Scalars['String']['input']>;
+  bio?: InputMaybe<Scalars['String']['input']>;
+  boards?: InputMaybe<BoardRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  email?: InputMaybe<Scalars['String']['input']>;
+  fax?: InputMaybe<Scalars['String']['input']>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  isLive?: InputMaybe<AssemblyDistrictRelateToOneForUpdateInput>;
+  memberName?: InputMaybe<Scalars['String']['input']>;
+  original?: InputMaybe<AssemblyDistrictRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  phone?: InputMaybe<Scalars['String']['input']>;
+  photo?: InputMaybe<ImageRelateToOneForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  termEnd?: InputMaybe<Scalars['DateTime']['input']>;
+  termStart?: InputMaybe<Scalars['DateTime']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type AssemblyDistrictVersionWhereInput = {
+  AND?: InputMaybe<Array<AssemblyDistrictVersionWhereInput>>;
+  NOT?: InputMaybe<Array<AssemblyDistrictVersionWhereInput>>;
+  OR?: InputMaybe<Array<AssemblyDistrictVersionWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  address?: InputMaybe<StringFilter>;
+  bio?: InputMaybe<StringFilter>;
+  boards?: InputMaybe<BoardManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  email?: InputMaybe<StringNullableFilter>;
+  fax?: InputMaybe<StringNullableFilter>;
+  id?: InputMaybe<IdFilter>;
+  isLive?: InputMaybe<AssemblyDistrictWhereInput>;
+  memberName?: InputMaybe<StringFilter>;
+  original?: InputMaybe<AssemblyDistrictWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  phone?: InputMaybe<StringNullableFilter>;
+  photo?: InputMaybe<ImageWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  termEnd?: InputMaybe<DateTimeNullableFilter>;
+  termStart?: InputMaybe<DateTimeNullableFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type AssemblyDistrictVersionWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  isLive?: InputMaybe<AssemblyDistrictWhereUniqueInput>;
+};
+
+export type AssemblyDistrictWhereInput = {
+  AND?: InputMaybe<Array<AssemblyDistrictWhereInput>>;
+  NOT?: InputMaybe<Array<AssemblyDistrictWhereInput>>;
+  OR?: InputMaybe<Array<AssemblyDistrictWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  address?: InputMaybe<StringFilter>;
+  bio?: InputMaybe<StringFilter>;
+  boards?: InputMaybe<BoardManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  currentVersion?: InputMaybe<AssemblyDistrictVersionWhereInput>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  drafts?: InputMaybe<AssemblyDistrictDraftManyRelationFilter>;
+  email?: InputMaybe<StringNullableFilter>;
+  fax?: InputMaybe<StringNullableFilter>;
+  id?: InputMaybe<IdFilter>;
+  memberName?: InputMaybe<StringFilter>;
+  owner?: InputMaybe<UserWhereInput>;
+  phone?: InputMaybe<StringNullableFilter>;
+  photo?: InputMaybe<ImageWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  slug?: InputMaybe<StringFilter>;
+  status?: InputMaybe<StringFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  termEnd?: InputMaybe<DateTimeNullableFilter>;
+  termStart?: InputMaybe<DateTimeNullableFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+  versions?: InputMaybe<AssemblyDistrictVersionManyRelationFilter>;
+};
+
+export type AssemblyDistrictWhereUniqueInput = {
+  currentVersion?: InputMaybe<AssemblyDistrictVersionWhereUniqueInput>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export enum BlueHarvestImageOrderDirection {
+  Asc = 'asc',
+  Desc = 'desc'
+}
+
+export type Board = {
+  __typename?: 'Board';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  communities?: Maybe<Array<Community>>;
+  communitiesCount?: Maybe<Scalars['Int']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  currentVersion?: Maybe<BoardVersion>;
+  description?: Maybe<Scalars['String']['output']>;
+  districts?: Maybe<Array<AssemblyDistrict>>;
+  districtsCount?: Maybe<Scalars['Int']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  drafts?: Maybe<Array<BoardDraft>>;
+  draftsCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  isActive?: Maybe<Scalars['Boolean']['output']>;
+  linkToAgendas?: Maybe<ExternalLink>;
+  linkToPublicOpinionMessage?: Maybe<ExternalLink>;
+  linkToResolutions?: Maybe<ExternalLink>;
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  makeDrafts?: Maybe<Scalars['String']['output']>;
+  meetingSchedule?: Maybe<Scalars['String']['output']>;
+  owner?: Maybe<User>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+  versions?: Maybe<Array<BoardVersion>>;
+  versionsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type BoardActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type BoardActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type BoardCommunitiesArgs = {
+  cursor?: InputMaybe<CommunityWhereUniqueInput>;
+  orderBy?: Array<CommunityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityWhereInput;
+};
+
+
+export type BoardCommunitiesCountArgs = {
+  where?: CommunityWhereInput;
+};
+
+
+export type BoardContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type BoardContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type BoardDistrictsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type BoardDistrictsCountArgs = {
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type BoardDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type BoardDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type BoardDraftsArgs = {
+  cursor?: InputMaybe<BoardDraftWhereUniqueInput>;
+  orderBy?: Array<BoardDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: BoardDraftWhereInput;
+};
+
+
+export type BoardDraftsCountArgs = {
+  where?: BoardDraftWhereInput;
+};
+
+
+export type BoardTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type BoardTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type BoardTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type BoardTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type BoardUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type BoardUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+
+export type BoardVersionsArgs = {
+  cursor?: InputMaybe<BoardVersionWhereUniqueInput>;
+  orderBy?: Array<BoardVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: BoardVersionWhereInput;
+};
+
+
+export type BoardVersionsCountArgs = {
+  where?: BoardVersionWhereInput;
+};
+
+export type BoardCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForCreateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<BoardVersionRelateToOneForCreateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForCreateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  drafts?: InputMaybe<BoardDraftRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  isActive?: InputMaybe<Scalars['Boolean']['input']>;
+  linkToAgendas?: InputMaybe<ExternalLinkRelateToOneForCreateInput>;
+  linkToPublicOpinionMessage?: InputMaybe<ExternalLinkRelateToOneForCreateInput>;
+  linkToResolutions?: InputMaybe<ExternalLinkRelateToOneForCreateInput>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  meetingSchedule?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  type?: InputMaybe<Scalars['String']['input']>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+  versions?: InputMaybe<BoardVersionRelateToManyForCreateInput>;
+};
+
+export type BoardDraft = {
+  __typename?: 'BoardDraft';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  communities?: Maybe<Array<Community>>;
+  communitiesCount?: Maybe<Scalars['Int']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  districts?: Maybe<Array<AssemblyDistrict>>;
+  districtsCount?: Maybe<Scalars['Int']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  isActive?: Maybe<Scalars['Boolean']['output']>;
+  linkToAgendas?: Maybe<ExternalLink>;
+  linkToPublicOpinionMessage?: Maybe<ExternalLink>;
+  linkToResolutions?: Maybe<ExternalLink>;
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  meetingSchedule?: Maybe<Scalars['String']['output']>;
+  original?: Maybe<Board>;
+  owner?: Maybe<User>;
+  publish?: Maybe<Scalars['String']['output']>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type BoardDraftActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type BoardDraftActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type BoardDraftCommunitiesArgs = {
+  cursor?: InputMaybe<CommunityWhereUniqueInput>;
+  orderBy?: Array<CommunityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityWhereInput;
+};
+
+
+export type BoardDraftCommunitiesCountArgs = {
+  where?: CommunityWhereInput;
+};
+
+
+export type BoardDraftContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type BoardDraftContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type BoardDraftDistrictsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type BoardDraftDistrictsCountArgs = {
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type BoardDraftDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type BoardDraftDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type BoardDraftTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type BoardDraftTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type BoardDraftTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type BoardDraftTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type BoardDraftUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type BoardDraftUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type BoardDraftCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForCreateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForCreateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  isActive?: InputMaybe<Scalars['Boolean']['input']>;
+  linkToAgendas?: InputMaybe<ExternalLinkRelateToOneForCreateInput>;
+  linkToPublicOpinionMessage?: InputMaybe<ExternalLinkRelateToOneForCreateInput>;
+  linkToResolutions?: InputMaybe<ExternalLinkRelateToOneForCreateInput>;
+  meetingSchedule?: InputMaybe<Scalars['String']['input']>;
+  original?: InputMaybe<BoardRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  type?: InputMaybe<Scalars['String']['input']>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type BoardDraftManyRelationFilter = {
+  every?: InputMaybe<BoardDraftWhereInput>;
+  none?: InputMaybe<BoardDraftWhereInput>;
+  some?: InputMaybe<BoardDraftWhereInput>;
+};
+
+export type BoardDraftOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  isActive?: InputMaybe<OrderDirection>;
+  meetingSchedule?: InputMaybe<OrderDirection>;
+  publish?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  type?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type BoardDraftRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<BoardDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<BoardDraftCreateInput>>;
+};
+
+export type BoardDraftRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<BoardDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<BoardDraftCreateInput>>;
+  disconnect?: InputMaybe<Array<BoardDraftWhereUniqueInput>>;
+  set?: InputMaybe<Array<BoardDraftWhereUniqueInput>>;
+};
+
+export type BoardDraftUpdateArgs = {
+  data: BoardDraftUpdateInput;
+  where: BoardDraftWhereUniqueInput;
+};
+
+export type BoardDraftUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForUpdateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForUpdateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  isActive?: InputMaybe<Scalars['Boolean']['input']>;
+  linkToAgendas?: InputMaybe<ExternalLinkRelateToOneForUpdateInput>;
+  linkToPublicOpinionMessage?: InputMaybe<ExternalLinkRelateToOneForUpdateInput>;
+  linkToResolutions?: InputMaybe<ExternalLinkRelateToOneForUpdateInput>;
+  meetingSchedule?: InputMaybe<Scalars['String']['input']>;
+  original?: InputMaybe<BoardRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  type?: InputMaybe<Scalars['String']['input']>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type BoardDraftWhereInput = {
+  AND?: InputMaybe<Array<BoardDraftWhereInput>>;
+  NOT?: InputMaybe<Array<BoardDraftWhereInput>>;
+  OR?: InputMaybe<Array<BoardDraftWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  communities?: InputMaybe<CommunityManyRelationFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  districts?: InputMaybe<AssemblyDistrictManyRelationFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  isActive?: InputMaybe<BooleanFilter>;
+  linkToAgendas?: InputMaybe<ExternalLinkWhereInput>;
+  linkToPublicOpinionMessage?: InputMaybe<ExternalLinkWhereInput>;
+  linkToResolutions?: InputMaybe<ExternalLinkWhereInput>;
+  meetingSchedule?: InputMaybe<StringFilter>;
+  original?: InputMaybe<BoardWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  type?: InputMaybe<StringFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type BoardDraftWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type BoardManyRelationFilter = {
+  every?: InputMaybe<BoardWhereInput>;
+  none?: InputMaybe<BoardWhereInput>;
+  some?: InputMaybe<BoardWhereInput>;
+};
+
+export type BoardOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  isActive?: InputMaybe<OrderDirection>;
+  makeDrafts?: InputMaybe<OrderDirection>;
+  meetingSchedule?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  slug?: InputMaybe<OrderDirection>;
+  status?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  type?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type BoardPage = {
+  __typename?: 'BoardPage';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  applicationForm?: Maybe<Document>;
+  body?: Maybe<Scalars['String']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  owner?: Maybe<User>;
+  title?: Maybe<Scalars['String']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  vacancyReport?: Maybe<Document>;
+};
+
+
+export type BoardPageActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type BoardPageActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type BoardPageContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type BoardPageContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type BoardPageDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type BoardPageDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+export type BoardPageCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  applicationForm?: InputMaybe<DocumentRelateToOneForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  vacancyReport?: InputMaybe<DocumentRelateToOneForCreateInput>;
+};
+
+export type BoardPageOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type BoardPageUpdateArgs = {
+  data: BoardPageUpdateInput;
+  where?: BoardPageWhereUniqueInput;
+};
+
+export type BoardPageUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  applicationForm?: InputMaybe<DocumentRelateToOneForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  vacancyReport?: InputMaybe<DocumentRelateToOneForUpdateInput>;
+};
+
+export type BoardPageWhereInput = {
+  AND?: InputMaybe<Array<BoardPageWhereInput>>;
+  NOT?: InputMaybe<Array<BoardPageWhereInput>>;
+  OR?: InputMaybe<Array<BoardPageWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  applicationForm?: InputMaybe<DocumentWhereInput>;
+  body?: InputMaybe<MyStringFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  owner?: InputMaybe<UserWhereInput>;
+  title?: InputMaybe<StringFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  vacancyReport?: InputMaybe<DocumentWhereInput>;
+};
+
+export type BoardPageWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type BoardRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<BoardWhereUniqueInput>>;
+  create?: InputMaybe<Array<BoardCreateInput>>;
+};
+
+export type BoardRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<BoardWhereUniqueInput>>;
+  create?: InputMaybe<Array<BoardCreateInput>>;
+  disconnect?: InputMaybe<Array<BoardWhereUniqueInput>>;
+  set?: InputMaybe<Array<BoardWhereUniqueInput>>;
+};
+
+export type BoardRelateToOneForCreateInput = {
+  connect?: InputMaybe<BoardWhereUniqueInput>;
+  create?: InputMaybe<BoardCreateInput>;
+};
+
+export type BoardRelateToOneForUpdateInput = {
+  connect?: InputMaybe<BoardWhereUniqueInput>;
+  create?: InputMaybe<BoardCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type BoardUpdateArgs = {
+  data: BoardUpdateInput;
+  where: BoardWhereUniqueInput;
+};
+
+export type BoardUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForUpdateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<BoardVersionRelateToOneForUpdateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForUpdateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  drafts?: InputMaybe<BoardDraftRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  isActive?: InputMaybe<Scalars['Boolean']['input']>;
+  linkToAgendas?: InputMaybe<ExternalLinkRelateToOneForUpdateInput>;
+  linkToPublicOpinionMessage?: InputMaybe<ExternalLinkRelateToOneForUpdateInput>;
+  linkToResolutions?: InputMaybe<ExternalLinkRelateToOneForUpdateInput>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  meetingSchedule?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  type?: InputMaybe<Scalars['String']['input']>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+  versions?: InputMaybe<BoardVersionRelateToManyForUpdateInput>;
+};
+
+export type BoardVersion = {
+  __typename?: 'BoardVersion';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  communities?: Maybe<Array<Community>>;
+  communitiesCount?: Maybe<Scalars['Int']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  districts?: Maybe<Array<AssemblyDistrict>>;
+  districtsCount?: Maybe<Scalars['Int']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  isActive?: Maybe<Scalars['Boolean']['output']>;
+  isLive?: Maybe<Board>;
+  linkToAgendas?: Maybe<ExternalLink>;
+  linkToPublicOpinionMessage?: Maybe<ExternalLink>;
+  linkToResolutions?: Maybe<ExternalLink>;
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  meetingSchedule?: Maybe<Scalars['String']['output']>;
+  original?: Maybe<Board>;
+  owner?: Maybe<User>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  republish?: Maybe<Scalars['String']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type BoardVersionActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type BoardVersionActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type BoardVersionCommunitiesArgs = {
+  cursor?: InputMaybe<CommunityWhereUniqueInput>;
+  orderBy?: Array<CommunityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityWhereInput;
+};
+
+
+export type BoardVersionCommunitiesCountArgs = {
+  where?: CommunityWhereInput;
+};
+
+
+export type BoardVersionContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type BoardVersionContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type BoardVersionDistrictsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type BoardVersionDistrictsCountArgs = {
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type BoardVersionDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type BoardVersionDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type BoardVersionTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type BoardVersionTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type BoardVersionTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type BoardVersionTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type BoardVersionUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type BoardVersionUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type BoardVersionCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForCreateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForCreateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  isActive?: InputMaybe<Scalars['Boolean']['input']>;
+  isLive?: InputMaybe<BoardRelateToOneForCreateInput>;
+  linkToAgendas?: InputMaybe<ExternalLinkRelateToOneForCreateInput>;
+  linkToPublicOpinionMessage?: InputMaybe<ExternalLinkRelateToOneForCreateInput>;
+  linkToResolutions?: InputMaybe<ExternalLinkRelateToOneForCreateInput>;
+  meetingSchedule?: InputMaybe<Scalars['String']['input']>;
+  original?: InputMaybe<BoardRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  type?: InputMaybe<Scalars['String']['input']>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type BoardVersionManyRelationFilter = {
+  every?: InputMaybe<BoardVersionWhereInput>;
+  none?: InputMaybe<BoardVersionWhereInput>;
+  some?: InputMaybe<BoardVersionWhereInput>;
+};
+
+export type BoardVersionOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  isActive?: InputMaybe<OrderDirection>;
+  meetingSchedule?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  republish?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  type?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type BoardVersionRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<BoardVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<BoardVersionCreateInput>>;
+};
+
+export type BoardVersionRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<BoardVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<BoardVersionCreateInput>>;
+  disconnect?: InputMaybe<Array<BoardVersionWhereUniqueInput>>;
+  set?: InputMaybe<Array<BoardVersionWhereUniqueInput>>;
+};
+
+export type BoardVersionRelateToOneForCreateInput = {
+  connect?: InputMaybe<BoardVersionWhereUniqueInput>;
+  create?: InputMaybe<BoardVersionCreateInput>;
+};
+
+export type BoardVersionRelateToOneForUpdateInput = {
+  connect?: InputMaybe<BoardVersionWhereUniqueInput>;
+  create?: InputMaybe<BoardVersionCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type BoardVersionUpdateArgs = {
+  data: BoardVersionUpdateInput;
+  where: BoardVersionWhereUniqueInput;
+};
+
+export type BoardVersionUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForUpdateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForUpdateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  isActive?: InputMaybe<Scalars['Boolean']['input']>;
+  isLive?: InputMaybe<BoardRelateToOneForUpdateInput>;
+  linkToAgendas?: InputMaybe<ExternalLinkRelateToOneForUpdateInput>;
+  linkToPublicOpinionMessage?: InputMaybe<ExternalLinkRelateToOneForUpdateInput>;
+  linkToResolutions?: InputMaybe<ExternalLinkRelateToOneForUpdateInput>;
+  meetingSchedule?: InputMaybe<Scalars['String']['input']>;
+  original?: InputMaybe<BoardRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  type?: InputMaybe<Scalars['String']['input']>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type BoardVersionWhereInput = {
+  AND?: InputMaybe<Array<BoardVersionWhereInput>>;
+  NOT?: InputMaybe<Array<BoardVersionWhereInput>>;
+  OR?: InputMaybe<Array<BoardVersionWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  communities?: InputMaybe<CommunityManyRelationFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  districts?: InputMaybe<AssemblyDistrictManyRelationFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  isActive?: InputMaybe<BooleanFilter>;
+  isLive?: InputMaybe<BoardWhereInput>;
+  linkToAgendas?: InputMaybe<ExternalLinkWhereInput>;
+  linkToPublicOpinionMessage?: InputMaybe<ExternalLinkWhereInput>;
+  linkToResolutions?: InputMaybe<ExternalLinkWhereInput>;
+  meetingSchedule?: InputMaybe<StringFilter>;
+  original?: InputMaybe<BoardWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  type?: InputMaybe<StringFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type BoardVersionWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  isLive?: InputMaybe<BoardWhereUniqueInput>;
+};
+
+export type BoardWhereInput = {
+  AND?: InputMaybe<Array<BoardWhereInput>>;
+  NOT?: InputMaybe<Array<BoardWhereInput>>;
+  OR?: InputMaybe<Array<BoardWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  communities?: InputMaybe<CommunityManyRelationFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  currentVersion?: InputMaybe<BoardVersionWhereInput>;
+  description?: InputMaybe<StringFilter>;
+  districts?: InputMaybe<AssemblyDistrictManyRelationFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  drafts?: InputMaybe<BoardDraftManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  isActive?: InputMaybe<BooleanFilter>;
+  linkToAgendas?: InputMaybe<ExternalLinkWhereInput>;
+  linkToPublicOpinionMessage?: InputMaybe<ExternalLinkWhereInput>;
+  linkToResolutions?: InputMaybe<ExternalLinkWhereInput>;
+  meetingSchedule?: InputMaybe<StringFilter>;
+  owner?: InputMaybe<UserWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  slug?: InputMaybe<StringFilter>;
+  status?: InputMaybe<StringFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  type?: InputMaybe<StringFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+  versions?: InputMaybe<BoardVersionManyRelationFilter>;
+};
+
+export type BoardWhereUniqueInput = {
+  currentVersion?: InputMaybe<BoardVersionWhereUniqueInput>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type BooleanFilter = {
+  equals?: InputMaybe<Scalars['Boolean']['input']>;
+  not?: InputMaybe<BooleanFilter>;
+};
+
+export type Community = {
+  __typename?: 'Community';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  boards?: Maybe<Array<Board>>;
+  boardsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  currentVersion?: Maybe<CommunityVersion>;
+  description?: Maybe<Scalars['String']['output']>;
+  districts?: Maybe<Array<AssemblyDistrict>>;
+  districtsCount?: Maybe<Scalars['Int']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  drafts?: Maybe<Array<CommunityDraft>>;
+  draftsCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  makeDrafts?: Maybe<Scalars['String']['output']>;
+  owner?: Maybe<User>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+  versions?: Maybe<Array<CommunityVersion>>;
+  versionsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type CommunityActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type CommunityActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type CommunityBoardsArgs = {
+  cursor?: InputMaybe<BoardWhereUniqueInput>;
+  orderBy?: Array<BoardOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: BoardWhereInput;
+};
+
+
+export type CommunityBoardsCountArgs = {
+  where?: BoardWhereInput;
+};
+
+
+export type CommunityContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type CommunityContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type CommunityDistrictsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type CommunityDistrictsCountArgs = {
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type CommunityDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type CommunityDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type CommunityDraftsArgs = {
+  cursor?: InputMaybe<CommunityDraftWhereUniqueInput>;
+  orderBy?: Array<CommunityDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityDraftWhereInput;
+};
+
+
+export type CommunityDraftsCountArgs = {
+  where?: CommunityDraftWhereInput;
+};
+
+
+export type CommunityServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type CommunityServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type CommunityTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type CommunityTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type CommunityTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type CommunityTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type CommunityUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type CommunityUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+
+export type CommunityVersionsArgs = {
+  cursor?: InputMaybe<CommunityVersionWhereUniqueInput>;
+  orderBy?: Array<CommunityVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityVersionWhereInput;
+};
+
+
+export type CommunityVersionsCountArgs = {
+  where?: CommunityVersionWhereInput;
+};
+
+export type CommunityCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  boards?: InputMaybe<BoardRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<CommunityVersionRelateToOneForCreateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForCreateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  drafts?: InputMaybe<CommunityDraftRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+  versions?: InputMaybe<CommunityVersionRelateToManyForCreateInput>;
+};
+
+export type CommunityDraft = {
+  __typename?: 'CommunityDraft';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  boards?: Maybe<Array<Board>>;
+  boardsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  districts?: Maybe<Array<AssemblyDistrict>>;
+  districtsCount?: Maybe<Scalars['Int']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  original?: Maybe<Community>;
+  owner?: Maybe<User>;
+  publish?: Maybe<Scalars['String']['output']>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type CommunityDraftActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type CommunityDraftActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type CommunityDraftBoardsArgs = {
+  cursor?: InputMaybe<BoardWhereUniqueInput>;
+  orderBy?: Array<BoardOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: BoardWhereInput;
+};
+
+
+export type CommunityDraftBoardsCountArgs = {
+  where?: BoardWhereInput;
+};
+
+
+export type CommunityDraftContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type CommunityDraftContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type CommunityDraftDistrictsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type CommunityDraftDistrictsCountArgs = {
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type CommunityDraftDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type CommunityDraftDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type CommunityDraftServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type CommunityDraftServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type CommunityDraftTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type CommunityDraftTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type CommunityDraftTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type CommunityDraftTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type CommunityDraftUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type CommunityDraftUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type CommunityDraftCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  boards?: InputMaybe<BoardRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForCreateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  original?: InputMaybe<CommunityRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type CommunityDraftManyRelationFilter = {
+  every?: InputMaybe<CommunityDraftWhereInput>;
+  none?: InputMaybe<CommunityDraftWhereInput>;
+  some?: InputMaybe<CommunityDraftWhereInput>;
+};
+
+export type CommunityDraftOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  publish?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type CommunityDraftRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<CommunityDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<CommunityDraftCreateInput>>;
+};
+
+export type CommunityDraftRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<CommunityDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<CommunityDraftCreateInput>>;
+  disconnect?: InputMaybe<Array<CommunityDraftWhereUniqueInput>>;
+  set?: InputMaybe<Array<CommunityDraftWhereUniqueInput>>;
+};
+
+export type CommunityDraftUpdateArgs = {
+  data: CommunityDraftUpdateInput;
+  where: CommunityDraftWhereUniqueInput;
+};
+
+export type CommunityDraftUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  boards?: InputMaybe<BoardRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForUpdateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  original?: InputMaybe<CommunityRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type CommunityDraftWhereInput = {
+  AND?: InputMaybe<Array<CommunityDraftWhereInput>>;
+  NOT?: InputMaybe<Array<CommunityDraftWhereInput>>;
+  OR?: InputMaybe<Array<CommunityDraftWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  boards?: InputMaybe<BoardManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  districts?: InputMaybe<AssemblyDistrictManyRelationFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  original?: InputMaybe<CommunityWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type CommunityDraftWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type CommunityManyRelationFilter = {
+  every?: InputMaybe<CommunityWhereInput>;
+  none?: InputMaybe<CommunityWhereInput>;
+  some?: InputMaybe<CommunityWhereInput>;
+};
+
+export type CommunityOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  makeDrafts?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  slug?: InputMaybe<OrderDirection>;
+  status?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type CommunityRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<CommunityWhereUniqueInput>>;
+  create?: InputMaybe<Array<CommunityCreateInput>>;
+};
+
+export type CommunityRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<CommunityWhereUniqueInput>>;
+  create?: InputMaybe<Array<CommunityCreateInput>>;
+  disconnect?: InputMaybe<Array<CommunityWhereUniqueInput>>;
+  set?: InputMaybe<Array<CommunityWhereUniqueInput>>;
+};
+
+export type CommunityRelateToOneForCreateInput = {
+  connect?: InputMaybe<CommunityWhereUniqueInput>;
+  create?: InputMaybe<CommunityCreateInput>;
+};
+
+export type CommunityRelateToOneForUpdateInput = {
+  connect?: InputMaybe<CommunityWhereUniqueInput>;
+  create?: InputMaybe<CommunityCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type CommunityUpdateArgs = {
+  data: CommunityUpdateInput;
+  where: CommunityWhereUniqueInput;
+};
+
+export type CommunityUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  boards?: InputMaybe<BoardRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<CommunityVersionRelateToOneForUpdateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForUpdateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  drafts?: InputMaybe<CommunityDraftRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+  versions?: InputMaybe<CommunityVersionRelateToManyForUpdateInput>;
+};
+
+export type CommunityVersion = {
+  __typename?: 'CommunityVersion';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  boards?: Maybe<Array<Board>>;
+  boardsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  districts?: Maybe<Array<AssemblyDistrict>>;
+  districtsCount?: Maybe<Scalars['Int']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  isLive?: Maybe<Community>;
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  original?: Maybe<Community>;
+  owner?: Maybe<User>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  republish?: Maybe<Scalars['String']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type CommunityVersionActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type CommunityVersionActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type CommunityVersionBoardsArgs = {
+  cursor?: InputMaybe<BoardWhereUniqueInput>;
+  orderBy?: Array<BoardOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: BoardWhereInput;
+};
+
+
+export type CommunityVersionBoardsCountArgs = {
+  where?: BoardWhereInput;
+};
+
+
+export type CommunityVersionContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type CommunityVersionContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type CommunityVersionDistrictsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type CommunityVersionDistrictsCountArgs = {
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type CommunityVersionDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type CommunityVersionDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type CommunityVersionServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type CommunityVersionServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type CommunityVersionTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type CommunityVersionTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type CommunityVersionTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type CommunityVersionTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type CommunityVersionUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type CommunityVersionUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type CommunityVersionCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  boards?: InputMaybe<BoardRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForCreateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  isLive?: InputMaybe<CommunityRelateToOneForCreateInput>;
+  original?: InputMaybe<CommunityRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type CommunityVersionManyRelationFilter = {
+  every?: InputMaybe<CommunityVersionWhereInput>;
+  none?: InputMaybe<CommunityVersionWhereInput>;
+  some?: InputMaybe<CommunityVersionWhereInput>;
+};
+
+export type CommunityVersionOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  republish?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type CommunityVersionRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<CommunityVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<CommunityVersionCreateInput>>;
+};
+
+export type CommunityVersionRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<CommunityVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<CommunityVersionCreateInput>>;
+  disconnect?: InputMaybe<Array<CommunityVersionWhereUniqueInput>>;
+  set?: InputMaybe<Array<CommunityVersionWhereUniqueInput>>;
+};
+
+export type CommunityVersionRelateToOneForCreateInput = {
+  connect?: InputMaybe<CommunityVersionWhereUniqueInput>;
+  create?: InputMaybe<CommunityVersionCreateInput>;
+};
+
+export type CommunityVersionRelateToOneForUpdateInput = {
+  connect?: InputMaybe<CommunityVersionWhereUniqueInput>;
+  create?: InputMaybe<CommunityVersionCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type CommunityVersionUpdateArgs = {
+  data: CommunityVersionUpdateInput;
+  where: CommunityVersionWhereUniqueInput;
+};
+
+export type CommunityVersionUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  boards?: InputMaybe<BoardRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForUpdateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  isLive?: InputMaybe<CommunityRelateToOneForUpdateInput>;
+  original?: InputMaybe<CommunityRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type CommunityVersionWhereInput = {
+  AND?: InputMaybe<Array<CommunityVersionWhereInput>>;
+  NOT?: InputMaybe<Array<CommunityVersionWhereInput>>;
+  OR?: InputMaybe<Array<CommunityVersionWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  boards?: InputMaybe<BoardManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  districts?: InputMaybe<AssemblyDistrictManyRelationFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  isLive?: InputMaybe<CommunityWhereInput>;
+  original?: InputMaybe<CommunityWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type CommunityVersionWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  isLive?: InputMaybe<CommunityWhereUniqueInput>;
+};
+
+export type CommunityWhereInput = {
+  AND?: InputMaybe<Array<CommunityWhereInput>>;
+  NOT?: InputMaybe<Array<CommunityWhereInput>>;
+  OR?: InputMaybe<Array<CommunityWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  boards?: InputMaybe<BoardManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  currentVersion?: InputMaybe<CommunityVersionWhereInput>;
+  description?: InputMaybe<StringFilter>;
+  districts?: InputMaybe<AssemblyDistrictManyRelationFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  drafts?: InputMaybe<CommunityDraftManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  owner?: InputMaybe<UserWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  slug?: InputMaybe<StringFilter>;
+  status?: InputMaybe<StringFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+  versions?: InputMaybe<CommunityVersionManyRelationFilter>;
+};
+
+export type CommunityWhereUniqueInput = {
+  currentVersion?: InputMaybe<CommunityVersionWhereUniqueInput>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type Contact = {
+  __typename?: 'Contact';
+  email?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  name?: Maybe<Scalars['String']['output']>;
+  phone?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type ContactCreateInput = {
+  email?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  phone?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ContactManyRelationFilter = {
+  every?: InputMaybe<ContactWhereInput>;
+  none?: InputMaybe<ContactWhereInput>;
+  some?: InputMaybe<ContactWhereInput>;
+};
+
+export type ContactOrderByInput = {
+  email?: InputMaybe<OrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  name?: InputMaybe<OrderDirection>;
+  phone?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+};
+
+export type ContactRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<ContactWhereUniqueInput>>;
+  create?: InputMaybe<Array<ContactCreateInput>>;
+};
+
+export type ContactRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<ContactWhereUniqueInput>>;
+  create?: InputMaybe<Array<ContactCreateInput>>;
+  disconnect?: InputMaybe<Array<ContactWhereUniqueInput>>;
+  set?: InputMaybe<Array<ContactWhereUniqueInput>>;
+};
+
+export type ContactRelateToOneForCreateInput = {
+  connect?: InputMaybe<ContactWhereUniqueInput>;
+  create?: InputMaybe<ContactCreateInput>;
+};
+
+export type ContactRelateToOneForUpdateInput = {
+  connect?: InputMaybe<ContactWhereUniqueInput>;
+  create?: InputMaybe<ContactCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type ContactUpdateArgs = {
+  data: ContactUpdateInput;
+  where: ContactWhereUniqueInput;
+};
+
+export type ContactUpdateInput = {
+  email?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  phone?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ContactWhereInput = {
+  AND?: InputMaybe<Array<ContactWhereInput>>;
+  NOT?: InputMaybe<Array<ContactWhereInput>>;
+  OR?: InputMaybe<Array<ContactWhereInput>>;
+  email?: InputMaybe<StringNullableFilter>;
+  id?: InputMaybe<IdFilter>;
+  name?: InputMaybe<StringFilter>;
+  phone?: InputMaybe<StringNullableFilter>;
+  title?: InputMaybe<StringNullableFilter>;
+};
+
+export type ContactWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type DateTimeNullableFilter = {
+  equals?: InputMaybe<Scalars['DateTime']['input']>;
+  gt?: InputMaybe<Scalars['DateTime']['input']>;
+  gte?: InputMaybe<Scalars['DateTime']['input']>;
+  in?: InputMaybe<Array<Scalars['DateTime']['input']>>;
+  lt?: InputMaybe<Scalars['DateTime']['input']>;
+  lte?: InputMaybe<Scalars['DateTime']['input']>;
+  not?: InputMaybe<DateTimeNullableFilter>;
+  notIn?: InputMaybe<Array<Scalars['DateTime']['input']>>;
+};
+
+export type Document = {
+  __typename?: 'Document';
+  collections?: Maybe<Array<DocumentCollection>>;
+  collectionsCount?: Maybe<Scalars['Int']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  editorNotes?: Maybe<Scalars['String']['output']>;
+  file?: Maybe<FileFieldOutput>;
+  id: Scalars['ID']['output'];
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type DocumentCollectionsArgs = {
+  cursor?: InputMaybe<DocumentCollectionWhereUniqueInput>;
+  orderBy?: Array<DocumentCollectionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentCollectionWhereInput;
+};
+
+
+export type DocumentCollectionsCountArgs = {
+  where?: DocumentCollectionWhereInput;
+};
+
+
+export type DocumentTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type DocumentTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+export type DocumentCollection = {
+  __typename?: 'DocumentCollection';
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  editorNotes?: Maybe<Scalars['String']['output']>;
+  embed?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  owner?: Maybe<User>;
+  referencedBy?: Maybe<Array<Maybe<Service>>>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type DocumentCollectionDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type DocumentCollectionDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type DocumentCollectionTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type DocumentCollectionTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type DocumentCollectionUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type DocumentCollectionUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type DocumentCollectionCreateInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  editorNotes?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type DocumentCollectionManyRelationFilter = {
+  every?: InputMaybe<DocumentCollectionWhereInput>;
+  none?: InputMaybe<DocumentCollectionWhereInput>;
+  some?: InputMaybe<DocumentCollectionWhereInput>;
+};
+
+export type DocumentCollectionOrderByInput = {
+  description?: InputMaybe<OrderDirection>;
+  editorNotes?: InputMaybe<OrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+};
+
+export type DocumentCollectionRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<DocumentCollectionWhereUniqueInput>>;
+  create?: InputMaybe<Array<DocumentCollectionCreateInput>>;
+};
+
+export type DocumentCollectionRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<DocumentCollectionWhereUniqueInput>>;
+  create?: InputMaybe<Array<DocumentCollectionCreateInput>>;
+  disconnect?: InputMaybe<Array<DocumentCollectionWhereUniqueInput>>;
+  set?: InputMaybe<Array<DocumentCollectionWhereUniqueInput>>;
+};
+
+export type DocumentCollectionUpdateArgs = {
+  data: DocumentCollectionUpdateInput;
+  where: DocumentCollectionWhereUniqueInput;
+};
+
+export type DocumentCollectionUpdateInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  editorNotes?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type DocumentCollectionWhereInput = {
+  AND?: InputMaybe<Array<DocumentCollectionWhereInput>>;
+  NOT?: InputMaybe<Array<DocumentCollectionWhereInput>>;
+  OR?: InputMaybe<Array<DocumentCollectionWhereInput>>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  editorNotes?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  owner?: InputMaybe<UserWhereInput>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type DocumentCollectionWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type DocumentCreateInput = {
+  collections?: InputMaybe<DocumentCollectionRelateToManyForCreateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  editorNotes?: InputMaybe<Scalars['String']['input']>;
+  file?: InputMaybe<FileFieldInput>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type DocumentManyRelationFilter = {
+  every?: InputMaybe<DocumentWhereInput>;
+  none?: InputMaybe<DocumentWhereInput>;
+  some?: InputMaybe<DocumentWhereInput>;
+};
+
+export type DocumentOrderByInput = {
+  description?: InputMaybe<OrderDirection>;
+  editorNotes?: InputMaybe<OrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+};
+
+export type DocumentRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<DocumentWhereUniqueInput>>;
+  create?: InputMaybe<Array<DocumentCreateInput>>;
+};
+
+export type DocumentRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<DocumentWhereUniqueInput>>;
+  create?: InputMaybe<Array<DocumentCreateInput>>;
+  disconnect?: InputMaybe<Array<DocumentWhereUniqueInput>>;
+  set?: InputMaybe<Array<DocumentWhereUniqueInput>>;
+};
+
+export type DocumentRelateToOneForCreateInput = {
+  connect?: InputMaybe<DocumentWhereUniqueInput>;
+  create?: InputMaybe<DocumentCreateInput>;
+};
+
+export type DocumentRelateToOneForUpdateInput = {
+  connect?: InputMaybe<DocumentWhereUniqueInput>;
+  create?: InputMaybe<DocumentCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type DocumentUpdateArgs = {
+  data: DocumentUpdateInput;
+  where: DocumentWhereUniqueInput;
+};
+
+export type DocumentUpdateInput = {
+  collections?: InputMaybe<DocumentCollectionRelateToManyForUpdateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  editorNotes?: InputMaybe<Scalars['String']['input']>;
+  file?: InputMaybe<FileFieldInput>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type DocumentWhereInput = {
+  AND?: InputMaybe<Array<DocumentWhereInput>>;
+  NOT?: InputMaybe<Array<DocumentWhereInput>>;
+  OR?: InputMaybe<Array<DocumentWhereInput>>;
+  collections?: InputMaybe<DocumentCollectionManyRelationFilter>;
+  description?: InputMaybe<StringFilter>;
+  editorNotes?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+};
+
+export type DocumentWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type ExternalLink = {
+  __typename?: 'ExternalLink';
+  id: Scalars['ID']['output'];
+  label?: Maybe<Scalars['String']['output']>;
+  url?: Maybe<Url>;
+};
+
+export type ExternalLinkCreateInput = {
+  label?: InputMaybe<Scalars['String']['input']>;
+  url?: InputMaybe<UrlRelateToOneForCreateInput>;
+};
+
+export type ExternalLinkManyRelationFilter = {
+  every?: InputMaybe<ExternalLinkWhereInput>;
+  none?: InputMaybe<ExternalLinkWhereInput>;
+  some?: InputMaybe<ExternalLinkWhereInput>;
+};
+
+export type ExternalLinkOrderByInput = {
+  id?: InputMaybe<OrderDirection>;
+  label?: InputMaybe<OrderDirection>;
+};
+
+export type ExternalLinkRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<ExternalLinkWhereUniqueInput>>;
+  create?: InputMaybe<Array<ExternalLinkCreateInput>>;
+};
+
+export type ExternalLinkRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<ExternalLinkWhereUniqueInput>>;
+  create?: InputMaybe<Array<ExternalLinkCreateInput>>;
+  disconnect?: InputMaybe<Array<ExternalLinkWhereUniqueInput>>;
+  set?: InputMaybe<Array<ExternalLinkWhereUniqueInput>>;
+};
+
+export type ExternalLinkRelateToOneForCreateInput = {
+  connect?: InputMaybe<ExternalLinkWhereUniqueInput>;
+  create?: InputMaybe<ExternalLinkCreateInput>;
+};
+
+export type ExternalLinkRelateToOneForUpdateInput = {
+  connect?: InputMaybe<ExternalLinkWhereUniqueInput>;
+  create?: InputMaybe<ExternalLinkCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type ExternalLinkUpdateArgs = {
+  data: ExternalLinkUpdateInput;
+  where: ExternalLinkWhereUniqueInput;
+};
+
+export type ExternalLinkUpdateInput = {
+  label?: InputMaybe<Scalars['String']['input']>;
+  url?: InputMaybe<UrlRelateToOneForUpdateInput>;
+};
+
+export type ExternalLinkWhereInput = {
+  AND?: InputMaybe<Array<ExternalLinkWhereInput>>;
+  NOT?: InputMaybe<Array<ExternalLinkWhereInput>>;
+  OR?: InputMaybe<Array<ExternalLinkWhereInput>>;
+  id?: InputMaybe<IdFilter>;
+  label?: InputMaybe<StringFilter>;
+  url?: InputMaybe<UrlWhereInput>;
+};
+
+export type ExternalLinkWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type Facility = {
+  __typename?: 'Facility';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  address?: Maybe<Location>;
+  body?: Maybe<Scalars['String']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  currentVersion?: Maybe<FacilityVersion>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  drafts?: Maybe<Array<FacilityDraft>>;
+  draftsCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  hours?: Maybe<Array<OperatingHour>>;
+  hoursCount?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  makeDrafts?: Maybe<Scalars['String']['output']>;
+  owner?: Maybe<User>;
+  park?: Maybe<Park>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+  versions?: Maybe<Array<FacilityVersion>>;
+  versionsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type FacilityActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type FacilityActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type FacilityContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type FacilityContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type FacilityDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type FacilityDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type FacilityDraftsArgs = {
+  cursor?: InputMaybe<FacilityDraftWhereUniqueInput>;
+  orderBy?: Array<FacilityDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityDraftWhereInput;
+};
+
+
+export type FacilityDraftsCountArgs = {
+  where?: FacilityDraftWhereInput;
+};
+
+
+export type FacilityHoursArgs = {
+  cursor?: InputMaybe<OperatingHourWhereUniqueInput>;
+  orderBy?: Array<OperatingHourOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OperatingHourWhereInput;
+};
+
+
+export type FacilityHoursCountArgs = {
+  where?: OperatingHourWhereInput;
+};
+
+
+export type FacilityServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type FacilityServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type FacilityTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type FacilityTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type FacilityTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type FacilityTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type FacilityUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type FacilityUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+
+export type FacilityVersionsArgs = {
+  cursor?: InputMaybe<FacilityVersionWhereUniqueInput>;
+  orderBy?: Array<FacilityVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityVersionWhereInput;
+};
+
+
+export type FacilityVersionsCountArgs = {
+  where?: FacilityVersionWhereInput;
+};
+
+export type FacilityCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  address?: InputMaybe<LocationRelateToOneForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<FacilityVersionRelateToOneForCreateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  drafts?: InputMaybe<FacilityDraftRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hours?: InputMaybe<OperatingHourRelateToManyForCreateInput>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  park?: InputMaybe<ParkRelateToOneForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+  versions?: InputMaybe<FacilityVersionRelateToManyForCreateInput>;
+};
+
+export type FacilityDraft = {
+  __typename?: 'FacilityDraft';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  address?: Maybe<Location>;
+  body?: Maybe<Scalars['String']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  hours?: Maybe<Array<OperatingHour>>;
+  hoursCount?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  original?: Maybe<Facility>;
+  owner?: Maybe<User>;
+  park?: Maybe<Park>;
+  publish?: Maybe<Scalars['String']['output']>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type FacilityDraftActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type FacilityDraftActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type FacilityDraftContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type FacilityDraftContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type FacilityDraftDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type FacilityDraftDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type FacilityDraftHoursArgs = {
+  cursor?: InputMaybe<OperatingHourWhereUniqueInput>;
+  orderBy?: Array<OperatingHourOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OperatingHourWhereInput;
+};
+
+
+export type FacilityDraftHoursCountArgs = {
+  where?: OperatingHourWhereInput;
+};
+
+
+export type FacilityDraftServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type FacilityDraftServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type FacilityDraftTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type FacilityDraftTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type FacilityDraftTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type FacilityDraftTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type FacilityDraftUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type FacilityDraftUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type FacilityDraftCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  address?: InputMaybe<LocationRelateToOneForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hours?: InputMaybe<OperatingHourRelateToManyForCreateInput>;
+  original?: InputMaybe<FacilityRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  park?: InputMaybe<ParkRelateToOneForCreateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type FacilityDraftManyRelationFilter = {
+  every?: InputMaybe<FacilityDraftWhereInput>;
+  none?: InputMaybe<FacilityDraftWhereInput>;
+  some?: InputMaybe<FacilityDraftWhereInput>;
+};
+
+export type FacilityDraftOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  publish?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type FacilityDraftRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<FacilityDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<FacilityDraftCreateInput>>;
+};
+
+export type FacilityDraftRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<FacilityDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<FacilityDraftCreateInput>>;
+  disconnect?: InputMaybe<Array<FacilityDraftWhereUniqueInput>>;
+  set?: InputMaybe<Array<FacilityDraftWhereUniqueInput>>;
+};
+
+export type FacilityDraftUpdateArgs = {
+  data: FacilityDraftUpdateInput;
+  where: FacilityDraftWhereUniqueInput;
+};
+
+export type FacilityDraftUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  address?: InputMaybe<LocationRelateToOneForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hours?: InputMaybe<OperatingHourRelateToManyForUpdateInput>;
+  original?: InputMaybe<FacilityRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  park?: InputMaybe<ParkRelateToOneForUpdateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type FacilityDraftWhereInput = {
+  AND?: InputMaybe<Array<FacilityDraftWhereInput>>;
+  NOT?: InputMaybe<Array<FacilityDraftWhereInput>>;
+  OR?: InputMaybe<Array<FacilityDraftWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  address?: InputMaybe<LocationWhereInput>;
+  body?: InputMaybe<MyStringFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  hours?: InputMaybe<OperatingHourManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  original?: InputMaybe<FacilityWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  park?: InputMaybe<ParkWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type FacilityDraftWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type FacilityManyRelationFilter = {
+  every?: InputMaybe<FacilityWhereInput>;
+  none?: InputMaybe<FacilityWhereInput>;
+  some?: InputMaybe<FacilityWhereInput>;
+};
+
+export type FacilityOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  makeDrafts?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  slug?: InputMaybe<OrderDirection>;
+  status?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type FacilityRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<FacilityWhereUniqueInput>>;
+  create?: InputMaybe<Array<FacilityCreateInput>>;
+};
+
+export type FacilityRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<FacilityWhereUniqueInput>>;
+  create?: InputMaybe<Array<FacilityCreateInput>>;
+  disconnect?: InputMaybe<Array<FacilityWhereUniqueInput>>;
+  set?: InputMaybe<Array<FacilityWhereUniqueInput>>;
+};
+
+export type FacilityRelateToOneForCreateInput = {
+  connect?: InputMaybe<FacilityWhereUniqueInput>;
+  create?: InputMaybe<FacilityCreateInput>;
+};
+
+export type FacilityRelateToOneForUpdateInput = {
+  connect?: InputMaybe<FacilityWhereUniqueInput>;
+  create?: InputMaybe<FacilityCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type FacilityUpdateArgs = {
+  data: FacilityUpdateInput;
+  where: FacilityWhereUniqueInput;
+};
+
+export type FacilityUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  address?: InputMaybe<LocationRelateToOneForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<FacilityVersionRelateToOneForUpdateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  drafts?: InputMaybe<FacilityDraftRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hours?: InputMaybe<OperatingHourRelateToManyForUpdateInput>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  park?: InputMaybe<ParkRelateToOneForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+  versions?: InputMaybe<FacilityVersionRelateToManyForUpdateInput>;
+};
+
+export type FacilityVersion = {
+  __typename?: 'FacilityVersion';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  address?: Maybe<Location>;
+  body?: Maybe<Scalars['String']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  hours?: Maybe<Array<OperatingHour>>;
+  hoursCount?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  isLive?: Maybe<Facility>;
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  original?: Maybe<Facility>;
+  owner?: Maybe<User>;
+  park?: Maybe<Park>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  republish?: Maybe<Scalars['String']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type FacilityVersionActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type FacilityVersionActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type FacilityVersionContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type FacilityVersionContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type FacilityVersionDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type FacilityVersionDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type FacilityVersionHoursArgs = {
+  cursor?: InputMaybe<OperatingHourWhereUniqueInput>;
+  orderBy?: Array<OperatingHourOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OperatingHourWhereInput;
+};
+
+
+export type FacilityVersionHoursCountArgs = {
+  where?: OperatingHourWhereInput;
+};
+
+
+export type FacilityVersionServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type FacilityVersionServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type FacilityVersionTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type FacilityVersionTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type FacilityVersionTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type FacilityVersionTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type FacilityVersionUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type FacilityVersionUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type FacilityVersionCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  address?: InputMaybe<LocationRelateToOneForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hours?: InputMaybe<OperatingHourRelateToManyForCreateInput>;
+  isLive?: InputMaybe<FacilityRelateToOneForCreateInput>;
+  original?: InputMaybe<FacilityRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  park?: InputMaybe<ParkRelateToOneForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type FacilityVersionManyRelationFilter = {
+  every?: InputMaybe<FacilityVersionWhereInput>;
+  none?: InputMaybe<FacilityVersionWhereInput>;
+  some?: InputMaybe<FacilityVersionWhereInput>;
+};
+
+export type FacilityVersionOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  republish?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type FacilityVersionRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<FacilityVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<FacilityVersionCreateInput>>;
+};
+
+export type FacilityVersionRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<FacilityVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<FacilityVersionCreateInput>>;
+  disconnect?: InputMaybe<Array<FacilityVersionWhereUniqueInput>>;
+  set?: InputMaybe<Array<FacilityVersionWhereUniqueInput>>;
+};
+
+export type FacilityVersionRelateToOneForCreateInput = {
+  connect?: InputMaybe<FacilityVersionWhereUniqueInput>;
+  create?: InputMaybe<FacilityVersionCreateInput>;
+};
+
+export type FacilityVersionRelateToOneForUpdateInput = {
+  connect?: InputMaybe<FacilityVersionWhereUniqueInput>;
+  create?: InputMaybe<FacilityVersionCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type FacilityVersionUpdateArgs = {
+  data: FacilityVersionUpdateInput;
+  where: FacilityVersionWhereUniqueInput;
+};
+
+export type FacilityVersionUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  address?: InputMaybe<LocationRelateToOneForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hours?: InputMaybe<OperatingHourRelateToManyForUpdateInput>;
+  isLive?: InputMaybe<FacilityRelateToOneForUpdateInput>;
+  original?: InputMaybe<FacilityRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  park?: InputMaybe<ParkRelateToOneForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type FacilityVersionWhereInput = {
+  AND?: InputMaybe<Array<FacilityVersionWhereInput>>;
+  NOT?: InputMaybe<Array<FacilityVersionWhereInput>>;
+  OR?: InputMaybe<Array<FacilityVersionWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  address?: InputMaybe<LocationWhereInput>;
+  body?: InputMaybe<MyStringFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  hours?: InputMaybe<OperatingHourManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  isLive?: InputMaybe<FacilityWhereInput>;
+  original?: InputMaybe<FacilityWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  park?: InputMaybe<ParkWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type FacilityVersionWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  isLive?: InputMaybe<FacilityWhereUniqueInput>;
+};
+
+export type FacilityWhereInput = {
+  AND?: InputMaybe<Array<FacilityWhereInput>>;
+  NOT?: InputMaybe<Array<FacilityWhereInput>>;
+  OR?: InputMaybe<Array<FacilityWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  address?: InputMaybe<LocationWhereInput>;
+  body?: InputMaybe<MyStringFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  currentVersion?: InputMaybe<FacilityVersionWhereInput>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  drafts?: InputMaybe<FacilityDraftManyRelationFilter>;
+  hours?: InputMaybe<OperatingHourManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  owner?: InputMaybe<UserWhereInput>;
+  park?: InputMaybe<ParkWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  slug?: InputMaybe<StringFilter>;
+  status?: InputMaybe<StringFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+  versions?: InputMaybe<FacilityVersionManyRelationFilter>;
+};
+
+export type FacilityWhereUniqueInput = {
+  currentVersion?: InputMaybe<FacilityVersionWhereUniqueInput>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type FileFieldInput = {
+  upload: Scalars['Upload']['input'];
+};
+
+export type FileFieldOutput = {
+  __typename?: 'FileFieldOutput';
+  filename: Scalars['String']['output'];
+  filesize: Scalars['Int']['output'];
+  url: Scalars['String']['output'];
+};
+
+export type Highlight = {
+  __typename?: 'Highlight';
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  editorNotes?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  image?: Maybe<Scalars['String']['output']>;
+  linkedItem?: Maybe<InternalLink>;
+  message?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+};
+
+export type HighlightCreateInput = {
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  editorNotes?: InputMaybe<Scalars['String']['input']>;
+  image?: InputMaybe<Scalars['String']['input']>;
+  linkedItem?: InputMaybe<InternalLinkRelateToOneForCreateInput>;
+  message?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+export type HighlightManyRelationFilter = {
+  every?: InputMaybe<HighlightWhereInput>;
+  none?: InputMaybe<HighlightWhereInput>;
+  some?: InputMaybe<HighlightWhereInput>;
+};
+
+export type HighlightOrderByInput = {
+  createdAt?: InputMaybe<OrderDirection>;
+  editorNotes?: InputMaybe<OrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  image?: InputMaybe<BlueHarvestImageOrderDirection>;
+  message?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type HighlightRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<HighlightWhereUniqueInput>>;
+  create?: InputMaybe<Array<HighlightCreateInput>>;
+};
+
+export type HighlightRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<HighlightWhereUniqueInput>>;
+  create?: InputMaybe<Array<HighlightCreateInput>>;
+  disconnect?: InputMaybe<Array<HighlightWhereUniqueInput>>;
+  set?: InputMaybe<Array<HighlightWhereUniqueInput>>;
+};
+
+export type HighlightRelateToOneForCreateInput = {
+  connect?: InputMaybe<HighlightWhereUniqueInput>;
+  create?: InputMaybe<HighlightCreateInput>;
+};
+
+export type HighlightRelateToOneForUpdateInput = {
+  connect?: InputMaybe<HighlightWhereUniqueInput>;
+  create?: InputMaybe<HighlightCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type HighlightUpdateArgs = {
+  data: HighlightUpdateInput;
+  where: HighlightWhereUniqueInput;
+};
+
+export type HighlightUpdateInput = {
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  editorNotes?: InputMaybe<Scalars['String']['input']>;
+  image?: InputMaybe<Scalars['String']['input']>;
+  linkedItem?: InputMaybe<InternalLinkRelateToOneForUpdateInput>;
+  message?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+export type HighlightWhereInput = {
+  AND?: InputMaybe<Array<HighlightWhereInput>>;
+  NOT?: InputMaybe<Array<HighlightWhereInput>>;
+  OR?: InputMaybe<Array<HighlightWhereInput>>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  editorNotes?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  linkedItem?: InputMaybe<InternalLinkWhereInput>;
+  message?: InputMaybe<StringFilter>;
+  title?: InputMaybe<StringFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+};
+
+export type HighlightWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type HomePage = {
+  __typename?: 'HomePage';
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  highlightOne?: Maybe<Highlight>;
+  highlightThree?: Maybe<Highlight>;
+  highlightTwo?: Maybe<Highlight>;
+  id: Scalars['ID']['output'];
+  title?: Maybe<Scalars['String']['output']>;
+  toolbeltFour?: Maybe<Highlight>;
+  toolbeltOne?: Maybe<Highlight>;
+  toolbeltThree?: Maybe<Highlight>;
+  toolbeltTwo?: Maybe<Highlight>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+};
+
+export type HomePageCreateInput = {
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  highlightOne?: InputMaybe<HighlightRelateToOneForCreateInput>;
+  highlightThree?: InputMaybe<HighlightRelateToOneForCreateInput>;
+  highlightTwo?: InputMaybe<HighlightRelateToOneForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  toolbeltFour?: InputMaybe<HighlightRelateToOneForCreateInput>;
+  toolbeltOne?: InputMaybe<HighlightRelateToOneForCreateInput>;
+  toolbeltThree?: InputMaybe<HighlightRelateToOneForCreateInput>;
+  toolbeltTwo?: InputMaybe<HighlightRelateToOneForCreateInput>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+export type HomePageOrderByInput = {
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type HomePageUpdateArgs = {
+  data: HomePageUpdateInput;
+  where?: HomePageWhereUniqueInput;
+};
+
+export type HomePageUpdateInput = {
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  highlightOne?: InputMaybe<HighlightRelateToOneForUpdateInput>;
+  highlightThree?: InputMaybe<HighlightRelateToOneForUpdateInput>;
+  highlightTwo?: InputMaybe<HighlightRelateToOneForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  toolbeltFour?: InputMaybe<HighlightRelateToOneForUpdateInput>;
+  toolbeltOne?: InputMaybe<HighlightRelateToOneForUpdateInput>;
+  toolbeltThree?: InputMaybe<HighlightRelateToOneForUpdateInput>;
+  toolbeltTwo?: InputMaybe<HighlightRelateToOneForUpdateInput>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+export type HomePageWhereInput = {
+  AND?: InputMaybe<Array<HomePageWhereInput>>;
+  NOT?: InputMaybe<Array<HomePageWhereInput>>;
+  OR?: InputMaybe<Array<HomePageWhereInput>>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  highlightOne?: InputMaybe<HighlightWhereInput>;
+  highlightThree?: InputMaybe<HighlightWhereInput>;
+  highlightTwo?: InputMaybe<HighlightWhereInput>;
+  id?: InputMaybe<IdFilter>;
+  title?: InputMaybe<StringFilter>;
+  toolbeltFour?: InputMaybe<HighlightWhereInput>;
+  toolbeltOne?: InputMaybe<HighlightWhereInput>;
+  toolbeltThree?: InputMaybe<HighlightWhereInput>;
+  toolbeltTwo?: InputMaybe<HighlightWhereInput>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+};
+
+export type HomePageWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type IdFilter = {
+  equals?: InputMaybe<Scalars['ID']['input']>;
+  gt?: InputMaybe<Scalars['ID']['input']>;
+  gte?: InputMaybe<Scalars['ID']['input']>;
+  in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  lt?: InputMaybe<Scalars['ID']['input']>;
+  lte?: InputMaybe<Scalars['ID']['input']>;
+  not?: InputMaybe<IdFilter>;
+  notIn?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type Image = {
+  __typename?: 'Image';
+  description?: Maybe<Scalars['String']['output']>;
+  file?: Maybe<ImageFieldOutput>;
+  id: Scalars['ID']['output'];
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type ImageTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type ImageTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+export type ImageCreateInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  file?: InputMaybe<ImageFieldInput>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export enum ImageExtension {
+  Gif = 'gif',
+  Jpg = 'jpg',
+  Png = 'png',
+  Webp = 'webp'
+}
+
+export type ImageFieldInput = {
+  upload: Scalars['Upload']['input'];
+};
+
+export type ImageFieldOutput = {
+  __typename?: 'ImageFieldOutput';
+  extension: ImageExtension;
+  filesize: Scalars['Int']['output'];
+  height: Scalars['Int']['output'];
+  id: Scalars['ID']['output'];
+  url: Scalars['String']['output'];
+  width: Scalars['Int']['output'];
+};
+
+export type ImageOrderByInput = {
+  description?: InputMaybe<OrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+};
+
+export type ImageRelateToOneForCreateInput = {
+  connect?: InputMaybe<ImageWhereUniqueInput>;
+  create?: InputMaybe<ImageCreateInput>;
+};
+
+export type ImageRelateToOneForUpdateInput = {
+  connect?: InputMaybe<ImageWhereUniqueInput>;
+  create?: InputMaybe<ImageCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type ImageUpdateArgs = {
+  data: ImageUpdateInput;
+  where: ImageWhereUniqueInput;
+};
+
+export type ImageUpdateInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  file?: InputMaybe<ImageFieldInput>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ImageWhereInput = {
+  AND?: InputMaybe<Array<ImageWhereInput>>;
+  NOT?: InputMaybe<Array<ImageWhereInput>>;
+  OR?: InputMaybe<Array<ImageWhereInput>>;
+  description?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+};
+
+export type ImageWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type IntFilter = {
+  equals?: InputMaybe<Scalars['Int']['input']>;
+  gt?: InputMaybe<Scalars['Int']['input']>;
+  gte?: InputMaybe<Scalars['Int']['input']>;
+  in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  lt?: InputMaybe<Scalars['Int']['input']>;
+  lte?: InputMaybe<Scalars['Int']['input']>;
+  not?: InputMaybe<IntFilter>;
+  notIn?: InputMaybe<Array<Scalars['Int']['input']>>;
+};
+
+export type IntNullableFilter = {
+  equals?: InputMaybe<Scalars['Int']['input']>;
+  gt?: InputMaybe<Scalars['Int']['input']>;
+  gte?: InputMaybe<Scalars['Int']['input']>;
+  in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  lt?: InputMaybe<Scalars['Int']['input']>;
+  lte?: InputMaybe<Scalars['Int']['input']>;
+  not?: InputMaybe<IntNullableFilter>;
+  notIn?: InputMaybe<Array<Scalars['Int']['input']>>;
+};
+
+export type InternalLink = {
+  __typename?: 'InternalLink';
+  id: Scalars['ID']['output'];
+  item?: Maybe<LinkedItemUnion>;
+  label?: Maybe<Scalars['String']['output']>;
+  selectItem?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type InternalLinkCreateInput = {
+  label?: InputMaybe<Scalars['String']['input']>;
+  selectItem?: InputMaybe<Scalars['JSON']['input']>;
+};
+
+export type InternalLinkManyRelationFilter = {
+  every?: InputMaybe<InternalLinkWhereInput>;
+  none?: InputMaybe<InternalLinkWhereInput>;
+  some?: InputMaybe<InternalLinkWhereInput>;
+};
+
+export type InternalLinkOrderByInput = {
+  id?: InputMaybe<OrderDirection>;
+  label?: InputMaybe<OrderDirection>;
+};
+
+export type InternalLinkRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<InternalLinkWhereUniqueInput>>;
+  create?: InputMaybe<Array<InternalLinkCreateInput>>;
+};
+
+export type InternalLinkRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<InternalLinkWhereUniqueInput>>;
+  create?: InputMaybe<Array<InternalLinkCreateInput>>;
+  disconnect?: InputMaybe<Array<InternalLinkWhereUniqueInput>>;
+  set?: InputMaybe<Array<InternalLinkWhereUniqueInput>>;
+};
+
+export type InternalLinkRelateToOneForCreateInput = {
+  connect?: InputMaybe<InternalLinkWhereUniqueInput>;
+  create?: InputMaybe<InternalLinkCreateInput>;
+};
+
+export type InternalLinkRelateToOneForUpdateInput = {
+  connect?: InputMaybe<InternalLinkWhereUniqueInput>;
+  create?: InputMaybe<InternalLinkCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type InternalLinkSearch = AssemblyDistrict | Board | BoardPage | Community | Facility | HomePage | OrgUnit | Park | PublicNotice | Service | Trail | Url;
+
+export type InternalLinkUpdateArgs = {
+  data: InternalLinkUpdateInput;
+  where: InternalLinkWhereUniqueInput;
+};
+
+export type InternalLinkUpdateInput = {
+  label?: InputMaybe<Scalars['String']['input']>;
+  selectItem?: InputMaybe<Scalars['JSON']['input']>;
+};
+
+export type InternalLinkWhereInput = {
+  AND?: InputMaybe<Array<InternalLinkWhereInput>>;
+  NOT?: InputMaybe<Array<InternalLinkWhereInput>>;
+  OR?: InputMaybe<Array<InternalLinkWhereInput>>;
+  id?: InputMaybe<IdFilter>;
+  label?: InputMaybe<StringFilter>;
+};
+
+export type InternalLinkWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type KeystoneAdminMeta = {
+  __typename?: 'KeystoneAdminMeta';
+  list?: Maybe<KeystoneAdminUiListMeta>;
+  lists: Array<KeystoneAdminUiListMeta>;
+};
+
+
+export type KeystoneAdminMetaListArgs = {
+  key: Scalars['String']['input'];
+};
+
+export type KeystoneAdminUiFieldGroupMeta = {
+  __typename?: 'KeystoneAdminUIFieldGroupMeta';
+  description?: Maybe<Scalars['String']['output']>;
+  fields: Array<KeystoneAdminUiFieldMeta>;
+  label: Scalars['String']['output'];
+};
+
+export type KeystoneAdminUiFieldMeta = {
+  __typename?: 'KeystoneAdminUIFieldMeta';
+  createView: KeystoneAdminUiFieldMetaCreateView;
+  customViewsIndex?: Maybe<Scalars['Int']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  fieldMeta?: Maybe<Scalars['JSON']['output']>;
+  isFilterable: Scalars['Boolean']['output'];
+  isNonNull?: Maybe<Array<KeystoneAdminUiFieldMetaIsNonNull>>;
+  isOrderable: Scalars['Boolean']['output'];
+  itemView?: Maybe<KeystoneAdminUiFieldMetaItemView>;
+  label: Scalars['String']['output'];
+  listView: KeystoneAdminUiFieldMetaListView;
+  path: Scalars['String']['output'];
+  search?: Maybe<QueryMode>;
+  viewsIndex: Scalars['Int']['output'];
+};
+
+
+export type KeystoneAdminUiFieldMetaItemViewArgs = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type KeystoneAdminUiFieldMetaCreateView = {
+  __typename?: 'KeystoneAdminUIFieldMetaCreateView';
+  fieldMode: KeystoneAdminUiFieldMetaCreateViewFieldMode;
+};
+
+export enum KeystoneAdminUiFieldMetaCreateViewFieldMode {
+  Edit = 'edit',
+  Hidden = 'hidden'
+}
+
+export enum KeystoneAdminUiFieldMetaIsNonNull {
+  Create = 'create',
+  Read = 'read',
+  Update = 'update'
+}
+
+export type KeystoneAdminUiFieldMetaItemView = {
+  __typename?: 'KeystoneAdminUIFieldMetaItemView';
+  fieldMode?: Maybe<KeystoneAdminUiFieldMetaItemViewFieldMode>;
+  fieldPosition?: Maybe<KeystoneAdminUiFieldMetaItemViewFieldPosition>;
+};
+
+export enum KeystoneAdminUiFieldMetaItemViewFieldMode {
+  Edit = 'edit',
+  Hidden = 'hidden',
+  Read = 'read'
+}
+
+export enum KeystoneAdminUiFieldMetaItemViewFieldPosition {
+  Form = 'form',
+  Sidebar = 'sidebar'
+}
+
+export type KeystoneAdminUiFieldMetaListView = {
+  __typename?: 'KeystoneAdminUIFieldMetaListView';
+  fieldMode: KeystoneAdminUiFieldMetaListViewFieldMode;
+};
+
+export enum KeystoneAdminUiFieldMetaListViewFieldMode {
+  Hidden = 'hidden',
+  Read = 'read'
+}
+
+export type KeystoneAdminUiGraphQl = {
+  __typename?: 'KeystoneAdminUIGraphQL';
+  names: KeystoneAdminUiGraphQlNames;
+};
+
+export type KeystoneAdminUiGraphQlNames = {
+  __typename?: 'KeystoneAdminUIGraphQLNames';
+  createInputName: Scalars['String']['output'];
+  createManyMutationName: Scalars['String']['output'];
+  createMutationName: Scalars['String']['output'];
+  deleteManyMutationName: Scalars['String']['output'];
+  deleteMutationName: Scalars['String']['output'];
+  itemQueryName: Scalars['String']['output'];
+  listOrderName: Scalars['String']['output'];
+  listQueryCountName: Scalars['String']['output'];
+  listQueryName: Scalars['String']['output'];
+  outputTypeName: Scalars['String']['output'];
+  relateToManyForCreateInputName: Scalars['String']['output'];
+  relateToManyForUpdateInputName: Scalars['String']['output'];
+  relateToOneForCreateInputName: Scalars['String']['output'];
+  relateToOneForUpdateInputName: Scalars['String']['output'];
+  updateInputName: Scalars['String']['output'];
+  updateManyInputName: Scalars['String']['output'];
+  updateManyMutationName: Scalars['String']['output'];
+  updateMutationName: Scalars['String']['output'];
+  whereInputName: Scalars['String']['output'];
+  whereUniqueInputName: Scalars['String']['output'];
+};
+
+export type KeystoneAdminUiListMeta = {
+  __typename?: 'KeystoneAdminUIListMeta';
+  description?: Maybe<Scalars['String']['output']>;
+  fields: Array<KeystoneAdminUiFieldMeta>;
+  graphql: KeystoneAdminUiGraphQl;
+  groups: Array<KeystoneAdminUiFieldGroupMeta>;
+  hideCreate: Scalars['Boolean']['output'];
+  hideDelete: Scalars['Boolean']['output'];
+  initialColumns: Array<Scalars['String']['output']>;
+  initialSearchFields: Array<Scalars['String']['output']>;
+  initialSort?: Maybe<KeystoneAdminUiSort>;
+  isHidden: Scalars['Boolean']['output'];
+  isSingleton: Scalars['Boolean']['output'];
+  itemQueryName: Scalars['String']['output'];
+  key: Scalars['String']['output'];
+  label: Scalars['String']['output'];
+  labelField: Scalars['String']['output'];
+  listQueryName: Scalars['String']['output'];
+  pageSize: Scalars['Int']['output'];
+  path: Scalars['String']['output'];
+  plural: Scalars['String']['output'];
+  singular: Scalars['String']['output'];
+};
+
+export type KeystoneAdminUiSort = {
+  __typename?: 'KeystoneAdminUISort';
+  direction: KeystoneAdminUiSortDirection;
+  field: Scalars['String']['output'];
+};
+
+export enum KeystoneAdminUiSortDirection {
+  Asc = 'ASC',
+  Desc = 'DESC'
+}
+
+export type KeystoneMeta = {
+  __typename?: 'KeystoneMeta';
+  adminMeta: KeystoneAdminMeta;
+};
+
+export type LinkedItemUnion = AssemblyDistrict | Community | Facility | OrgUnit | Park | Service | Trail | Url;
+
+export type Location = {
+  __typename?: 'Location';
+  city?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  lineOne?: Maybe<Scalars['String']['output']>;
+  lineTwo?: Maybe<Scalars['String']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  zip?: Maybe<Scalars['String']['output']>;
+};
+
+export type LocationCreateInput = {
+  city?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  lineOne?: InputMaybe<Scalars['String']['input']>;
+  lineTwo?: InputMaybe<Scalars['String']['input']>;
+  state?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  zip?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type LocationOrderByInput = {
+  city?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  lineOne?: InputMaybe<OrderDirection>;
+  lineTwo?: InputMaybe<OrderDirection>;
+  state?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  zip?: InputMaybe<OrderDirection>;
+};
+
+export type LocationRelateToOneForCreateInput = {
+  connect?: InputMaybe<LocationWhereUniqueInput>;
+  create?: InputMaybe<LocationCreateInput>;
+};
+
+export type LocationRelateToOneForUpdateInput = {
+  connect?: InputMaybe<LocationWhereUniqueInput>;
+  create?: InputMaybe<LocationCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type LocationUpdateArgs = {
+  data: LocationUpdateInput;
+  where: LocationWhereUniqueInput;
+};
+
+export type LocationUpdateInput = {
+  city?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  lineOne?: InputMaybe<Scalars['String']['input']>;
+  lineTwo?: InputMaybe<Scalars['String']['input']>;
+  state?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  zip?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type LocationWhereInput = {
+  AND?: InputMaybe<Array<LocationWhereInput>>;
+  NOT?: InputMaybe<Array<LocationWhereInput>>;
+  OR?: InputMaybe<Array<LocationWhereInput>>;
+  city?: InputMaybe<StringFilter>;
+  description?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  lineOne?: InputMaybe<StringFilter>;
+  lineTwo?: InputMaybe<StringFilter>;
+  state?: InputMaybe<StringFilter>;
+  title?: InputMaybe<StringFilter>;
+  zip?: InputMaybe<StringFilter>;
+};
+
+export type LocationWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  createAlert?: Maybe<Alert>;
+  createAlerts?: Maybe<Array<Maybe<Alert>>>;
+  createAssemblyDistrict?: Maybe<AssemblyDistrict>;
+  createAssemblyDistrictDraft?: Maybe<AssemblyDistrictDraft>;
+  createAssemblyDistrictDrafts?: Maybe<Array<Maybe<AssemblyDistrictDraft>>>;
+  createAssemblyDistrictVersion?: Maybe<AssemblyDistrictVersion>;
+  createAssemblyDistrictVersions?: Maybe<Array<Maybe<AssemblyDistrictVersion>>>;
+  createAssemblyDistricts?: Maybe<Array<Maybe<AssemblyDistrict>>>;
+  createBoard?: Maybe<Board>;
+  createBoardDraft?: Maybe<BoardDraft>;
+  createBoardDrafts?: Maybe<Array<Maybe<BoardDraft>>>;
+  createBoardPage?: Maybe<BoardPage>;
+  createBoardPages?: Maybe<Array<Maybe<BoardPage>>>;
+  createBoardVersion?: Maybe<BoardVersion>;
+  createBoardVersions?: Maybe<Array<Maybe<BoardVersion>>>;
+  createBoards?: Maybe<Array<Maybe<Board>>>;
+  createCommunities?: Maybe<Array<Maybe<Community>>>;
+  createCommunity?: Maybe<Community>;
+  createCommunityDraft?: Maybe<CommunityDraft>;
+  createCommunityDrafts?: Maybe<Array<Maybe<CommunityDraft>>>;
+  createCommunityVersion?: Maybe<CommunityVersion>;
+  createCommunityVersions?: Maybe<Array<Maybe<CommunityVersion>>>;
+  createContact?: Maybe<Contact>;
+  createContacts?: Maybe<Array<Maybe<Contact>>>;
+  createDocument?: Maybe<Document>;
+  createDocumentCollection?: Maybe<DocumentCollection>;
+  createDocumentCollections?: Maybe<Array<Maybe<DocumentCollection>>>;
+  createDocuments?: Maybe<Array<Maybe<Document>>>;
+  createExternalLink?: Maybe<ExternalLink>;
+  createExternalLinks?: Maybe<Array<Maybe<ExternalLink>>>;
+  createFacilities?: Maybe<Array<Maybe<Facility>>>;
+  createFacility?: Maybe<Facility>;
+  createFacilityDraft?: Maybe<FacilityDraft>;
+  createFacilityDrafts?: Maybe<Array<Maybe<FacilityDraft>>>;
+  createFacilityVersion?: Maybe<FacilityVersion>;
+  createFacilityVersions?: Maybe<Array<Maybe<FacilityVersion>>>;
+  createHighlight?: Maybe<Highlight>;
+  createHighlights?: Maybe<Array<Maybe<Highlight>>>;
+  createHomePage?: Maybe<HomePage>;
+  createHomePages?: Maybe<Array<Maybe<HomePage>>>;
+  createImage?: Maybe<Image>;
+  createImages?: Maybe<Array<Maybe<Image>>>;
+  createInternalLink?: Maybe<InternalLink>;
+  createInternalLinks?: Maybe<Array<Maybe<InternalLink>>>;
+  createLocation?: Maybe<Location>;
+  createLocations?: Maybe<Array<Maybe<Location>>>;
+  createOperatingHour?: Maybe<OperatingHour>;
+  createOperatingHours?: Maybe<Array<Maybe<OperatingHour>>>;
+  createOrgUnit?: Maybe<OrgUnit>;
+  createOrgUnitDraft?: Maybe<OrgUnitDraft>;
+  createOrgUnitDrafts?: Maybe<Array<Maybe<OrgUnitDraft>>>;
+  createOrgUnitVersion?: Maybe<OrgUnitVersion>;
+  createOrgUnitVersions?: Maybe<Array<Maybe<OrgUnitVersion>>>;
+  createOrgUnits?: Maybe<Array<Maybe<OrgUnit>>>;
+  createPark?: Maybe<Park>;
+  createParkDraft?: Maybe<ParkDraft>;
+  createParkDrafts?: Maybe<Array<Maybe<ParkDraft>>>;
+  createParkVersion?: Maybe<ParkVersion>;
+  createParkVersions?: Maybe<Array<Maybe<ParkVersion>>>;
+  createParks?: Maybe<Array<Maybe<Park>>>;
+  createPublicNotice?: Maybe<PublicNotice>;
+  createPublicNoticeDraft?: Maybe<PublicNoticeDraft>;
+  createPublicNoticeDrafts?: Maybe<Array<Maybe<PublicNoticeDraft>>>;
+  createPublicNoticeVersion?: Maybe<PublicNoticeVersion>;
+  createPublicNoticeVersions?: Maybe<Array<Maybe<PublicNoticeVersion>>>;
+  createPublicNotices?: Maybe<Array<Maybe<PublicNotice>>>;
+  createService?: Maybe<Service>;
+  createServiceDraft?: Maybe<ServiceDraft>;
+  createServiceDrafts?: Maybe<Array<Maybe<ServiceDraft>>>;
+  createServiceVersion?: Maybe<ServiceVersion>;
+  createServiceVersions?: Maybe<Array<Maybe<ServiceVersion>>>;
+  createServices?: Maybe<Array<Maybe<Service>>>;
+  createTag?: Maybe<Tag>;
+  createTags?: Maybe<Array<Maybe<Tag>>>;
+  createTopic?: Maybe<Topic>;
+  createTopicDraft?: Maybe<TopicDraft>;
+  createTopicDrafts?: Maybe<Array<Maybe<TopicDraft>>>;
+  createTopicVersion?: Maybe<TopicVersion>;
+  createTopicVersions?: Maybe<Array<Maybe<TopicVersion>>>;
+  createTopics?: Maybe<Array<Maybe<Topic>>>;
+  createTrail?: Maybe<Trail>;
+  createTrailDraft?: Maybe<TrailDraft>;
+  createTrailDrafts?: Maybe<Array<Maybe<TrailDraft>>>;
+  createTrailVersion?: Maybe<TrailVersion>;
+  createTrailVersions?: Maybe<Array<Maybe<TrailVersion>>>;
+  createTrails?: Maybe<Array<Maybe<Trail>>>;
+  createUrl?: Maybe<Url>;
+  createUrls?: Maybe<Array<Maybe<Url>>>;
+  createUser?: Maybe<User>;
+  createUserGroup?: Maybe<UserGroup>;
+  createUserGroups?: Maybe<Array<Maybe<UserGroup>>>;
+  createUsers?: Maybe<Array<Maybe<User>>>;
+  deleteAlert?: Maybe<Alert>;
+  deleteAlerts?: Maybe<Array<Maybe<Alert>>>;
+  deleteAssemblyDistrict?: Maybe<AssemblyDistrict>;
+  deleteAssemblyDistrictDraft?: Maybe<AssemblyDistrictDraft>;
+  deleteAssemblyDistrictDrafts?: Maybe<Array<Maybe<AssemblyDistrictDraft>>>;
+  deleteAssemblyDistrictVersion?: Maybe<AssemblyDistrictVersion>;
+  deleteAssemblyDistrictVersions?: Maybe<Array<Maybe<AssemblyDistrictVersion>>>;
+  deleteAssemblyDistricts?: Maybe<Array<Maybe<AssemblyDistrict>>>;
+  deleteBoard?: Maybe<Board>;
+  deleteBoardDraft?: Maybe<BoardDraft>;
+  deleteBoardDrafts?: Maybe<Array<Maybe<BoardDraft>>>;
+  deleteBoardPage?: Maybe<BoardPage>;
+  deleteBoardPages?: Maybe<Array<Maybe<BoardPage>>>;
+  deleteBoardVersion?: Maybe<BoardVersion>;
+  deleteBoardVersions?: Maybe<Array<Maybe<BoardVersion>>>;
+  deleteBoards?: Maybe<Array<Maybe<Board>>>;
+  deleteCommunities?: Maybe<Array<Maybe<Community>>>;
+  deleteCommunity?: Maybe<Community>;
+  deleteCommunityDraft?: Maybe<CommunityDraft>;
+  deleteCommunityDrafts?: Maybe<Array<Maybe<CommunityDraft>>>;
+  deleteCommunityVersion?: Maybe<CommunityVersion>;
+  deleteCommunityVersions?: Maybe<Array<Maybe<CommunityVersion>>>;
+  deleteContact?: Maybe<Contact>;
+  deleteContacts?: Maybe<Array<Maybe<Contact>>>;
+  deleteDocument?: Maybe<Document>;
+  deleteDocumentCollection?: Maybe<DocumentCollection>;
+  deleteDocumentCollections?: Maybe<Array<Maybe<DocumentCollection>>>;
+  deleteDocuments?: Maybe<Array<Maybe<Document>>>;
+  deleteExternalLink?: Maybe<ExternalLink>;
+  deleteExternalLinks?: Maybe<Array<Maybe<ExternalLink>>>;
+  deleteFacilities?: Maybe<Array<Maybe<Facility>>>;
+  deleteFacility?: Maybe<Facility>;
+  deleteFacilityDraft?: Maybe<FacilityDraft>;
+  deleteFacilityDrafts?: Maybe<Array<Maybe<FacilityDraft>>>;
+  deleteFacilityVersion?: Maybe<FacilityVersion>;
+  deleteFacilityVersions?: Maybe<Array<Maybe<FacilityVersion>>>;
+  deleteHighlight?: Maybe<Highlight>;
+  deleteHighlights?: Maybe<Array<Maybe<Highlight>>>;
+  deleteHomePage?: Maybe<HomePage>;
+  deleteHomePages?: Maybe<Array<Maybe<HomePage>>>;
+  deleteImage?: Maybe<Image>;
+  deleteImages?: Maybe<Array<Maybe<Image>>>;
+  deleteInternalLink?: Maybe<InternalLink>;
+  deleteInternalLinks?: Maybe<Array<Maybe<InternalLink>>>;
+  deleteLocation?: Maybe<Location>;
+  deleteLocations?: Maybe<Array<Maybe<Location>>>;
+  deleteOperatingHour?: Maybe<OperatingHour>;
+  deleteOperatingHours?: Maybe<Array<Maybe<OperatingHour>>>;
+  deleteOrgUnit?: Maybe<OrgUnit>;
+  deleteOrgUnitDraft?: Maybe<OrgUnitDraft>;
+  deleteOrgUnitDrafts?: Maybe<Array<Maybe<OrgUnitDraft>>>;
+  deleteOrgUnitVersion?: Maybe<OrgUnitVersion>;
+  deleteOrgUnitVersions?: Maybe<Array<Maybe<OrgUnitVersion>>>;
+  deleteOrgUnits?: Maybe<Array<Maybe<OrgUnit>>>;
+  deletePark?: Maybe<Park>;
+  deleteParkDraft?: Maybe<ParkDraft>;
+  deleteParkDrafts?: Maybe<Array<Maybe<ParkDraft>>>;
+  deleteParkVersion?: Maybe<ParkVersion>;
+  deleteParkVersions?: Maybe<Array<Maybe<ParkVersion>>>;
+  deleteParks?: Maybe<Array<Maybe<Park>>>;
+  deletePublicNotice?: Maybe<PublicNotice>;
+  deletePublicNoticeDraft?: Maybe<PublicNoticeDraft>;
+  deletePublicNoticeDrafts?: Maybe<Array<Maybe<PublicNoticeDraft>>>;
+  deletePublicNoticeVersion?: Maybe<PublicNoticeVersion>;
+  deletePublicNoticeVersions?: Maybe<Array<Maybe<PublicNoticeVersion>>>;
+  deletePublicNotices?: Maybe<Array<Maybe<PublicNotice>>>;
+  deleteService?: Maybe<Service>;
+  deleteServiceDraft?: Maybe<ServiceDraft>;
+  deleteServiceDrafts?: Maybe<Array<Maybe<ServiceDraft>>>;
+  deleteServiceVersion?: Maybe<ServiceVersion>;
+  deleteServiceVersions?: Maybe<Array<Maybe<ServiceVersion>>>;
+  deleteServices?: Maybe<Array<Maybe<Service>>>;
+  deleteTag?: Maybe<Tag>;
+  deleteTags?: Maybe<Array<Maybe<Tag>>>;
+  deleteTopic?: Maybe<Topic>;
+  deleteTopicDraft?: Maybe<TopicDraft>;
+  deleteTopicDrafts?: Maybe<Array<Maybe<TopicDraft>>>;
+  deleteTopicVersion?: Maybe<TopicVersion>;
+  deleteTopicVersions?: Maybe<Array<Maybe<TopicVersion>>>;
+  deleteTopics?: Maybe<Array<Maybe<Topic>>>;
+  deleteTrail?: Maybe<Trail>;
+  deleteTrailDraft?: Maybe<TrailDraft>;
+  deleteTrailDrafts?: Maybe<Array<Maybe<TrailDraft>>>;
+  deleteTrailVersion?: Maybe<TrailVersion>;
+  deleteTrailVersions?: Maybe<Array<Maybe<TrailVersion>>>;
+  deleteTrails?: Maybe<Array<Maybe<Trail>>>;
+  deleteUrl?: Maybe<Url>;
+  deleteUrls?: Maybe<Array<Maybe<Url>>>;
+  deleteUser?: Maybe<User>;
+  deleteUserGroup?: Maybe<UserGroup>;
+  deleteUserGroups?: Maybe<Array<Maybe<UserGroup>>>;
+  deleteUsers?: Maybe<Array<Maybe<User>>>;
+  endSession: Scalars['Boolean']['output'];
+  updateAlert?: Maybe<Alert>;
+  updateAlerts?: Maybe<Array<Maybe<Alert>>>;
+  updateAssemblyDistrict?: Maybe<AssemblyDistrict>;
+  updateAssemblyDistrictDraft?: Maybe<AssemblyDistrictDraft>;
+  updateAssemblyDistrictDrafts?: Maybe<Array<Maybe<AssemblyDistrictDraft>>>;
+  updateAssemblyDistrictVersion?: Maybe<AssemblyDistrictVersion>;
+  updateAssemblyDistrictVersions?: Maybe<Array<Maybe<AssemblyDistrictVersion>>>;
+  updateAssemblyDistricts?: Maybe<Array<Maybe<AssemblyDistrict>>>;
+  updateBoard?: Maybe<Board>;
+  updateBoardDraft?: Maybe<BoardDraft>;
+  updateBoardDrafts?: Maybe<Array<Maybe<BoardDraft>>>;
+  updateBoardPage?: Maybe<BoardPage>;
+  updateBoardPages?: Maybe<Array<Maybe<BoardPage>>>;
+  updateBoardVersion?: Maybe<BoardVersion>;
+  updateBoardVersions?: Maybe<Array<Maybe<BoardVersion>>>;
+  updateBoards?: Maybe<Array<Maybe<Board>>>;
+  updateCommunities?: Maybe<Array<Maybe<Community>>>;
+  updateCommunity?: Maybe<Community>;
+  updateCommunityDraft?: Maybe<CommunityDraft>;
+  updateCommunityDrafts?: Maybe<Array<Maybe<CommunityDraft>>>;
+  updateCommunityVersion?: Maybe<CommunityVersion>;
+  updateCommunityVersions?: Maybe<Array<Maybe<CommunityVersion>>>;
+  updateContact?: Maybe<Contact>;
+  updateContacts?: Maybe<Array<Maybe<Contact>>>;
+  updateDocument?: Maybe<Document>;
+  updateDocumentCollection?: Maybe<DocumentCollection>;
+  updateDocumentCollections?: Maybe<Array<Maybe<DocumentCollection>>>;
+  updateDocuments?: Maybe<Array<Maybe<Document>>>;
+  updateExternalLink?: Maybe<ExternalLink>;
+  updateExternalLinks?: Maybe<Array<Maybe<ExternalLink>>>;
+  updateFacilities?: Maybe<Array<Maybe<Facility>>>;
+  updateFacility?: Maybe<Facility>;
+  updateFacilityDraft?: Maybe<FacilityDraft>;
+  updateFacilityDrafts?: Maybe<Array<Maybe<FacilityDraft>>>;
+  updateFacilityVersion?: Maybe<FacilityVersion>;
+  updateFacilityVersions?: Maybe<Array<Maybe<FacilityVersion>>>;
+  updateHighlight?: Maybe<Highlight>;
+  updateHighlights?: Maybe<Array<Maybe<Highlight>>>;
+  updateHomePage?: Maybe<HomePage>;
+  updateHomePages?: Maybe<Array<Maybe<HomePage>>>;
+  updateImage?: Maybe<Image>;
+  updateImages?: Maybe<Array<Maybe<Image>>>;
+  updateInternalLink?: Maybe<InternalLink>;
+  updateInternalLinks?: Maybe<Array<Maybe<InternalLink>>>;
+  updateLocation?: Maybe<Location>;
+  updateLocations?: Maybe<Array<Maybe<Location>>>;
+  updateOperatingHour?: Maybe<OperatingHour>;
+  updateOperatingHours?: Maybe<Array<Maybe<OperatingHour>>>;
+  updateOrgUnit?: Maybe<OrgUnit>;
+  updateOrgUnitDraft?: Maybe<OrgUnitDraft>;
+  updateOrgUnitDrafts?: Maybe<Array<Maybe<OrgUnitDraft>>>;
+  updateOrgUnitVersion?: Maybe<OrgUnitVersion>;
+  updateOrgUnitVersions?: Maybe<Array<Maybe<OrgUnitVersion>>>;
+  updateOrgUnits?: Maybe<Array<Maybe<OrgUnit>>>;
+  updatePark?: Maybe<Park>;
+  updateParkDraft?: Maybe<ParkDraft>;
+  updateParkDrafts?: Maybe<Array<Maybe<ParkDraft>>>;
+  updateParkVersion?: Maybe<ParkVersion>;
+  updateParkVersions?: Maybe<Array<Maybe<ParkVersion>>>;
+  updateParks?: Maybe<Array<Maybe<Park>>>;
+  updatePublicNotice?: Maybe<PublicNotice>;
+  updatePublicNoticeDraft?: Maybe<PublicNoticeDraft>;
+  updatePublicNoticeDrafts?: Maybe<Array<Maybe<PublicNoticeDraft>>>;
+  updatePublicNoticeVersion?: Maybe<PublicNoticeVersion>;
+  updatePublicNoticeVersions?: Maybe<Array<Maybe<PublicNoticeVersion>>>;
+  updatePublicNotices?: Maybe<Array<Maybe<PublicNotice>>>;
+  updateService?: Maybe<Service>;
+  updateServiceDraft?: Maybe<ServiceDraft>;
+  updateServiceDrafts?: Maybe<Array<Maybe<ServiceDraft>>>;
+  updateServiceVersion?: Maybe<ServiceVersion>;
+  updateServiceVersions?: Maybe<Array<Maybe<ServiceVersion>>>;
+  updateServices?: Maybe<Array<Maybe<Service>>>;
+  updateTag?: Maybe<Tag>;
+  updateTags?: Maybe<Array<Maybe<Tag>>>;
+  updateTopic?: Maybe<Topic>;
+  updateTopicDraft?: Maybe<TopicDraft>;
+  updateTopicDrafts?: Maybe<Array<Maybe<TopicDraft>>>;
+  updateTopicVersion?: Maybe<TopicVersion>;
+  updateTopicVersions?: Maybe<Array<Maybe<TopicVersion>>>;
+  updateTopics?: Maybe<Array<Maybe<Topic>>>;
+  updateTrail?: Maybe<Trail>;
+  updateTrailDraft?: Maybe<TrailDraft>;
+  updateTrailDrafts?: Maybe<Array<Maybe<TrailDraft>>>;
+  updateTrailVersion?: Maybe<TrailVersion>;
+  updateTrailVersions?: Maybe<Array<Maybe<TrailVersion>>>;
+  updateTrails?: Maybe<Array<Maybe<Trail>>>;
+  updateUrl?: Maybe<Url>;
+  updateUrls?: Maybe<Array<Maybe<Url>>>;
+  updateUser?: Maybe<User>;
+  updateUserGroup?: Maybe<UserGroup>;
+  updateUserGroups?: Maybe<Array<Maybe<UserGroup>>>;
+  updateUsers?: Maybe<Array<Maybe<User>>>;
+};
+
+
+export type MutationCreateAlertArgs = {
+  data: AlertCreateInput;
+};
+
+
+export type MutationCreateAlertsArgs = {
+  data: Array<AlertCreateInput>;
+};
+
+
+export type MutationCreateAssemblyDistrictArgs = {
+  data: AssemblyDistrictCreateInput;
+};
+
+
+export type MutationCreateAssemblyDistrictDraftArgs = {
+  data: AssemblyDistrictDraftCreateInput;
+};
+
+
+export type MutationCreateAssemblyDistrictDraftsArgs = {
+  data: Array<AssemblyDistrictDraftCreateInput>;
+};
+
+
+export type MutationCreateAssemblyDistrictVersionArgs = {
+  data: AssemblyDistrictVersionCreateInput;
+};
+
+
+export type MutationCreateAssemblyDistrictVersionsArgs = {
+  data: Array<AssemblyDistrictVersionCreateInput>;
+};
+
+
+export type MutationCreateAssemblyDistrictsArgs = {
+  data: Array<AssemblyDistrictCreateInput>;
+};
+
+
+export type MutationCreateBoardArgs = {
+  data: BoardCreateInput;
+};
+
+
+export type MutationCreateBoardDraftArgs = {
+  data: BoardDraftCreateInput;
+};
+
+
+export type MutationCreateBoardDraftsArgs = {
+  data: Array<BoardDraftCreateInput>;
+};
+
+
+export type MutationCreateBoardPageArgs = {
+  data: BoardPageCreateInput;
+};
+
+
+export type MutationCreateBoardPagesArgs = {
+  data: Array<BoardPageCreateInput>;
+};
+
+
+export type MutationCreateBoardVersionArgs = {
+  data: BoardVersionCreateInput;
+};
+
+
+export type MutationCreateBoardVersionsArgs = {
+  data: Array<BoardVersionCreateInput>;
+};
+
+
+export type MutationCreateBoardsArgs = {
+  data: Array<BoardCreateInput>;
+};
+
+
+export type MutationCreateCommunitiesArgs = {
+  data: Array<CommunityCreateInput>;
+};
+
+
+export type MutationCreateCommunityArgs = {
+  data: CommunityCreateInput;
+};
+
+
+export type MutationCreateCommunityDraftArgs = {
+  data: CommunityDraftCreateInput;
+};
+
+
+export type MutationCreateCommunityDraftsArgs = {
+  data: Array<CommunityDraftCreateInput>;
+};
+
+
+export type MutationCreateCommunityVersionArgs = {
+  data: CommunityVersionCreateInput;
+};
+
+
+export type MutationCreateCommunityVersionsArgs = {
+  data: Array<CommunityVersionCreateInput>;
+};
+
+
+export type MutationCreateContactArgs = {
+  data: ContactCreateInput;
+};
+
+
+export type MutationCreateContactsArgs = {
+  data: Array<ContactCreateInput>;
+};
+
+
+export type MutationCreateDocumentArgs = {
+  data: DocumentCreateInput;
+};
+
+
+export type MutationCreateDocumentCollectionArgs = {
+  data: DocumentCollectionCreateInput;
+};
+
+
+export type MutationCreateDocumentCollectionsArgs = {
+  data: Array<DocumentCollectionCreateInput>;
+};
+
+
+export type MutationCreateDocumentsArgs = {
+  data: Array<DocumentCreateInput>;
+};
+
+
+export type MutationCreateExternalLinkArgs = {
+  data: ExternalLinkCreateInput;
+};
+
+
+export type MutationCreateExternalLinksArgs = {
+  data: Array<ExternalLinkCreateInput>;
+};
+
+
+export type MutationCreateFacilitiesArgs = {
+  data: Array<FacilityCreateInput>;
+};
+
+
+export type MutationCreateFacilityArgs = {
+  data: FacilityCreateInput;
+};
+
+
+export type MutationCreateFacilityDraftArgs = {
+  data: FacilityDraftCreateInput;
+};
+
+
+export type MutationCreateFacilityDraftsArgs = {
+  data: Array<FacilityDraftCreateInput>;
+};
+
+
+export type MutationCreateFacilityVersionArgs = {
+  data: FacilityVersionCreateInput;
+};
+
+
+export type MutationCreateFacilityVersionsArgs = {
+  data: Array<FacilityVersionCreateInput>;
+};
+
+
+export type MutationCreateHighlightArgs = {
+  data: HighlightCreateInput;
+};
+
+
+export type MutationCreateHighlightsArgs = {
+  data: Array<HighlightCreateInput>;
+};
+
+
+export type MutationCreateHomePageArgs = {
+  data: HomePageCreateInput;
+};
+
+
+export type MutationCreateHomePagesArgs = {
+  data: Array<HomePageCreateInput>;
+};
+
+
+export type MutationCreateImageArgs = {
+  data: ImageCreateInput;
+};
+
+
+export type MutationCreateImagesArgs = {
+  data: Array<ImageCreateInput>;
+};
+
+
+export type MutationCreateInternalLinkArgs = {
+  data: InternalLinkCreateInput;
+};
+
+
+export type MutationCreateInternalLinksArgs = {
+  data: Array<InternalLinkCreateInput>;
+};
+
+
+export type MutationCreateLocationArgs = {
+  data: LocationCreateInput;
+};
+
+
+export type MutationCreateLocationsArgs = {
+  data: Array<LocationCreateInput>;
+};
+
+
+export type MutationCreateOperatingHourArgs = {
+  data: OperatingHourCreateInput;
+};
+
+
+export type MutationCreateOperatingHoursArgs = {
+  data: Array<OperatingHourCreateInput>;
+};
+
+
+export type MutationCreateOrgUnitArgs = {
+  data: OrgUnitCreateInput;
+};
+
+
+export type MutationCreateOrgUnitDraftArgs = {
+  data: OrgUnitDraftCreateInput;
+};
+
+
+export type MutationCreateOrgUnitDraftsArgs = {
+  data: Array<OrgUnitDraftCreateInput>;
+};
+
+
+export type MutationCreateOrgUnitVersionArgs = {
+  data: OrgUnitVersionCreateInput;
+};
+
+
+export type MutationCreateOrgUnitVersionsArgs = {
+  data: Array<OrgUnitVersionCreateInput>;
+};
+
+
+export type MutationCreateOrgUnitsArgs = {
+  data: Array<OrgUnitCreateInput>;
+};
+
+
+export type MutationCreateParkArgs = {
+  data: ParkCreateInput;
+};
+
+
+export type MutationCreateParkDraftArgs = {
+  data: ParkDraftCreateInput;
+};
+
+
+export type MutationCreateParkDraftsArgs = {
+  data: Array<ParkDraftCreateInput>;
+};
+
+
+export type MutationCreateParkVersionArgs = {
+  data: ParkVersionCreateInput;
+};
+
+
+export type MutationCreateParkVersionsArgs = {
+  data: Array<ParkVersionCreateInput>;
+};
+
+
+export type MutationCreateParksArgs = {
+  data: Array<ParkCreateInput>;
+};
+
+
+export type MutationCreatePublicNoticeArgs = {
+  data: PublicNoticeCreateInput;
+};
+
+
+export type MutationCreatePublicNoticeDraftArgs = {
+  data: PublicNoticeDraftCreateInput;
+};
+
+
+export type MutationCreatePublicNoticeDraftsArgs = {
+  data: Array<PublicNoticeDraftCreateInput>;
+};
+
+
+export type MutationCreatePublicNoticeVersionArgs = {
+  data: PublicNoticeVersionCreateInput;
+};
+
+
+export type MutationCreatePublicNoticeVersionsArgs = {
+  data: Array<PublicNoticeVersionCreateInput>;
+};
+
+
+export type MutationCreatePublicNoticesArgs = {
+  data: Array<PublicNoticeCreateInput>;
+};
+
+
+export type MutationCreateServiceArgs = {
+  data: ServiceCreateInput;
+};
+
+
+export type MutationCreateServiceDraftArgs = {
+  data: ServiceDraftCreateInput;
+};
+
+
+export type MutationCreateServiceDraftsArgs = {
+  data: Array<ServiceDraftCreateInput>;
+};
+
+
+export type MutationCreateServiceVersionArgs = {
+  data: ServiceVersionCreateInput;
+};
+
+
+export type MutationCreateServiceVersionsArgs = {
+  data: Array<ServiceVersionCreateInput>;
+};
+
+
+export type MutationCreateServicesArgs = {
+  data: Array<ServiceCreateInput>;
+};
+
+
+export type MutationCreateTagArgs = {
+  data: TagCreateInput;
+};
+
+
+export type MutationCreateTagsArgs = {
+  data: Array<TagCreateInput>;
+};
+
+
+export type MutationCreateTopicArgs = {
+  data: TopicCreateInput;
+};
+
+
+export type MutationCreateTopicDraftArgs = {
+  data: TopicDraftCreateInput;
+};
+
+
+export type MutationCreateTopicDraftsArgs = {
+  data: Array<TopicDraftCreateInput>;
+};
+
+
+export type MutationCreateTopicVersionArgs = {
+  data: TopicVersionCreateInput;
+};
+
+
+export type MutationCreateTopicVersionsArgs = {
+  data: Array<TopicVersionCreateInput>;
+};
+
+
+export type MutationCreateTopicsArgs = {
+  data: Array<TopicCreateInput>;
+};
+
+
+export type MutationCreateTrailArgs = {
+  data: TrailCreateInput;
+};
+
+
+export type MutationCreateTrailDraftArgs = {
+  data: TrailDraftCreateInput;
+};
+
+
+export type MutationCreateTrailDraftsArgs = {
+  data: Array<TrailDraftCreateInput>;
+};
+
+
+export type MutationCreateTrailVersionArgs = {
+  data: TrailVersionCreateInput;
+};
+
+
+export type MutationCreateTrailVersionsArgs = {
+  data: Array<TrailVersionCreateInput>;
+};
+
+
+export type MutationCreateTrailsArgs = {
+  data: Array<TrailCreateInput>;
+};
+
+
+export type MutationCreateUrlArgs = {
+  data: UrlCreateInput;
+};
+
+
+export type MutationCreateUrlsArgs = {
+  data: Array<UrlCreateInput>;
+};
+
+
+export type MutationCreateUserArgs = {
+  data: UserCreateInput;
+};
+
+
+export type MutationCreateUserGroupArgs = {
+  data: UserGroupCreateInput;
+};
+
+
+export type MutationCreateUserGroupsArgs = {
+  data: Array<UserGroupCreateInput>;
+};
+
+
+export type MutationCreateUsersArgs = {
+  data: Array<UserCreateInput>;
+};
+
+
+export type MutationDeleteAlertArgs = {
+  where: AlertWhereUniqueInput;
+};
+
+
+export type MutationDeleteAlertsArgs = {
+  where: Array<AlertWhereUniqueInput>;
+};
+
+
+export type MutationDeleteAssemblyDistrictArgs = {
+  where: AssemblyDistrictWhereUniqueInput;
+};
+
+
+export type MutationDeleteAssemblyDistrictDraftArgs = {
+  where: AssemblyDistrictDraftWhereUniqueInput;
+};
+
+
+export type MutationDeleteAssemblyDistrictDraftsArgs = {
+  where: Array<AssemblyDistrictDraftWhereUniqueInput>;
+};
+
+
+export type MutationDeleteAssemblyDistrictVersionArgs = {
+  where: AssemblyDistrictVersionWhereUniqueInput;
+};
+
+
+export type MutationDeleteAssemblyDistrictVersionsArgs = {
+  where: Array<AssemblyDistrictVersionWhereUniqueInput>;
+};
+
+
+export type MutationDeleteAssemblyDistrictsArgs = {
+  where: Array<AssemblyDistrictWhereUniqueInput>;
+};
+
+
+export type MutationDeleteBoardArgs = {
+  where: BoardWhereUniqueInput;
+};
+
+
+export type MutationDeleteBoardDraftArgs = {
+  where: BoardDraftWhereUniqueInput;
+};
+
+
+export type MutationDeleteBoardDraftsArgs = {
+  where: Array<BoardDraftWhereUniqueInput>;
+};
+
+
+export type MutationDeleteBoardPageArgs = {
+  where?: BoardPageWhereUniqueInput;
+};
+
+
+export type MutationDeleteBoardPagesArgs = {
+  where: Array<BoardPageWhereUniqueInput>;
+};
+
+
+export type MutationDeleteBoardVersionArgs = {
+  where: BoardVersionWhereUniqueInput;
+};
+
+
+export type MutationDeleteBoardVersionsArgs = {
+  where: Array<BoardVersionWhereUniqueInput>;
+};
+
+
+export type MutationDeleteBoardsArgs = {
+  where: Array<BoardWhereUniqueInput>;
+};
+
+
+export type MutationDeleteCommunitiesArgs = {
+  where: Array<CommunityWhereUniqueInput>;
+};
+
+
+export type MutationDeleteCommunityArgs = {
+  where: CommunityWhereUniqueInput;
+};
+
+
+export type MutationDeleteCommunityDraftArgs = {
+  where: CommunityDraftWhereUniqueInput;
+};
+
+
+export type MutationDeleteCommunityDraftsArgs = {
+  where: Array<CommunityDraftWhereUniqueInput>;
+};
+
+
+export type MutationDeleteCommunityVersionArgs = {
+  where: CommunityVersionWhereUniqueInput;
+};
+
+
+export type MutationDeleteCommunityVersionsArgs = {
+  where: Array<CommunityVersionWhereUniqueInput>;
+};
+
+
+export type MutationDeleteContactArgs = {
+  where: ContactWhereUniqueInput;
+};
+
+
+export type MutationDeleteContactsArgs = {
+  where: Array<ContactWhereUniqueInput>;
+};
+
+
+export type MutationDeleteDocumentArgs = {
+  where: DocumentWhereUniqueInput;
+};
+
+
+export type MutationDeleteDocumentCollectionArgs = {
+  where: DocumentCollectionWhereUniqueInput;
+};
+
+
+export type MutationDeleteDocumentCollectionsArgs = {
+  where: Array<DocumentCollectionWhereUniqueInput>;
+};
+
+
+export type MutationDeleteDocumentsArgs = {
+  where: Array<DocumentWhereUniqueInput>;
+};
+
+
+export type MutationDeleteExternalLinkArgs = {
+  where: ExternalLinkWhereUniqueInput;
+};
+
+
+export type MutationDeleteExternalLinksArgs = {
+  where: Array<ExternalLinkWhereUniqueInput>;
+};
+
+
+export type MutationDeleteFacilitiesArgs = {
+  where: Array<FacilityWhereUniqueInput>;
+};
+
+
+export type MutationDeleteFacilityArgs = {
+  where: FacilityWhereUniqueInput;
+};
+
+
+export type MutationDeleteFacilityDraftArgs = {
+  where: FacilityDraftWhereUniqueInput;
+};
+
+
+export type MutationDeleteFacilityDraftsArgs = {
+  where: Array<FacilityDraftWhereUniqueInput>;
+};
+
+
+export type MutationDeleteFacilityVersionArgs = {
+  where: FacilityVersionWhereUniqueInput;
+};
+
+
+export type MutationDeleteFacilityVersionsArgs = {
+  where: Array<FacilityVersionWhereUniqueInput>;
+};
+
+
+export type MutationDeleteHighlightArgs = {
+  where: HighlightWhereUniqueInput;
+};
+
+
+export type MutationDeleteHighlightsArgs = {
+  where: Array<HighlightWhereUniqueInput>;
+};
+
+
+export type MutationDeleteHomePageArgs = {
+  where?: HomePageWhereUniqueInput;
+};
+
+
+export type MutationDeleteHomePagesArgs = {
+  where: Array<HomePageWhereUniqueInput>;
+};
+
+
+export type MutationDeleteImageArgs = {
+  where: ImageWhereUniqueInput;
+};
+
+
+export type MutationDeleteImagesArgs = {
+  where: Array<ImageWhereUniqueInput>;
+};
+
+
+export type MutationDeleteInternalLinkArgs = {
+  where: InternalLinkWhereUniqueInput;
+};
+
+
+export type MutationDeleteInternalLinksArgs = {
+  where: Array<InternalLinkWhereUniqueInput>;
+};
+
+
+export type MutationDeleteLocationArgs = {
+  where: LocationWhereUniqueInput;
+};
+
+
+export type MutationDeleteLocationsArgs = {
+  where: Array<LocationWhereUniqueInput>;
+};
+
+
+export type MutationDeleteOperatingHourArgs = {
+  where: OperatingHourWhereUniqueInput;
+};
+
+
+export type MutationDeleteOperatingHoursArgs = {
+  where: Array<OperatingHourWhereUniqueInput>;
+};
+
+
+export type MutationDeleteOrgUnitArgs = {
+  where: OrgUnitWhereUniqueInput;
+};
+
+
+export type MutationDeleteOrgUnitDraftArgs = {
+  where: OrgUnitDraftWhereUniqueInput;
+};
+
+
+export type MutationDeleteOrgUnitDraftsArgs = {
+  where: Array<OrgUnitDraftWhereUniqueInput>;
+};
+
+
+export type MutationDeleteOrgUnitVersionArgs = {
+  where: OrgUnitVersionWhereUniqueInput;
+};
+
+
+export type MutationDeleteOrgUnitVersionsArgs = {
+  where: Array<OrgUnitVersionWhereUniqueInput>;
+};
+
+
+export type MutationDeleteOrgUnitsArgs = {
+  where: Array<OrgUnitWhereUniqueInput>;
+};
+
+
+export type MutationDeleteParkArgs = {
+  where: ParkWhereUniqueInput;
+};
+
+
+export type MutationDeleteParkDraftArgs = {
+  where: ParkDraftWhereUniqueInput;
+};
+
+
+export type MutationDeleteParkDraftsArgs = {
+  where: Array<ParkDraftWhereUniqueInput>;
+};
+
+
+export type MutationDeleteParkVersionArgs = {
+  where: ParkVersionWhereUniqueInput;
+};
+
+
+export type MutationDeleteParkVersionsArgs = {
+  where: Array<ParkVersionWhereUniqueInput>;
+};
+
+
+export type MutationDeleteParksArgs = {
+  where: Array<ParkWhereUniqueInput>;
+};
+
+
+export type MutationDeletePublicNoticeArgs = {
+  where: PublicNoticeWhereUniqueInput;
+};
+
+
+export type MutationDeletePublicNoticeDraftArgs = {
+  where: PublicNoticeDraftWhereUniqueInput;
+};
+
+
+export type MutationDeletePublicNoticeDraftsArgs = {
+  where: Array<PublicNoticeDraftWhereUniqueInput>;
+};
+
+
+export type MutationDeletePublicNoticeVersionArgs = {
+  where: PublicNoticeVersionWhereUniqueInput;
+};
+
+
+export type MutationDeletePublicNoticeVersionsArgs = {
+  where: Array<PublicNoticeVersionWhereUniqueInput>;
+};
+
+
+export type MutationDeletePublicNoticesArgs = {
+  where: Array<PublicNoticeWhereUniqueInput>;
+};
+
+
+export type MutationDeleteServiceArgs = {
+  where: ServiceWhereUniqueInput;
+};
+
+
+export type MutationDeleteServiceDraftArgs = {
+  where: ServiceDraftWhereUniqueInput;
+};
+
+
+export type MutationDeleteServiceDraftsArgs = {
+  where: Array<ServiceDraftWhereUniqueInput>;
+};
+
+
+export type MutationDeleteServiceVersionArgs = {
+  where: ServiceVersionWhereUniqueInput;
+};
+
+
+export type MutationDeleteServiceVersionsArgs = {
+  where: Array<ServiceVersionWhereUniqueInput>;
+};
+
+
+export type MutationDeleteServicesArgs = {
+  where: Array<ServiceWhereUniqueInput>;
+};
+
+
+export type MutationDeleteTagArgs = {
+  where: TagWhereUniqueInput;
+};
+
+
+export type MutationDeleteTagsArgs = {
+  where: Array<TagWhereUniqueInput>;
+};
+
+
+export type MutationDeleteTopicArgs = {
+  where: TopicWhereUniqueInput;
+};
+
+
+export type MutationDeleteTopicDraftArgs = {
+  where: TopicDraftWhereUniqueInput;
+};
+
+
+export type MutationDeleteTopicDraftsArgs = {
+  where: Array<TopicDraftWhereUniqueInput>;
+};
+
+
+export type MutationDeleteTopicVersionArgs = {
+  where: TopicVersionWhereUniqueInput;
+};
+
+
+export type MutationDeleteTopicVersionsArgs = {
+  where: Array<TopicVersionWhereUniqueInput>;
+};
+
+
+export type MutationDeleteTopicsArgs = {
+  where: Array<TopicWhereUniqueInput>;
+};
+
+
+export type MutationDeleteTrailArgs = {
+  where: TrailWhereUniqueInput;
+};
+
+
+export type MutationDeleteTrailDraftArgs = {
+  where: TrailDraftWhereUniqueInput;
+};
+
+
+export type MutationDeleteTrailDraftsArgs = {
+  where: Array<TrailDraftWhereUniqueInput>;
+};
+
+
+export type MutationDeleteTrailVersionArgs = {
+  where: TrailVersionWhereUniqueInput;
+};
+
+
+export type MutationDeleteTrailVersionsArgs = {
+  where: Array<TrailVersionWhereUniqueInput>;
+};
+
+
+export type MutationDeleteTrailsArgs = {
+  where: Array<TrailWhereUniqueInput>;
+};
+
+
+export type MutationDeleteUrlArgs = {
+  where: UrlWhereUniqueInput;
+};
+
+
+export type MutationDeleteUrlsArgs = {
+  where: Array<UrlWhereUniqueInput>;
+};
+
+
+export type MutationDeleteUserArgs = {
+  where: UserWhereUniqueInput;
+};
+
+
+export type MutationDeleteUserGroupArgs = {
+  where: UserGroupWhereUniqueInput;
+};
+
+
+export type MutationDeleteUserGroupsArgs = {
+  where: Array<UserGroupWhereUniqueInput>;
+};
+
+
+export type MutationDeleteUsersArgs = {
+  where: Array<UserWhereUniqueInput>;
+};
+
+
+export type MutationUpdateAlertArgs = {
+  data: AlertUpdateInput;
+  where: AlertWhereUniqueInput;
+};
+
+
+export type MutationUpdateAlertsArgs = {
+  data: Array<AlertUpdateArgs>;
+};
+
+
+export type MutationUpdateAssemblyDistrictArgs = {
+  data: AssemblyDistrictUpdateInput;
+  where: AssemblyDistrictWhereUniqueInput;
+};
+
+
+export type MutationUpdateAssemblyDistrictDraftArgs = {
+  data: AssemblyDistrictDraftUpdateInput;
+  where: AssemblyDistrictDraftWhereUniqueInput;
+};
+
+
+export type MutationUpdateAssemblyDistrictDraftsArgs = {
+  data: Array<AssemblyDistrictDraftUpdateArgs>;
+};
+
+
+export type MutationUpdateAssemblyDistrictVersionArgs = {
+  data: AssemblyDistrictVersionUpdateInput;
+  where: AssemblyDistrictVersionWhereUniqueInput;
+};
+
+
+export type MutationUpdateAssemblyDistrictVersionsArgs = {
+  data: Array<AssemblyDistrictVersionUpdateArgs>;
+};
+
+
+export type MutationUpdateAssemblyDistrictsArgs = {
+  data: Array<AssemblyDistrictUpdateArgs>;
+};
+
+
+export type MutationUpdateBoardArgs = {
+  data: BoardUpdateInput;
+  where: BoardWhereUniqueInput;
+};
+
+
+export type MutationUpdateBoardDraftArgs = {
+  data: BoardDraftUpdateInput;
+  where: BoardDraftWhereUniqueInput;
+};
+
+
+export type MutationUpdateBoardDraftsArgs = {
+  data: Array<BoardDraftUpdateArgs>;
+};
+
+
+export type MutationUpdateBoardPageArgs = {
+  data: BoardPageUpdateInput;
+  where?: BoardPageWhereUniqueInput;
+};
+
+
+export type MutationUpdateBoardPagesArgs = {
+  data: Array<BoardPageUpdateArgs>;
+};
+
+
+export type MutationUpdateBoardVersionArgs = {
+  data: BoardVersionUpdateInput;
+  where: BoardVersionWhereUniqueInput;
+};
+
+
+export type MutationUpdateBoardVersionsArgs = {
+  data: Array<BoardVersionUpdateArgs>;
+};
+
+
+export type MutationUpdateBoardsArgs = {
+  data: Array<BoardUpdateArgs>;
+};
+
+
+export type MutationUpdateCommunitiesArgs = {
+  data: Array<CommunityUpdateArgs>;
+};
+
+
+export type MutationUpdateCommunityArgs = {
+  data: CommunityUpdateInput;
+  where: CommunityWhereUniqueInput;
+};
+
+
+export type MutationUpdateCommunityDraftArgs = {
+  data: CommunityDraftUpdateInput;
+  where: CommunityDraftWhereUniqueInput;
+};
+
+
+export type MutationUpdateCommunityDraftsArgs = {
+  data: Array<CommunityDraftUpdateArgs>;
+};
+
+
+export type MutationUpdateCommunityVersionArgs = {
+  data: CommunityVersionUpdateInput;
+  where: CommunityVersionWhereUniqueInput;
+};
+
+
+export type MutationUpdateCommunityVersionsArgs = {
+  data: Array<CommunityVersionUpdateArgs>;
+};
+
+
+export type MutationUpdateContactArgs = {
+  data: ContactUpdateInput;
+  where: ContactWhereUniqueInput;
+};
+
+
+export type MutationUpdateContactsArgs = {
+  data: Array<ContactUpdateArgs>;
+};
+
+
+export type MutationUpdateDocumentArgs = {
+  data: DocumentUpdateInput;
+  where: DocumentWhereUniqueInput;
+};
+
+
+export type MutationUpdateDocumentCollectionArgs = {
+  data: DocumentCollectionUpdateInput;
+  where: DocumentCollectionWhereUniqueInput;
+};
+
+
+export type MutationUpdateDocumentCollectionsArgs = {
+  data: Array<DocumentCollectionUpdateArgs>;
+};
+
+
+export type MutationUpdateDocumentsArgs = {
+  data: Array<DocumentUpdateArgs>;
+};
+
+
+export type MutationUpdateExternalLinkArgs = {
+  data: ExternalLinkUpdateInput;
+  where: ExternalLinkWhereUniqueInput;
+};
+
+
+export type MutationUpdateExternalLinksArgs = {
+  data: Array<ExternalLinkUpdateArgs>;
+};
+
+
+export type MutationUpdateFacilitiesArgs = {
+  data: Array<FacilityUpdateArgs>;
+};
+
+
+export type MutationUpdateFacilityArgs = {
+  data: FacilityUpdateInput;
+  where: FacilityWhereUniqueInput;
+};
+
+
+export type MutationUpdateFacilityDraftArgs = {
+  data: FacilityDraftUpdateInput;
+  where: FacilityDraftWhereUniqueInput;
+};
+
+
+export type MutationUpdateFacilityDraftsArgs = {
+  data: Array<FacilityDraftUpdateArgs>;
+};
+
+
+export type MutationUpdateFacilityVersionArgs = {
+  data: FacilityVersionUpdateInput;
+  where: FacilityVersionWhereUniqueInput;
+};
+
+
+export type MutationUpdateFacilityVersionsArgs = {
+  data: Array<FacilityVersionUpdateArgs>;
+};
+
+
+export type MutationUpdateHighlightArgs = {
+  data: HighlightUpdateInput;
+  where: HighlightWhereUniqueInput;
+};
+
+
+export type MutationUpdateHighlightsArgs = {
+  data: Array<HighlightUpdateArgs>;
+};
+
+
+export type MutationUpdateHomePageArgs = {
+  data: HomePageUpdateInput;
+  where?: HomePageWhereUniqueInput;
+};
+
+
+export type MutationUpdateHomePagesArgs = {
+  data: Array<HomePageUpdateArgs>;
+};
+
+
+export type MutationUpdateImageArgs = {
+  data: ImageUpdateInput;
+  where: ImageWhereUniqueInput;
+};
+
+
+export type MutationUpdateImagesArgs = {
+  data: Array<ImageUpdateArgs>;
+};
+
+
+export type MutationUpdateInternalLinkArgs = {
+  data: InternalLinkUpdateInput;
+  where: InternalLinkWhereUniqueInput;
+};
+
+
+export type MutationUpdateInternalLinksArgs = {
+  data: Array<InternalLinkUpdateArgs>;
+};
+
+
+export type MutationUpdateLocationArgs = {
+  data: LocationUpdateInput;
+  where: LocationWhereUniqueInput;
+};
+
+
+export type MutationUpdateLocationsArgs = {
+  data: Array<LocationUpdateArgs>;
+};
+
+
+export type MutationUpdateOperatingHourArgs = {
+  data: OperatingHourUpdateInput;
+  where: OperatingHourWhereUniqueInput;
+};
+
+
+export type MutationUpdateOperatingHoursArgs = {
+  data: Array<OperatingHourUpdateArgs>;
+};
+
+
+export type MutationUpdateOrgUnitArgs = {
+  data: OrgUnitUpdateInput;
+  where: OrgUnitWhereUniqueInput;
+};
+
+
+export type MutationUpdateOrgUnitDraftArgs = {
+  data: OrgUnitDraftUpdateInput;
+  where: OrgUnitDraftWhereUniqueInput;
+};
+
+
+export type MutationUpdateOrgUnitDraftsArgs = {
+  data: Array<OrgUnitDraftUpdateArgs>;
+};
+
+
+export type MutationUpdateOrgUnitVersionArgs = {
+  data: OrgUnitVersionUpdateInput;
+  where: OrgUnitVersionWhereUniqueInput;
+};
+
+
+export type MutationUpdateOrgUnitVersionsArgs = {
+  data: Array<OrgUnitVersionUpdateArgs>;
+};
+
+
+export type MutationUpdateOrgUnitsArgs = {
+  data: Array<OrgUnitUpdateArgs>;
+};
+
+
+export type MutationUpdateParkArgs = {
+  data: ParkUpdateInput;
+  where: ParkWhereUniqueInput;
+};
+
+
+export type MutationUpdateParkDraftArgs = {
+  data: ParkDraftUpdateInput;
+  where: ParkDraftWhereUniqueInput;
+};
+
+
+export type MutationUpdateParkDraftsArgs = {
+  data: Array<ParkDraftUpdateArgs>;
+};
+
+
+export type MutationUpdateParkVersionArgs = {
+  data: ParkVersionUpdateInput;
+  where: ParkVersionWhereUniqueInput;
+};
+
+
+export type MutationUpdateParkVersionsArgs = {
+  data: Array<ParkVersionUpdateArgs>;
+};
+
+
+export type MutationUpdateParksArgs = {
+  data: Array<ParkUpdateArgs>;
+};
+
+
+export type MutationUpdatePublicNoticeArgs = {
+  data: PublicNoticeUpdateInput;
+  where: PublicNoticeWhereUniqueInput;
+};
+
+
+export type MutationUpdatePublicNoticeDraftArgs = {
+  data: PublicNoticeDraftUpdateInput;
+  where: PublicNoticeDraftWhereUniqueInput;
+};
+
+
+export type MutationUpdatePublicNoticeDraftsArgs = {
+  data: Array<PublicNoticeDraftUpdateArgs>;
+};
+
+
+export type MutationUpdatePublicNoticeVersionArgs = {
+  data: PublicNoticeVersionUpdateInput;
+  where: PublicNoticeVersionWhereUniqueInput;
+};
+
+
+export type MutationUpdatePublicNoticeVersionsArgs = {
+  data: Array<PublicNoticeVersionUpdateArgs>;
+};
+
+
+export type MutationUpdatePublicNoticesArgs = {
+  data: Array<PublicNoticeUpdateArgs>;
+};
+
+
+export type MutationUpdateServiceArgs = {
+  data: ServiceUpdateInput;
+  where: ServiceWhereUniqueInput;
+};
+
+
+export type MutationUpdateServiceDraftArgs = {
+  data: ServiceDraftUpdateInput;
+  where: ServiceDraftWhereUniqueInput;
+};
+
+
+export type MutationUpdateServiceDraftsArgs = {
+  data: Array<ServiceDraftUpdateArgs>;
+};
+
+
+export type MutationUpdateServiceVersionArgs = {
+  data: ServiceVersionUpdateInput;
+  where: ServiceVersionWhereUniqueInput;
+};
+
+
+export type MutationUpdateServiceVersionsArgs = {
+  data: Array<ServiceVersionUpdateArgs>;
+};
+
+
+export type MutationUpdateServicesArgs = {
+  data: Array<ServiceUpdateArgs>;
+};
+
+
+export type MutationUpdateTagArgs = {
+  data: TagUpdateInput;
+  where: TagWhereUniqueInput;
+};
+
+
+export type MutationUpdateTagsArgs = {
+  data: Array<TagUpdateArgs>;
+};
+
+
+export type MutationUpdateTopicArgs = {
+  data: TopicUpdateInput;
+  where: TopicWhereUniqueInput;
+};
+
+
+export type MutationUpdateTopicDraftArgs = {
+  data: TopicDraftUpdateInput;
+  where: TopicDraftWhereUniqueInput;
+};
+
+
+export type MutationUpdateTopicDraftsArgs = {
+  data: Array<TopicDraftUpdateArgs>;
+};
+
+
+export type MutationUpdateTopicVersionArgs = {
+  data: TopicVersionUpdateInput;
+  where: TopicVersionWhereUniqueInput;
+};
+
+
+export type MutationUpdateTopicVersionsArgs = {
+  data: Array<TopicVersionUpdateArgs>;
+};
+
+
+export type MutationUpdateTopicsArgs = {
+  data: Array<TopicUpdateArgs>;
+};
+
+
+export type MutationUpdateTrailArgs = {
+  data: TrailUpdateInput;
+  where: TrailWhereUniqueInput;
+};
+
+
+export type MutationUpdateTrailDraftArgs = {
+  data: TrailDraftUpdateInput;
+  where: TrailDraftWhereUniqueInput;
+};
+
+
+export type MutationUpdateTrailDraftsArgs = {
+  data: Array<TrailDraftUpdateArgs>;
+};
+
+
+export type MutationUpdateTrailVersionArgs = {
+  data: TrailVersionUpdateInput;
+  where: TrailVersionWhereUniqueInput;
+};
+
+
+export type MutationUpdateTrailVersionsArgs = {
+  data: Array<TrailVersionUpdateArgs>;
+};
+
+
+export type MutationUpdateTrailsArgs = {
+  data: Array<TrailUpdateArgs>;
+};
+
+
+export type MutationUpdateUrlArgs = {
+  data: UrlUpdateInput;
+  where: UrlWhereUniqueInput;
+};
+
+
+export type MutationUpdateUrlsArgs = {
+  data: Array<UrlUpdateArgs>;
+};
+
+
+export type MutationUpdateUserArgs = {
+  data: UserUpdateInput;
+  where: UserWhereUniqueInput;
+};
+
+
+export type MutationUpdateUserGroupArgs = {
+  data: UserGroupUpdateInput;
+  where: UserGroupWhereUniqueInput;
+};
+
+
+export type MutationUpdateUserGroupsArgs = {
+  data: Array<UserGroupUpdateArgs>;
+};
+
+
+export type MutationUpdateUsersArgs = {
+  data: Array<UserUpdateArgs>;
+};
+
+export enum MyOrderDirection {
+  Asc = 'asc',
+  Desc = 'desc'
+}
+
+export enum MyQueryMode {
+  Default = 'default',
+  Insensitive = 'insensitive'
+}
+
+export type MyStringFilter = {
+  contains?: InputMaybe<Scalars['String']['input']>;
+  endsWith?: InputMaybe<Scalars['String']['input']>;
+  equals?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
+  mode?: InputMaybe<MyQueryMode>;
+  not?: InputMaybe<NestedMyStringFilter>;
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+  startsWith?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type NestedMyStringFilter = {
+  contains?: InputMaybe<Scalars['String']['input']>;
+  endsWith?: InputMaybe<Scalars['String']['input']>;
+  equals?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
+  not?: InputMaybe<NestedMyStringFilter>;
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+  startsWith?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type NestedStringFilter = {
+  contains?: InputMaybe<Scalars['String']['input']>;
+  endsWith?: InputMaybe<Scalars['String']['input']>;
+  equals?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
+  not?: InputMaybe<NestedStringFilter>;
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+  startsWith?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type OperatingHour = {
+  __typename?: 'OperatingHour';
+  close?: Maybe<Scalars['String']['output']>;
+  day?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  open?: Maybe<Scalars['String']['output']>;
+};
+
+export type OperatingHourCreateInput = {
+  close?: InputMaybe<Scalars['String']['input']>;
+  day?: InputMaybe<Scalars['String']['input']>;
+  open?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type OperatingHourManyRelationFilter = {
+  every?: InputMaybe<OperatingHourWhereInput>;
+  none?: InputMaybe<OperatingHourWhereInput>;
+  some?: InputMaybe<OperatingHourWhereInput>;
+};
+
+export type OperatingHourOrderByInput = {
+  close?: InputMaybe<OrderDirection>;
+  day?: InputMaybe<OrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  open?: InputMaybe<OrderDirection>;
+};
+
+export type OperatingHourRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<OperatingHourWhereUniqueInput>>;
+  create?: InputMaybe<Array<OperatingHourCreateInput>>;
+};
+
+export type OperatingHourRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<OperatingHourWhereUniqueInput>>;
+  create?: InputMaybe<Array<OperatingHourCreateInput>>;
+  disconnect?: InputMaybe<Array<OperatingHourWhereUniqueInput>>;
+  set?: InputMaybe<Array<OperatingHourWhereUniqueInput>>;
+};
+
+export type OperatingHourUpdateArgs = {
+  data: OperatingHourUpdateInput;
+  where: OperatingHourWhereUniqueInput;
+};
+
+export type OperatingHourUpdateInput = {
+  close?: InputMaybe<Scalars['String']['input']>;
+  day?: InputMaybe<Scalars['String']['input']>;
+  open?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type OperatingHourWhereInput = {
+  AND?: InputMaybe<Array<OperatingHourWhereInput>>;
+  NOT?: InputMaybe<Array<OperatingHourWhereInput>>;
+  OR?: InputMaybe<Array<OperatingHourWhereInput>>;
+  close?: InputMaybe<StringFilter>;
+  day?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  open?: InputMaybe<StringFilter>;
+};
+
+export type OperatingHourWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export enum OrderDirection {
+  Asc = 'asc',
+  Desc = 'desc'
+}
+
+export type OrgUnit = {
+  __typename?: 'OrgUnit';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  children?: Maybe<Array<OrgUnit>>;
+  childrenCount?: Maybe<Scalars['Int']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  currentVersion?: Maybe<OrgUnitVersion>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  drafts?: Maybe<Array<OrgUnitDraft>>;
+  draftsCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  makeDrafts?: Maybe<Scalars['String']['output']>;
+  owner?: Maybe<User>;
+  parent?: Maybe<OrgUnit>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  showPage?: Maybe<Scalars['Boolean']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+  versions?: Maybe<Array<OrgUnitVersion>>;
+  versionsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type OrgUnitActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type OrgUnitActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type OrgUnitChildrenArgs = {
+  cursor?: InputMaybe<OrgUnitWhereUniqueInput>;
+  orderBy?: Array<OrgUnitOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitWhereInput;
+};
+
+
+export type OrgUnitChildrenCountArgs = {
+  where?: OrgUnitWhereInput;
+};
+
+
+export type OrgUnitContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type OrgUnitContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type OrgUnitDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type OrgUnitDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type OrgUnitDraftsArgs = {
+  cursor?: InputMaybe<OrgUnitDraftWhereUniqueInput>;
+  orderBy?: Array<OrgUnitDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitDraftWhereInput;
+};
+
+
+export type OrgUnitDraftsCountArgs = {
+  where?: OrgUnitDraftWhereInput;
+};
+
+
+export type OrgUnitServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type OrgUnitServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type OrgUnitTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type OrgUnitTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type OrgUnitTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type OrgUnitTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type OrgUnitUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type OrgUnitUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+
+export type OrgUnitVersionsArgs = {
+  cursor?: InputMaybe<OrgUnitVersionWhereUniqueInput>;
+  orderBy?: Array<OrgUnitVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitVersionWhereInput;
+};
+
+
+export type OrgUnitVersionsCountArgs = {
+  where?: OrgUnitVersionWhereInput;
+};
+
+export type OrgUnitCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  children?: InputMaybe<OrgUnitRelateToManyForCreateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<OrgUnitVersionRelateToOneForCreateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  drafts?: InputMaybe<OrgUnitDraftRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  parent?: InputMaybe<OrgUnitRelateToOneForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  showPage?: InputMaybe<Scalars['Boolean']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+  versions?: InputMaybe<OrgUnitVersionRelateToManyForCreateInput>;
+};
+
+export type OrgUnitDraft = {
+  __typename?: 'OrgUnitDraft';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  children?: Maybe<Array<OrgUnit>>;
+  childrenCount?: Maybe<Scalars['Int']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  original?: Maybe<OrgUnit>;
+  owner?: Maybe<User>;
+  parent?: Maybe<OrgUnit>;
+  publish?: Maybe<Scalars['String']['output']>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  showPage?: Maybe<Scalars['Boolean']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type OrgUnitDraftActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type OrgUnitDraftActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type OrgUnitDraftChildrenArgs = {
+  cursor?: InputMaybe<OrgUnitWhereUniqueInput>;
+  orderBy?: Array<OrgUnitOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitWhereInput;
+};
+
+
+export type OrgUnitDraftChildrenCountArgs = {
+  where?: OrgUnitWhereInput;
+};
+
+
+export type OrgUnitDraftContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type OrgUnitDraftContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type OrgUnitDraftDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type OrgUnitDraftDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type OrgUnitDraftServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type OrgUnitDraftServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type OrgUnitDraftTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type OrgUnitDraftTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type OrgUnitDraftTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type OrgUnitDraftTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type OrgUnitDraftUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type OrgUnitDraftUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type OrgUnitDraftCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  children?: InputMaybe<OrgUnitRelateToManyForCreateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  original?: InputMaybe<OrgUnitRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  parent?: InputMaybe<OrgUnitRelateToOneForCreateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  showPage?: InputMaybe<Scalars['Boolean']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type OrgUnitDraftManyRelationFilter = {
+  every?: InputMaybe<OrgUnitDraftWhereInput>;
+  none?: InputMaybe<OrgUnitDraftWhereInput>;
+  some?: InputMaybe<OrgUnitDraftWhereInput>;
+};
+
+export type OrgUnitDraftOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  publish?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  showPage?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type OrgUnitDraftRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<OrgUnitDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<OrgUnitDraftCreateInput>>;
+};
+
+export type OrgUnitDraftRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<OrgUnitDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<OrgUnitDraftCreateInput>>;
+  disconnect?: InputMaybe<Array<OrgUnitDraftWhereUniqueInput>>;
+  set?: InputMaybe<Array<OrgUnitDraftWhereUniqueInput>>;
+};
+
+export type OrgUnitDraftUpdateArgs = {
+  data: OrgUnitDraftUpdateInput;
+  where: OrgUnitDraftWhereUniqueInput;
+};
+
+export type OrgUnitDraftUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  children?: InputMaybe<OrgUnitRelateToManyForUpdateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  original?: InputMaybe<OrgUnitRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  parent?: InputMaybe<OrgUnitRelateToOneForUpdateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  showPage?: InputMaybe<Scalars['Boolean']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type OrgUnitDraftWhereInput = {
+  AND?: InputMaybe<Array<OrgUnitDraftWhereInput>>;
+  NOT?: InputMaybe<Array<OrgUnitDraftWhereInput>>;
+  OR?: InputMaybe<Array<OrgUnitDraftWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  children?: InputMaybe<OrgUnitManyRelationFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  original?: InputMaybe<OrgUnitWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  parent?: InputMaybe<OrgUnitWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  showPage?: InputMaybe<BooleanFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type OrgUnitDraftWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type OrgUnitManyRelationFilter = {
+  every?: InputMaybe<OrgUnitWhereInput>;
+  none?: InputMaybe<OrgUnitWhereInput>;
+  some?: InputMaybe<OrgUnitWhereInput>;
+};
+
+export type OrgUnitOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  makeDrafts?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  showPage?: InputMaybe<OrderDirection>;
+  slug?: InputMaybe<OrderDirection>;
+  status?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type OrgUnitRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<OrgUnitWhereUniqueInput>>;
+  create?: InputMaybe<Array<OrgUnitCreateInput>>;
+};
+
+export type OrgUnitRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<OrgUnitWhereUniqueInput>>;
+  create?: InputMaybe<Array<OrgUnitCreateInput>>;
+  disconnect?: InputMaybe<Array<OrgUnitWhereUniqueInput>>;
+  set?: InputMaybe<Array<OrgUnitWhereUniqueInput>>;
+};
+
+export type OrgUnitRelateToOneForCreateInput = {
+  connect?: InputMaybe<OrgUnitWhereUniqueInput>;
+  create?: InputMaybe<OrgUnitCreateInput>;
+};
+
+export type OrgUnitRelateToOneForUpdateInput = {
+  connect?: InputMaybe<OrgUnitWhereUniqueInput>;
+  create?: InputMaybe<OrgUnitCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type OrgUnitUpdateArgs = {
+  data: OrgUnitUpdateInput;
+  where: OrgUnitWhereUniqueInput;
+};
+
+export type OrgUnitUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  children?: InputMaybe<OrgUnitRelateToManyForUpdateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<OrgUnitVersionRelateToOneForUpdateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  drafts?: InputMaybe<OrgUnitDraftRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  parent?: InputMaybe<OrgUnitRelateToOneForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  showPage?: InputMaybe<Scalars['Boolean']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+  versions?: InputMaybe<OrgUnitVersionRelateToManyForUpdateInput>;
+};
+
+export type OrgUnitVersion = {
+  __typename?: 'OrgUnitVersion';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  children?: Maybe<Array<OrgUnit>>;
+  childrenCount?: Maybe<Scalars['Int']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  isLive?: Maybe<OrgUnit>;
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  original?: Maybe<OrgUnit>;
+  owner?: Maybe<User>;
+  parent?: Maybe<OrgUnit>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  republish?: Maybe<Scalars['String']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  showPage?: Maybe<Scalars['Boolean']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type OrgUnitVersionActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type OrgUnitVersionActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type OrgUnitVersionChildrenArgs = {
+  cursor?: InputMaybe<OrgUnitWhereUniqueInput>;
+  orderBy?: Array<OrgUnitOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitWhereInput;
+};
+
+
+export type OrgUnitVersionChildrenCountArgs = {
+  where?: OrgUnitWhereInput;
+};
+
+
+export type OrgUnitVersionContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type OrgUnitVersionContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type OrgUnitVersionDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type OrgUnitVersionDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type OrgUnitVersionServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type OrgUnitVersionServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type OrgUnitVersionTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type OrgUnitVersionTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type OrgUnitVersionTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type OrgUnitVersionTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type OrgUnitVersionUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type OrgUnitVersionUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type OrgUnitVersionCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  children?: InputMaybe<OrgUnitRelateToManyForCreateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  isLive?: InputMaybe<OrgUnitRelateToOneForCreateInput>;
+  original?: InputMaybe<OrgUnitRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  parent?: InputMaybe<OrgUnitRelateToOneForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  showPage?: InputMaybe<Scalars['Boolean']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type OrgUnitVersionManyRelationFilter = {
+  every?: InputMaybe<OrgUnitVersionWhereInput>;
+  none?: InputMaybe<OrgUnitVersionWhereInput>;
+  some?: InputMaybe<OrgUnitVersionWhereInput>;
+};
+
+export type OrgUnitVersionOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  republish?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  showPage?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type OrgUnitVersionRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<OrgUnitVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<OrgUnitVersionCreateInput>>;
+};
+
+export type OrgUnitVersionRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<OrgUnitVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<OrgUnitVersionCreateInput>>;
+  disconnect?: InputMaybe<Array<OrgUnitVersionWhereUniqueInput>>;
+  set?: InputMaybe<Array<OrgUnitVersionWhereUniqueInput>>;
+};
+
+export type OrgUnitVersionRelateToOneForCreateInput = {
+  connect?: InputMaybe<OrgUnitVersionWhereUniqueInput>;
+  create?: InputMaybe<OrgUnitVersionCreateInput>;
+};
+
+export type OrgUnitVersionRelateToOneForUpdateInput = {
+  connect?: InputMaybe<OrgUnitVersionWhereUniqueInput>;
+  create?: InputMaybe<OrgUnitVersionCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type OrgUnitVersionUpdateArgs = {
+  data: OrgUnitVersionUpdateInput;
+  where: OrgUnitVersionWhereUniqueInput;
+};
+
+export type OrgUnitVersionUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  children?: InputMaybe<OrgUnitRelateToManyForUpdateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  isLive?: InputMaybe<OrgUnitRelateToOneForUpdateInput>;
+  original?: InputMaybe<OrgUnitRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  parent?: InputMaybe<OrgUnitRelateToOneForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  showPage?: InputMaybe<Scalars['Boolean']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type OrgUnitVersionWhereInput = {
+  AND?: InputMaybe<Array<OrgUnitVersionWhereInput>>;
+  NOT?: InputMaybe<Array<OrgUnitVersionWhereInput>>;
+  OR?: InputMaybe<Array<OrgUnitVersionWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  children?: InputMaybe<OrgUnitManyRelationFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  isLive?: InputMaybe<OrgUnitWhereInput>;
+  original?: InputMaybe<OrgUnitWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  parent?: InputMaybe<OrgUnitWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  showPage?: InputMaybe<BooleanFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type OrgUnitVersionWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  isLive?: InputMaybe<OrgUnitWhereUniqueInput>;
+};
+
+export type OrgUnitWhereInput = {
+  AND?: InputMaybe<Array<OrgUnitWhereInput>>;
+  NOT?: InputMaybe<Array<OrgUnitWhereInput>>;
+  OR?: InputMaybe<Array<OrgUnitWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  children?: InputMaybe<OrgUnitManyRelationFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  currentVersion?: InputMaybe<OrgUnitVersionWhereInput>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  drafts?: InputMaybe<OrgUnitDraftManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  owner?: InputMaybe<UserWhereInput>;
+  parent?: InputMaybe<OrgUnitWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  showPage?: InputMaybe<BooleanFilter>;
+  slug?: InputMaybe<StringFilter>;
+  status?: InputMaybe<StringFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+  versions?: InputMaybe<OrgUnitVersionManyRelationFilter>;
+};
+
+export type OrgUnitWhereUniqueInput = {
+  currentVersion?: InputMaybe<OrgUnitVersionWhereUniqueInput>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type Park = {
+  __typename?: 'Park';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  address?: Maybe<Location>;
+  body?: Maybe<Scalars['String']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  currentVersion?: Maybe<ParkVersion>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  drafts?: Maybe<Array<ParkDraft>>;
+  draftsCount?: Maybe<Scalars['Int']['output']>;
+  facilities?: Maybe<Array<Facility>>;
+  facilitiesCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  hours?: Maybe<Array<OperatingHour>>;
+  hoursCount?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  makeDrafts?: Maybe<Scalars['String']['output']>;
+  owner?: Maybe<User>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  trails?: Maybe<Array<Trail>>;
+  trailsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+  versions?: Maybe<Array<ParkVersion>>;
+  versionsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type ParkActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type ParkActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type ParkContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type ParkContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type ParkDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type ParkDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type ParkDraftsArgs = {
+  cursor?: InputMaybe<ParkDraftWhereUniqueInput>;
+  orderBy?: Array<ParkDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ParkDraftWhereInput;
+};
+
+
+export type ParkDraftsCountArgs = {
+  where?: ParkDraftWhereInput;
+};
+
+
+export type ParkFacilitiesArgs = {
+  cursor?: InputMaybe<FacilityWhereUniqueInput>;
+  orderBy?: Array<FacilityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityWhereInput;
+};
+
+
+export type ParkFacilitiesCountArgs = {
+  where?: FacilityWhereInput;
+};
+
+
+export type ParkHoursArgs = {
+  cursor?: InputMaybe<OperatingHourWhereUniqueInput>;
+  orderBy?: Array<OperatingHourOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OperatingHourWhereInput;
+};
+
+
+export type ParkHoursCountArgs = {
+  where?: OperatingHourWhereInput;
+};
+
+
+export type ParkServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type ParkServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type ParkTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type ParkTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type ParkTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type ParkTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type ParkTrailsArgs = {
+  cursor?: InputMaybe<TrailWhereUniqueInput>;
+  orderBy?: Array<TrailOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailWhereInput;
+};
+
+
+export type ParkTrailsCountArgs = {
+  where?: TrailWhereInput;
+};
+
+
+export type ParkUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type ParkUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+
+export type ParkVersionsArgs = {
+  cursor?: InputMaybe<ParkVersionWhereUniqueInput>;
+  orderBy?: Array<ParkVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ParkVersionWhereInput;
+};
+
+
+export type ParkVersionsCountArgs = {
+  where?: ParkVersionWhereInput;
+};
+
+export type ParkCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  address?: InputMaybe<LocationRelateToOneForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<ParkVersionRelateToOneForCreateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  drafts?: InputMaybe<ParkDraftRelateToManyForCreateInput>;
+  facilities?: InputMaybe<FacilityRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hours?: InputMaybe<OperatingHourRelateToManyForCreateInput>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  trails?: InputMaybe<TrailRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+  versions?: InputMaybe<ParkVersionRelateToManyForCreateInput>;
+};
+
+export type ParkDraft = {
+  __typename?: 'ParkDraft';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  address?: Maybe<Location>;
+  body?: Maybe<Scalars['String']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  facilities?: Maybe<Array<Facility>>;
+  facilitiesCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  hours?: Maybe<Array<OperatingHour>>;
+  hoursCount?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  original?: Maybe<Park>;
+  owner?: Maybe<User>;
+  publish?: Maybe<Scalars['String']['output']>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  trails?: Maybe<Array<Trail>>;
+  trailsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type ParkDraftActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type ParkDraftActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type ParkDraftContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type ParkDraftContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type ParkDraftDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type ParkDraftDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type ParkDraftFacilitiesArgs = {
+  cursor?: InputMaybe<FacilityWhereUniqueInput>;
+  orderBy?: Array<FacilityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityWhereInput;
+};
+
+
+export type ParkDraftFacilitiesCountArgs = {
+  where?: FacilityWhereInput;
+};
+
+
+export type ParkDraftHoursArgs = {
+  cursor?: InputMaybe<OperatingHourWhereUniqueInput>;
+  orderBy?: Array<OperatingHourOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OperatingHourWhereInput;
+};
+
+
+export type ParkDraftHoursCountArgs = {
+  where?: OperatingHourWhereInput;
+};
+
+
+export type ParkDraftServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type ParkDraftServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type ParkDraftTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type ParkDraftTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type ParkDraftTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type ParkDraftTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type ParkDraftTrailsArgs = {
+  cursor?: InputMaybe<TrailWhereUniqueInput>;
+  orderBy?: Array<TrailOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailWhereInput;
+};
+
+
+export type ParkDraftTrailsCountArgs = {
+  where?: TrailWhereInput;
+};
+
+
+export type ParkDraftUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type ParkDraftUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type ParkDraftCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  address?: InputMaybe<LocationRelateToOneForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  facilities?: InputMaybe<FacilityRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hours?: InputMaybe<OperatingHourRelateToManyForCreateInput>;
+  original?: InputMaybe<ParkRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  trails?: InputMaybe<TrailRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type ParkDraftManyRelationFilter = {
+  every?: InputMaybe<ParkDraftWhereInput>;
+  none?: InputMaybe<ParkDraftWhereInput>;
+  some?: InputMaybe<ParkDraftWhereInput>;
+};
+
+export type ParkDraftOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  publish?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type ParkDraftRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<ParkDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<ParkDraftCreateInput>>;
+};
+
+export type ParkDraftRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<ParkDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<ParkDraftCreateInput>>;
+  disconnect?: InputMaybe<Array<ParkDraftWhereUniqueInput>>;
+  set?: InputMaybe<Array<ParkDraftWhereUniqueInput>>;
+};
+
+export type ParkDraftUpdateArgs = {
+  data: ParkDraftUpdateInput;
+  where: ParkDraftWhereUniqueInput;
+};
+
+export type ParkDraftUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  address?: InputMaybe<LocationRelateToOneForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  facilities?: InputMaybe<FacilityRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hours?: InputMaybe<OperatingHourRelateToManyForUpdateInput>;
+  original?: InputMaybe<ParkRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  trails?: InputMaybe<TrailRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type ParkDraftWhereInput = {
+  AND?: InputMaybe<Array<ParkDraftWhereInput>>;
+  NOT?: InputMaybe<Array<ParkDraftWhereInput>>;
+  OR?: InputMaybe<Array<ParkDraftWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  address?: InputMaybe<LocationWhereInput>;
+  body?: InputMaybe<MyStringFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  facilities?: InputMaybe<FacilityManyRelationFilter>;
+  hours?: InputMaybe<OperatingHourManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  original?: InputMaybe<ParkWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  trails?: InputMaybe<TrailManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type ParkDraftWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type ParkManyRelationFilter = {
+  every?: InputMaybe<ParkWhereInput>;
+  none?: InputMaybe<ParkWhereInput>;
+  some?: InputMaybe<ParkWhereInput>;
+};
+
+export type ParkOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  makeDrafts?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  slug?: InputMaybe<OrderDirection>;
+  status?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type ParkRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<ParkWhereUniqueInput>>;
+  create?: InputMaybe<Array<ParkCreateInput>>;
+};
+
+export type ParkRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<ParkWhereUniqueInput>>;
+  create?: InputMaybe<Array<ParkCreateInput>>;
+  disconnect?: InputMaybe<Array<ParkWhereUniqueInput>>;
+  set?: InputMaybe<Array<ParkWhereUniqueInput>>;
+};
+
+export type ParkRelateToOneForCreateInput = {
+  connect?: InputMaybe<ParkWhereUniqueInput>;
+  create?: InputMaybe<ParkCreateInput>;
+};
+
+export type ParkRelateToOneForUpdateInput = {
+  connect?: InputMaybe<ParkWhereUniqueInput>;
+  create?: InputMaybe<ParkCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type ParkUpdateArgs = {
+  data: ParkUpdateInput;
+  where: ParkWhereUniqueInput;
+};
+
+export type ParkUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  address?: InputMaybe<LocationRelateToOneForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<ParkVersionRelateToOneForUpdateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  drafts?: InputMaybe<ParkDraftRelateToManyForUpdateInput>;
+  facilities?: InputMaybe<FacilityRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hours?: InputMaybe<OperatingHourRelateToManyForUpdateInput>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  trails?: InputMaybe<TrailRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+  versions?: InputMaybe<ParkVersionRelateToManyForUpdateInput>;
+};
+
+export type ParkVersion = {
+  __typename?: 'ParkVersion';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  address?: Maybe<Location>;
+  body?: Maybe<Scalars['String']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  facilities?: Maybe<Array<Facility>>;
+  facilitiesCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  hours?: Maybe<Array<OperatingHour>>;
+  hoursCount?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  isLive?: Maybe<Park>;
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  original?: Maybe<Park>;
+  owner?: Maybe<User>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  republish?: Maybe<Scalars['String']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  trails?: Maybe<Array<Trail>>;
+  trailsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type ParkVersionActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type ParkVersionActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type ParkVersionContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type ParkVersionContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type ParkVersionDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type ParkVersionDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type ParkVersionFacilitiesArgs = {
+  cursor?: InputMaybe<FacilityWhereUniqueInput>;
+  orderBy?: Array<FacilityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityWhereInput;
+};
+
+
+export type ParkVersionFacilitiesCountArgs = {
+  where?: FacilityWhereInput;
+};
+
+
+export type ParkVersionHoursArgs = {
+  cursor?: InputMaybe<OperatingHourWhereUniqueInput>;
+  orderBy?: Array<OperatingHourOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OperatingHourWhereInput;
+};
+
+
+export type ParkVersionHoursCountArgs = {
+  where?: OperatingHourWhereInput;
+};
+
+
+export type ParkVersionServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type ParkVersionServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type ParkVersionTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type ParkVersionTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type ParkVersionTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type ParkVersionTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type ParkVersionTrailsArgs = {
+  cursor?: InputMaybe<TrailWhereUniqueInput>;
+  orderBy?: Array<TrailOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailWhereInput;
+};
+
+
+export type ParkVersionTrailsCountArgs = {
+  where?: TrailWhereInput;
+};
+
+
+export type ParkVersionUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type ParkVersionUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type ParkVersionCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  address?: InputMaybe<LocationRelateToOneForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  facilities?: InputMaybe<FacilityRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hours?: InputMaybe<OperatingHourRelateToManyForCreateInput>;
+  isLive?: InputMaybe<ParkRelateToOneForCreateInput>;
+  original?: InputMaybe<ParkRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  trails?: InputMaybe<TrailRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type ParkVersionManyRelationFilter = {
+  every?: InputMaybe<ParkVersionWhereInput>;
+  none?: InputMaybe<ParkVersionWhereInput>;
+  some?: InputMaybe<ParkVersionWhereInput>;
+};
+
+export type ParkVersionOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  republish?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type ParkVersionRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<ParkVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<ParkVersionCreateInput>>;
+};
+
+export type ParkVersionRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<ParkVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<ParkVersionCreateInput>>;
+  disconnect?: InputMaybe<Array<ParkVersionWhereUniqueInput>>;
+  set?: InputMaybe<Array<ParkVersionWhereUniqueInput>>;
+};
+
+export type ParkVersionRelateToOneForCreateInput = {
+  connect?: InputMaybe<ParkVersionWhereUniqueInput>;
+  create?: InputMaybe<ParkVersionCreateInput>;
+};
+
+export type ParkVersionRelateToOneForUpdateInput = {
+  connect?: InputMaybe<ParkVersionWhereUniqueInput>;
+  create?: InputMaybe<ParkVersionCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type ParkVersionUpdateArgs = {
+  data: ParkVersionUpdateInput;
+  where: ParkVersionWhereUniqueInput;
+};
+
+export type ParkVersionUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  address?: InputMaybe<LocationRelateToOneForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  facilities?: InputMaybe<FacilityRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hours?: InputMaybe<OperatingHourRelateToManyForUpdateInput>;
+  isLive?: InputMaybe<ParkRelateToOneForUpdateInput>;
+  original?: InputMaybe<ParkRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  trails?: InputMaybe<TrailRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type ParkVersionWhereInput = {
+  AND?: InputMaybe<Array<ParkVersionWhereInput>>;
+  NOT?: InputMaybe<Array<ParkVersionWhereInput>>;
+  OR?: InputMaybe<Array<ParkVersionWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  address?: InputMaybe<LocationWhereInput>;
+  body?: InputMaybe<MyStringFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  facilities?: InputMaybe<FacilityManyRelationFilter>;
+  hours?: InputMaybe<OperatingHourManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  isLive?: InputMaybe<ParkWhereInput>;
+  original?: InputMaybe<ParkWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  trails?: InputMaybe<TrailManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type ParkVersionWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  isLive?: InputMaybe<ParkWhereUniqueInput>;
+};
+
+export type ParkWhereInput = {
+  AND?: InputMaybe<Array<ParkWhereInput>>;
+  NOT?: InputMaybe<Array<ParkWhereInput>>;
+  OR?: InputMaybe<Array<ParkWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  address?: InputMaybe<LocationWhereInput>;
+  body?: InputMaybe<MyStringFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  currentVersion?: InputMaybe<ParkVersionWhereInput>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  drafts?: InputMaybe<ParkDraftManyRelationFilter>;
+  facilities?: InputMaybe<FacilityManyRelationFilter>;
+  hours?: InputMaybe<OperatingHourManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  owner?: InputMaybe<UserWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  slug?: InputMaybe<StringFilter>;
+  status?: InputMaybe<StringFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  trails?: InputMaybe<TrailManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+  versions?: InputMaybe<ParkVersionManyRelationFilter>;
+};
+
+export type ParkWhereUniqueInput = {
+  currentVersion?: InputMaybe<ParkVersionWhereUniqueInput>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type PasswordFilter = {
+  isSet: Scalars['Boolean']['input'];
+};
+
+export type PasswordState = {
+  __typename?: 'PasswordState';
+  isSet: Scalars['Boolean']['output'];
+};
+
+export type PublicNotice = {
+  __typename?: 'PublicNotice';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  assemblyDistricts?: Maybe<Array<AssemblyDistrict>>;
+  assemblyDistrictsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  communities?: Maybe<Array<Community>>;
+  communitiesCount?: Maybe<Scalars['Int']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  currentVersion?: Maybe<PublicNoticeVersion>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  drafts?: Maybe<Array<PublicNoticeDraft>>;
+  draftsCount?: Maybe<Scalars['Int']['output']>;
+  effectiveDate?: Maybe<Scalars['DateTime']['output']>;
+  endDate?: Maybe<Scalars['DateTime']['output']>;
+  facilities?: Maybe<Array<Facility>>;
+  facilitiesCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  makeDrafts?: Maybe<Scalars['String']['output']>;
+  orgUnits?: Maybe<Array<OrgUnit>>;
+  orgUnitsCount?: Maybe<Scalars['Int']['output']>;
+  owner?: Maybe<User>;
+  parks?: Maybe<Array<Park>>;
+  parksCount?: Maybe<Scalars['Int']['output']>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  trails?: Maybe<Array<Trail>>;
+  trailsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  urgency?: Maybe<Scalars['Int']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+  versions?: Maybe<Array<PublicNoticeVersion>>;
+  versionsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type PublicNoticeActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type PublicNoticeActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type PublicNoticeAssemblyDistrictsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type PublicNoticeAssemblyDistrictsCountArgs = {
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type PublicNoticeCommunitiesArgs = {
+  cursor?: InputMaybe<CommunityWhereUniqueInput>;
+  orderBy?: Array<CommunityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityWhereInput;
+};
+
+
+export type PublicNoticeCommunitiesCountArgs = {
+  where?: CommunityWhereInput;
+};
+
+
+export type PublicNoticeContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type PublicNoticeContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type PublicNoticeDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type PublicNoticeDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type PublicNoticeDraftsArgs = {
+  cursor?: InputMaybe<PublicNoticeDraftWhereUniqueInput>;
+  orderBy?: Array<PublicNoticeDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: PublicNoticeDraftWhereInput;
+};
+
+
+export type PublicNoticeDraftsCountArgs = {
+  where?: PublicNoticeDraftWhereInput;
+};
+
+
+export type PublicNoticeFacilitiesArgs = {
+  cursor?: InputMaybe<FacilityWhereUniqueInput>;
+  orderBy?: Array<FacilityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityWhereInput;
+};
+
+
+export type PublicNoticeFacilitiesCountArgs = {
+  where?: FacilityWhereInput;
+};
+
+
+export type PublicNoticeOrgUnitsArgs = {
+  cursor?: InputMaybe<OrgUnitWhereUniqueInput>;
+  orderBy?: Array<OrgUnitOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitWhereInput;
+};
+
+
+export type PublicNoticeOrgUnitsCountArgs = {
+  where?: OrgUnitWhereInput;
+};
+
+
+export type PublicNoticeParksArgs = {
+  cursor?: InputMaybe<ParkWhereUniqueInput>;
+  orderBy?: Array<ParkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ParkWhereInput;
+};
+
+
+export type PublicNoticeParksCountArgs = {
+  where?: ParkWhereInput;
+};
+
+
+export type PublicNoticeServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type PublicNoticeServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type PublicNoticeTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type PublicNoticeTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type PublicNoticeTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type PublicNoticeTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type PublicNoticeTrailsArgs = {
+  cursor?: InputMaybe<TrailWhereUniqueInput>;
+  orderBy?: Array<TrailOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailWhereInput;
+};
+
+
+export type PublicNoticeTrailsCountArgs = {
+  where?: TrailWhereInput;
+};
+
+
+export type PublicNoticeUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type PublicNoticeUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+
+export type PublicNoticeVersionsArgs = {
+  cursor?: InputMaybe<PublicNoticeVersionWhereUniqueInput>;
+  orderBy?: Array<PublicNoticeVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: PublicNoticeVersionWhereInput;
+};
+
+
+export type PublicNoticeVersionsCountArgs = {
+  where?: PublicNoticeVersionWhereInput;
+};
+
+export type PublicNoticeCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  assemblyDistricts?: InputMaybe<AssemblyDistrictRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForCreateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<PublicNoticeVersionRelateToOneForCreateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  drafts?: InputMaybe<PublicNoticeDraftRelateToManyForCreateInput>;
+  effectiveDate?: InputMaybe<Scalars['DateTime']['input']>;
+  endDate?: InputMaybe<Scalars['DateTime']['input']>;
+  facilities?: InputMaybe<FacilityRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  parks?: InputMaybe<ParkRelateToManyForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  trails?: InputMaybe<TrailRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  urgency?: InputMaybe<Scalars['Int']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+  versions?: InputMaybe<PublicNoticeVersionRelateToManyForCreateInput>;
+};
+
+export type PublicNoticeDraft = {
+  __typename?: 'PublicNoticeDraft';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  assemblyDistricts?: Maybe<Array<AssemblyDistrict>>;
+  assemblyDistrictsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  communities?: Maybe<Array<Community>>;
+  communitiesCount?: Maybe<Scalars['Int']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  effectiveDate?: Maybe<Scalars['DateTime']['output']>;
+  endDate?: Maybe<Scalars['DateTime']['output']>;
+  facilities?: Maybe<Array<Facility>>;
+  facilitiesCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  orgUnits?: Maybe<Array<OrgUnit>>;
+  orgUnitsCount?: Maybe<Scalars['Int']['output']>;
+  original?: Maybe<PublicNotice>;
+  owner?: Maybe<User>;
+  parks?: Maybe<Array<Park>>;
+  parksCount?: Maybe<Scalars['Int']['output']>;
+  publish?: Maybe<Scalars['String']['output']>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  trails?: Maybe<Array<Trail>>;
+  trailsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  urgency?: Maybe<Scalars['Int']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type PublicNoticeDraftActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type PublicNoticeDraftActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type PublicNoticeDraftAssemblyDistrictsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type PublicNoticeDraftAssemblyDistrictsCountArgs = {
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type PublicNoticeDraftCommunitiesArgs = {
+  cursor?: InputMaybe<CommunityWhereUniqueInput>;
+  orderBy?: Array<CommunityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityWhereInput;
+};
+
+
+export type PublicNoticeDraftCommunitiesCountArgs = {
+  where?: CommunityWhereInput;
+};
+
+
+export type PublicNoticeDraftContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type PublicNoticeDraftContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type PublicNoticeDraftDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type PublicNoticeDraftDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type PublicNoticeDraftFacilitiesArgs = {
+  cursor?: InputMaybe<FacilityWhereUniqueInput>;
+  orderBy?: Array<FacilityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityWhereInput;
+};
+
+
+export type PublicNoticeDraftFacilitiesCountArgs = {
+  where?: FacilityWhereInput;
+};
+
+
+export type PublicNoticeDraftOrgUnitsArgs = {
+  cursor?: InputMaybe<OrgUnitWhereUniqueInput>;
+  orderBy?: Array<OrgUnitOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitWhereInput;
+};
+
+
+export type PublicNoticeDraftOrgUnitsCountArgs = {
+  where?: OrgUnitWhereInput;
+};
+
+
+export type PublicNoticeDraftParksArgs = {
+  cursor?: InputMaybe<ParkWhereUniqueInput>;
+  orderBy?: Array<ParkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ParkWhereInput;
+};
+
+
+export type PublicNoticeDraftParksCountArgs = {
+  where?: ParkWhereInput;
+};
+
+
+export type PublicNoticeDraftServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type PublicNoticeDraftServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type PublicNoticeDraftTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type PublicNoticeDraftTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type PublicNoticeDraftTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type PublicNoticeDraftTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type PublicNoticeDraftTrailsArgs = {
+  cursor?: InputMaybe<TrailWhereUniqueInput>;
+  orderBy?: Array<TrailOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailWhereInput;
+};
+
+
+export type PublicNoticeDraftTrailsCountArgs = {
+  where?: TrailWhereInput;
+};
+
+
+export type PublicNoticeDraftUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type PublicNoticeDraftUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type PublicNoticeDraftCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  assemblyDistricts?: InputMaybe<AssemblyDistrictRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForCreateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  effectiveDate?: InputMaybe<Scalars['DateTime']['input']>;
+  endDate?: InputMaybe<Scalars['DateTime']['input']>;
+  facilities?: InputMaybe<FacilityRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForCreateInput>;
+  original?: InputMaybe<PublicNoticeRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  parks?: InputMaybe<ParkRelateToManyForCreateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  trails?: InputMaybe<TrailRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  urgency?: InputMaybe<Scalars['Int']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type PublicNoticeDraftManyRelationFilter = {
+  every?: InputMaybe<PublicNoticeDraftWhereInput>;
+  none?: InputMaybe<PublicNoticeDraftWhereInput>;
+  some?: InputMaybe<PublicNoticeDraftWhereInput>;
+};
+
+export type PublicNoticeDraftOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  effectiveDate?: InputMaybe<OrderDirection>;
+  endDate?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  publish?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+  urgency?: InputMaybe<OrderDirection>;
+};
+
+export type PublicNoticeDraftRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<PublicNoticeDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<PublicNoticeDraftCreateInput>>;
+};
+
+export type PublicNoticeDraftRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<PublicNoticeDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<PublicNoticeDraftCreateInput>>;
+  disconnect?: InputMaybe<Array<PublicNoticeDraftWhereUniqueInput>>;
+  set?: InputMaybe<Array<PublicNoticeDraftWhereUniqueInput>>;
+};
+
+export type PublicNoticeDraftUpdateArgs = {
+  data: PublicNoticeDraftUpdateInput;
+  where: PublicNoticeDraftWhereUniqueInput;
+};
+
+export type PublicNoticeDraftUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  assemblyDistricts?: InputMaybe<AssemblyDistrictRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForUpdateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  effectiveDate?: InputMaybe<Scalars['DateTime']['input']>;
+  endDate?: InputMaybe<Scalars['DateTime']['input']>;
+  facilities?: InputMaybe<FacilityRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForUpdateInput>;
+  original?: InputMaybe<PublicNoticeRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  parks?: InputMaybe<ParkRelateToManyForUpdateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  trails?: InputMaybe<TrailRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  urgency?: InputMaybe<Scalars['Int']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type PublicNoticeDraftWhereInput = {
+  AND?: InputMaybe<Array<PublicNoticeDraftWhereInput>>;
+  NOT?: InputMaybe<Array<PublicNoticeDraftWhereInput>>;
+  OR?: InputMaybe<Array<PublicNoticeDraftWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  assemblyDistricts?: InputMaybe<AssemblyDistrictManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  communities?: InputMaybe<CommunityManyRelationFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  effectiveDate?: InputMaybe<DateTimeNullableFilter>;
+  endDate?: InputMaybe<DateTimeNullableFilter>;
+  facilities?: InputMaybe<FacilityManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  orgUnits?: InputMaybe<OrgUnitManyRelationFilter>;
+  original?: InputMaybe<PublicNoticeWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  parks?: InputMaybe<ParkManyRelationFilter>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  trails?: InputMaybe<TrailManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  urgency?: InputMaybe<IntFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type PublicNoticeDraftWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type PublicNoticeManyRelationFilter = {
+  every?: InputMaybe<PublicNoticeWhereInput>;
+  none?: InputMaybe<PublicNoticeWhereInput>;
+  some?: InputMaybe<PublicNoticeWhereInput>;
+};
+
+export type PublicNoticeOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  effectiveDate?: InputMaybe<OrderDirection>;
+  endDate?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  makeDrafts?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  slug?: InputMaybe<OrderDirection>;
+  status?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+  urgency?: InputMaybe<OrderDirection>;
+};
+
+export type PublicNoticeRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<PublicNoticeWhereUniqueInput>>;
+  create?: InputMaybe<Array<PublicNoticeCreateInput>>;
+};
+
+export type PublicNoticeRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<PublicNoticeWhereUniqueInput>>;
+  create?: InputMaybe<Array<PublicNoticeCreateInput>>;
+  disconnect?: InputMaybe<Array<PublicNoticeWhereUniqueInput>>;
+  set?: InputMaybe<Array<PublicNoticeWhereUniqueInput>>;
+};
+
+export type PublicNoticeRelateToOneForCreateInput = {
+  connect?: InputMaybe<PublicNoticeWhereUniqueInput>;
+  create?: InputMaybe<PublicNoticeCreateInput>;
+};
+
+export type PublicNoticeRelateToOneForUpdateInput = {
+  connect?: InputMaybe<PublicNoticeWhereUniqueInput>;
+  create?: InputMaybe<PublicNoticeCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type PublicNoticeUpdateArgs = {
+  data: PublicNoticeUpdateInput;
+  where: PublicNoticeWhereUniqueInput;
+};
+
+export type PublicNoticeUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  assemblyDistricts?: InputMaybe<AssemblyDistrictRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForUpdateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<PublicNoticeVersionRelateToOneForUpdateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  drafts?: InputMaybe<PublicNoticeDraftRelateToManyForUpdateInput>;
+  effectiveDate?: InputMaybe<Scalars['DateTime']['input']>;
+  endDate?: InputMaybe<Scalars['DateTime']['input']>;
+  facilities?: InputMaybe<FacilityRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  parks?: InputMaybe<ParkRelateToManyForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  trails?: InputMaybe<TrailRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  urgency?: InputMaybe<Scalars['Int']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+  versions?: InputMaybe<PublicNoticeVersionRelateToManyForUpdateInput>;
+};
+
+export type PublicNoticeVersion = {
+  __typename?: 'PublicNoticeVersion';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  assemblyDistricts?: Maybe<Array<AssemblyDistrict>>;
+  assemblyDistrictsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  communities?: Maybe<Array<Community>>;
+  communitiesCount?: Maybe<Scalars['Int']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  effectiveDate?: Maybe<Scalars['DateTime']['output']>;
+  endDate?: Maybe<Scalars['DateTime']['output']>;
+  facilities?: Maybe<Array<Facility>>;
+  facilitiesCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  isLive?: Maybe<PublicNotice>;
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  orgUnits?: Maybe<Array<OrgUnit>>;
+  orgUnitsCount?: Maybe<Scalars['Int']['output']>;
+  original?: Maybe<PublicNotice>;
+  owner?: Maybe<User>;
+  parks?: Maybe<Array<Park>>;
+  parksCount?: Maybe<Scalars['Int']['output']>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  republish?: Maybe<Scalars['String']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  trails?: Maybe<Array<Trail>>;
+  trailsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  urgency?: Maybe<Scalars['Int']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type PublicNoticeVersionActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type PublicNoticeVersionActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type PublicNoticeVersionAssemblyDistrictsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type PublicNoticeVersionAssemblyDistrictsCountArgs = {
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type PublicNoticeVersionCommunitiesArgs = {
+  cursor?: InputMaybe<CommunityWhereUniqueInput>;
+  orderBy?: Array<CommunityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityWhereInput;
+};
+
+
+export type PublicNoticeVersionCommunitiesCountArgs = {
+  where?: CommunityWhereInput;
+};
+
+
+export type PublicNoticeVersionContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type PublicNoticeVersionContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type PublicNoticeVersionDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type PublicNoticeVersionDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type PublicNoticeVersionFacilitiesArgs = {
+  cursor?: InputMaybe<FacilityWhereUniqueInput>;
+  orderBy?: Array<FacilityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityWhereInput;
+};
+
+
+export type PublicNoticeVersionFacilitiesCountArgs = {
+  where?: FacilityWhereInput;
+};
+
+
+export type PublicNoticeVersionOrgUnitsArgs = {
+  cursor?: InputMaybe<OrgUnitWhereUniqueInput>;
+  orderBy?: Array<OrgUnitOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitWhereInput;
+};
+
+
+export type PublicNoticeVersionOrgUnitsCountArgs = {
+  where?: OrgUnitWhereInput;
+};
+
+
+export type PublicNoticeVersionParksArgs = {
+  cursor?: InputMaybe<ParkWhereUniqueInput>;
+  orderBy?: Array<ParkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ParkWhereInput;
+};
+
+
+export type PublicNoticeVersionParksCountArgs = {
+  where?: ParkWhereInput;
+};
+
+
+export type PublicNoticeVersionServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type PublicNoticeVersionServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type PublicNoticeVersionTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type PublicNoticeVersionTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type PublicNoticeVersionTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type PublicNoticeVersionTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type PublicNoticeVersionTrailsArgs = {
+  cursor?: InputMaybe<TrailWhereUniqueInput>;
+  orderBy?: Array<TrailOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailWhereInput;
+};
+
+
+export type PublicNoticeVersionTrailsCountArgs = {
+  where?: TrailWhereInput;
+};
+
+
+export type PublicNoticeVersionUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type PublicNoticeVersionUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type PublicNoticeVersionCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  assemblyDistricts?: InputMaybe<AssemblyDistrictRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForCreateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  effectiveDate?: InputMaybe<Scalars['DateTime']['input']>;
+  endDate?: InputMaybe<Scalars['DateTime']['input']>;
+  facilities?: InputMaybe<FacilityRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  isLive?: InputMaybe<PublicNoticeRelateToOneForCreateInput>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForCreateInput>;
+  original?: InputMaybe<PublicNoticeRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  parks?: InputMaybe<ParkRelateToManyForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  trails?: InputMaybe<TrailRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  urgency?: InputMaybe<Scalars['Int']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type PublicNoticeVersionManyRelationFilter = {
+  every?: InputMaybe<PublicNoticeVersionWhereInput>;
+  none?: InputMaybe<PublicNoticeVersionWhereInput>;
+  some?: InputMaybe<PublicNoticeVersionWhereInput>;
+};
+
+export type PublicNoticeVersionOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  effectiveDate?: InputMaybe<OrderDirection>;
+  endDate?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  republish?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+  urgency?: InputMaybe<OrderDirection>;
+};
+
+export type PublicNoticeVersionRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<PublicNoticeVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<PublicNoticeVersionCreateInput>>;
+};
+
+export type PublicNoticeVersionRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<PublicNoticeVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<PublicNoticeVersionCreateInput>>;
+  disconnect?: InputMaybe<Array<PublicNoticeVersionWhereUniqueInput>>;
+  set?: InputMaybe<Array<PublicNoticeVersionWhereUniqueInput>>;
+};
+
+export type PublicNoticeVersionRelateToOneForCreateInput = {
+  connect?: InputMaybe<PublicNoticeVersionWhereUniqueInput>;
+  create?: InputMaybe<PublicNoticeVersionCreateInput>;
+};
+
+export type PublicNoticeVersionRelateToOneForUpdateInput = {
+  connect?: InputMaybe<PublicNoticeVersionWhereUniqueInput>;
+  create?: InputMaybe<PublicNoticeVersionCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type PublicNoticeVersionUpdateArgs = {
+  data: PublicNoticeVersionUpdateInput;
+  where: PublicNoticeVersionWhereUniqueInput;
+};
+
+export type PublicNoticeVersionUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  assemblyDistricts?: InputMaybe<AssemblyDistrictRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForUpdateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  effectiveDate?: InputMaybe<Scalars['DateTime']['input']>;
+  endDate?: InputMaybe<Scalars['DateTime']['input']>;
+  facilities?: InputMaybe<FacilityRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  isLive?: InputMaybe<PublicNoticeRelateToOneForUpdateInput>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForUpdateInput>;
+  original?: InputMaybe<PublicNoticeRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  parks?: InputMaybe<ParkRelateToManyForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  trails?: InputMaybe<TrailRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  urgency?: InputMaybe<Scalars['Int']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type PublicNoticeVersionWhereInput = {
+  AND?: InputMaybe<Array<PublicNoticeVersionWhereInput>>;
+  NOT?: InputMaybe<Array<PublicNoticeVersionWhereInput>>;
+  OR?: InputMaybe<Array<PublicNoticeVersionWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  assemblyDistricts?: InputMaybe<AssemblyDistrictManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  communities?: InputMaybe<CommunityManyRelationFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  effectiveDate?: InputMaybe<DateTimeNullableFilter>;
+  endDate?: InputMaybe<DateTimeNullableFilter>;
+  facilities?: InputMaybe<FacilityManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  isLive?: InputMaybe<PublicNoticeWhereInput>;
+  orgUnits?: InputMaybe<OrgUnitManyRelationFilter>;
+  original?: InputMaybe<PublicNoticeWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  parks?: InputMaybe<ParkManyRelationFilter>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  trails?: InputMaybe<TrailManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  urgency?: InputMaybe<IntFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type PublicNoticeVersionWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  isLive?: InputMaybe<PublicNoticeWhereUniqueInput>;
+};
+
+export type PublicNoticeWhereInput = {
+  AND?: InputMaybe<Array<PublicNoticeWhereInput>>;
+  NOT?: InputMaybe<Array<PublicNoticeWhereInput>>;
+  OR?: InputMaybe<Array<PublicNoticeWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  assemblyDistricts?: InputMaybe<AssemblyDistrictManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  communities?: InputMaybe<CommunityManyRelationFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  currentVersion?: InputMaybe<PublicNoticeVersionWhereInput>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  drafts?: InputMaybe<PublicNoticeDraftManyRelationFilter>;
+  effectiveDate?: InputMaybe<DateTimeNullableFilter>;
+  endDate?: InputMaybe<DateTimeNullableFilter>;
+  facilities?: InputMaybe<FacilityManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  orgUnits?: InputMaybe<OrgUnitManyRelationFilter>;
+  owner?: InputMaybe<UserWhereInput>;
+  parks?: InputMaybe<ParkManyRelationFilter>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  slug?: InputMaybe<StringFilter>;
+  status?: InputMaybe<StringFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  trails?: InputMaybe<TrailManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  urgency?: InputMaybe<IntFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+  versions?: InputMaybe<PublicNoticeVersionManyRelationFilter>;
+};
+
+export type PublicNoticeWhereUniqueInput = {
+  currentVersion?: InputMaybe<PublicNoticeVersionWhereUniqueInput>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  alert?: Maybe<Alert>;
+  alerts?: Maybe<Array<Alert>>;
+  alertsCount?: Maybe<Scalars['Int']['output']>;
+  assemblyDistrict?: Maybe<AssemblyDistrict>;
+  assemblyDistrictDraft?: Maybe<AssemblyDistrictDraft>;
+  assemblyDistrictDrafts?: Maybe<Array<AssemblyDistrictDraft>>;
+  assemblyDistrictDraftsCount?: Maybe<Scalars['Int']['output']>;
+  assemblyDistrictVersion?: Maybe<AssemblyDistrictVersion>;
+  assemblyDistrictVersions?: Maybe<Array<AssemblyDistrictVersion>>;
+  assemblyDistrictVersionsCount?: Maybe<Scalars['Int']['output']>;
+  assemblyDistricts?: Maybe<Array<AssemblyDistrict>>;
+  assemblyDistrictsCount?: Maybe<Scalars['Int']['output']>;
+  board?: Maybe<Board>;
+  boardDraft?: Maybe<BoardDraft>;
+  boardDrafts?: Maybe<Array<BoardDraft>>;
+  boardDraftsCount?: Maybe<Scalars['Int']['output']>;
+  boardPage?: Maybe<BoardPage>;
+  boardPages?: Maybe<Array<BoardPage>>;
+  boardPagesCount?: Maybe<Scalars['Int']['output']>;
+  boardVersion?: Maybe<BoardVersion>;
+  boardVersions?: Maybe<Array<BoardVersion>>;
+  boardVersionsCount?: Maybe<Scalars['Int']['output']>;
+  boards?: Maybe<Array<Board>>;
+  boardsCount?: Maybe<Scalars['Int']['output']>;
+  communities?: Maybe<Array<Community>>;
+  communitiesCount?: Maybe<Scalars['Int']['output']>;
+  community?: Maybe<Community>;
+  communityDraft?: Maybe<CommunityDraft>;
+  communityDrafts?: Maybe<Array<CommunityDraft>>;
+  communityDraftsCount?: Maybe<Scalars['Int']['output']>;
+  communityVersion?: Maybe<CommunityVersion>;
+  communityVersions?: Maybe<Array<CommunityVersion>>;
+  communityVersionsCount?: Maybe<Scalars['Int']['output']>;
+  contact?: Maybe<Contact>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  document?: Maybe<Document>;
+  documentCollection?: Maybe<DocumentCollection>;
+  documentCollections?: Maybe<Array<DocumentCollection>>;
+  documentCollectionsCount?: Maybe<Scalars['Int']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  externalLink?: Maybe<ExternalLink>;
+  externalLinks?: Maybe<Array<ExternalLink>>;
+  externalLinksCount?: Maybe<Scalars['Int']['output']>;
+  facilities?: Maybe<Array<Facility>>;
+  facilitiesCount?: Maybe<Scalars['Int']['output']>;
+  facility?: Maybe<Facility>;
+  facilityDraft?: Maybe<FacilityDraft>;
+  facilityDrafts?: Maybe<Array<FacilityDraft>>;
+  facilityDraftsCount?: Maybe<Scalars['Int']['output']>;
+  facilityVersion?: Maybe<FacilityVersion>;
+  facilityVersions?: Maybe<Array<FacilityVersion>>;
+  facilityVersionsCount?: Maybe<Scalars['Int']['output']>;
+  getInternalLink?: Maybe<InternalLinkSearch>;
+  highlight?: Maybe<Highlight>;
+  highlights?: Maybe<Array<Highlight>>;
+  highlightsCount?: Maybe<Scalars['Int']['output']>;
+  homePage?: Maybe<HomePage>;
+  homePages?: Maybe<Array<HomePage>>;
+  homePagesCount?: Maybe<Scalars['Int']['output']>;
+  image?: Maybe<Image>;
+  images?: Maybe<Array<Image>>;
+  imagesCount?: Maybe<Scalars['Int']['output']>;
+  internalLink?: Maybe<InternalLink>;
+  internalLinks?: Maybe<Array<InternalLink>>;
+  internalLinksCount?: Maybe<Scalars['Int']['output']>;
+  internalSearch?: Maybe<Array<Maybe<InternalLinkSearch>>>;
+  keystone: KeystoneMeta;
+  location?: Maybe<Location>;
+  locations?: Maybe<Array<Location>>;
+  locationsCount?: Maybe<Scalars['Int']['output']>;
+  operatingHour?: Maybe<OperatingHour>;
+  operatingHours?: Maybe<Array<OperatingHour>>;
+  operatingHoursCount?: Maybe<Scalars['Int']['output']>;
+  orgUnit?: Maybe<OrgUnit>;
+  orgUnitDraft?: Maybe<OrgUnitDraft>;
+  orgUnitDrafts?: Maybe<Array<OrgUnitDraft>>;
+  orgUnitDraftsCount?: Maybe<Scalars['Int']['output']>;
+  orgUnitVersion?: Maybe<OrgUnitVersion>;
+  orgUnitVersions?: Maybe<Array<OrgUnitVersion>>;
+  orgUnitVersionsCount?: Maybe<Scalars['Int']['output']>;
+  orgUnits?: Maybe<Array<OrgUnit>>;
+  orgUnitsCount?: Maybe<Scalars['Int']['output']>;
+  park?: Maybe<Park>;
+  parkDraft?: Maybe<ParkDraft>;
+  parkDrafts?: Maybe<Array<ParkDraft>>;
+  parkDraftsCount?: Maybe<Scalars['Int']['output']>;
+  parkVersion?: Maybe<ParkVersion>;
+  parkVersions?: Maybe<Array<ParkVersion>>;
+  parkVersionsCount?: Maybe<Scalars['Int']['output']>;
+  parks?: Maybe<Array<Park>>;
+  parksCount?: Maybe<Scalars['Int']['output']>;
+  publicNotice?: Maybe<PublicNotice>;
+  publicNoticeDraft?: Maybe<PublicNoticeDraft>;
+  publicNoticeDrafts?: Maybe<Array<PublicNoticeDraft>>;
+  publicNoticeDraftsCount?: Maybe<Scalars['Int']['output']>;
+  publicNoticeVersion?: Maybe<PublicNoticeVersion>;
+  publicNoticeVersions?: Maybe<Array<PublicNoticeVersion>>;
+  publicNoticeVersionsCount?: Maybe<Scalars['Int']['output']>;
+  publicNotices?: Maybe<Array<PublicNotice>>;
+  publicNoticesCount?: Maybe<Scalars['Int']['output']>;
+  service?: Maybe<Service>;
+  serviceDraft?: Maybe<ServiceDraft>;
+  serviceDrafts?: Maybe<Array<ServiceDraft>>;
+  serviceDraftsCount?: Maybe<Scalars['Int']['output']>;
+  serviceVersion?: Maybe<ServiceVersion>;
+  serviceVersions?: Maybe<Array<ServiceVersion>>;
+  serviceVersionsCount?: Maybe<Scalars['Int']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  tag?: Maybe<Tag>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  topic?: Maybe<Topic>;
+  topicDraft?: Maybe<TopicDraft>;
+  topicDrafts?: Maybe<Array<TopicDraft>>;
+  topicDraftsCount?: Maybe<Scalars['Int']['output']>;
+  topicVersion?: Maybe<TopicVersion>;
+  topicVersions?: Maybe<Array<TopicVersion>>;
+  topicVersionsCount?: Maybe<Scalars['Int']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  trail?: Maybe<Trail>;
+  trailDraft?: Maybe<TrailDraft>;
+  trailDrafts?: Maybe<Array<TrailDraft>>;
+  trailDraftsCount?: Maybe<Scalars['Int']['output']>;
+  trailVersion?: Maybe<TrailVersion>;
+  trailVersions?: Maybe<Array<TrailVersion>>;
+  trailVersionsCount?: Maybe<Scalars['Int']['output']>;
+  trails?: Maybe<Array<Trail>>;
+  trailsCount?: Maybe<Scalars['Int']['output']>;
+  url?: Maybe<Url>;
+  urls?: Maybe<Array<Url>>;
+  urlsCount?: Maybe<Scalars['Int']['output']>;
+  user?: Maybe<User>;
+  userGroup?: Maybe<UserGroup>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+  users?: Maybe<Array<User>>;
+  usersCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type QueryAlertArgs = {
+  where: AlertWhereUniqueInput;
+};
+
+
+export type QueryAlertsArgs = {
+  cursor?: InputMaybe<AlertWhereUniqueInput>;
+  orderBy?: Array<AlertOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AlertWhereInput;
+};
+
+
+export type QueryAlertsCountArgs = {
+  where?: AlertWhereInput;
+};
+
+
+export type QueryAssemblyDistrictArgs = {
+  where: AssemblyDistrictWhereUniqueInput;
+};
+
+
+export type QueryAssemblyDistrictDraftArgs = {
+  where: AssemblyDistrictDraftWhereUniqueInput;
+};
+
+
+export type QueryAssemblyDistrictDraftsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictDraftWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictDraftWhereInput;
+};
+
+
+export type QueryAssemblyDistrictDraftsCountArgs = {
+  where?: AssemblyDistrictDraftWhereInput;
+};
+
+
+export type QueryAssemblyDistrictVersionArgs = {
+  where: AssemblyDistrictVersionWhereUniqueInput;
+};
+
+
+export type QueryAssemblyDistrictVersionsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictVersionWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictVersionWhereInput;
+};
+
+
+export type QueryAssemblyDistrictVersionsCountArgs = {
+  where?: AssemblyDistrictVersionWhereInput;
+};
+
+
+export type QueryAssemblyDistrictsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type QueryAssemblyDistrictsCountArgs = {
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type QueryBoardArgs = {
+  where: BoardWhereUniqueInput;
+};
+
+
+export type QueryBoardDraftArgs = {
+  where: BoardDraftWhereUniqueInput;
+};
+
+
+export type QueryBoardDraftsArgs = {
+  cursor?: InputMaybe<BoardDraftWhereUniqueInput>;
+  orderBy?: Array<BoardDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: BoardDraftWhereInput;
+};
+
+
+export type QueryBoardDraftsCountArgs = {
+  where?: BoardDraftWhereInput;
+};
+
+
+export type QueryBoardPageArgs = {
+  where?: BoardPageWhereUniqueInput;
+};
+
+
+export type QueryBoardPagesArgs = {
+  cursor?: InputMaybe<BoardPageWhereUniqueInput>;
+  orderBy?: Array<BoardPageOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: BoardPageWhereInput;
+};
+
+
+export type QueryBoardPagesCountArgs = {
+  where?: BoardPageWhereInput;
+};
+
+
+export type QueryBoardVersionArgs = {
+  where: BoardVersionWhereUniqueInput;
+};
+
+
+export type QueryBoardVersionsArgs = {
+  cursor?: InputMaybe<BoardVersionWhereUniqueInput>;
+  orderBy?: Array<BoardVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: BoardVersionWhereInput;
+};
+
+
+export type QueryBoardVersionsCountArgs = {
+  where?: BoardVersionWhereInput;
+};
+
+
+export type QueryBoardsArgs = {
+  cursor?: InputMaybe<BoardWhereUniqueInput>;
+  orderBy?: Array<BoardOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: BoardWhereInput;
+};
+
+
+export type QueryBoardsCountArgs = {
+  where?: BoardWhereInput;
+};
+
+
+export type QueryCommunitiesArgs = {
+  cursor?: InputMaybe<CommunityWhereUniqueInput>;
+  orderBy?: Array<CommunityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityWhereInput;
+};
+
+
+export type QueryCommunitiesCountArgs = {
+  where?: CommunityWhereInput;
+};
+
+
+export type QueryCommunityArgs = {
+  where: CommunityWhereUniqueInput;
+};
+
+
+export type QueryCommunityDraftArgs = {
+  where: CommunityDraftWhereUniqueInput;
+};
+
+
+export type QueryCommunityDraftsArgs = {
+  cursor?: InputMaybe<CommunityDraftWhereUniqueInput>;
+  orderBy?: Array<CommunityDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityDraftWhereInput;
+};
+
+
+export type QueryCommunityDraftsCountArgs = {
+  where?: CommunityDraftWhereInput;
+};
+
+
+export type QueryCommunityVersionArgs = {
+  where: CommunityVersionWhereUniqueInput;
+};
+
+
+export type QueryCommunityVersionsArgs = {
+  cursor?: InputMaybe<CommunityVersionWhereUniqueInput>;
+  orderBy?: Array<CommunityVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityVersionWhereInput;
+};
+
+
+export type QueryCommunityVersionsCountArgs = {
+  where?: CommunityVersionWhereInput;
+};
+
+
+export type QueryContactArgs = {
+  where: ContactWhereUniqueInput;
+};
+
+
+export type QueryContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type QueryContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type QueryDocumentArgs = {
+  where: DocumentWhereUniqueInput;
+};
+
+
+export type QueryDocumentCollectionArgs = {
+  where: DocumentCollectionWhereUniqueInput;
+};
+
+
+export type QueryDocumentCollectionsArgs = {
+  cursor?: InputMaybe<DocumentCollectionWhereUniqueInput>;
+  orderBy?: Array<DocumentCollectionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentCollectionWhereInput;
+};
+
+
+export type QueryDocumentCollectionsCountArgs = {
+  where?: DocumentCollectionWhereInput;
+};
+
+
+export type QueryDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type QueryDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type QueryExternalLinkArgs = {
+  where: ExternalLinkWhereUniqueInput;
+};
+
+
+export type QueryExternalLinksArgs = {
+  cursor?: InputMaybe<ExternalLinkWhereUniqueInput>;
+  orderBy?: Array<ExternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ExternalLinkWhereInput;
+};
+
+
+export type QueryExternalLinksCountArgs = {
+  where?: ExternalLinkWhereInput;
+};
+
+
+export type QueryFacilitiesArgs = {
+  cursor?: InputMaybe<FacilityWhereUniqueInput>;
+  orderBy?: Array<FacilityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityWhereInput;
+};
+
+
+export type QueryFacilitiesCountArgs = {
+  where?: FacilityWhereInput;
+};
+
+
+export type QueryFacilityArgs = {
+  where: FacilityWhereUniqueInput;
+};
+
+
+export type QueryFacilityDraftArgs = {
+  where: FacilityDraftWhereUniqueInput;
+};
+
+
+export type QueryFacilityDraftsArgs = {
+  cursor?: InputMaybe<FacilityDraftWhereUniqueInput>;
+  orderBy?: Array<FacilityDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityDraftWhereInput;
+};
+
+
+export type QueryFacilityDraftsCountArgs = {
+  where?: FacilityDraftWhereInput;
+};
+
+
+export type QueryFacilityVersionArgs = {
+  where: FacilityVersionWhereUniqueInput;
+};
+
+
+export type QueryFacilityVersionsArgs = {
+  cursor?: InputMaybe<FacilityVersionWhereUniqueInput>;
+  orderBy?: Array<FacilityVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityVersionWhereInput;
+};
+
+
+export type QueryFacilityVersionsCountArgs = {
+  where?: FacilityVersionWhereInput;
+};
+
+
+export type QueryGetInternalLinkArgs = {
+  id: Scalars['ID']['input'];
+  type: Scalars['String']['input'];
+};
+
+
+export type QueryHighlightArgs = {
+  where: HighlightWhereUniqueInput;
+};
+
+
+export type QueryHighlightsArgs = {
+  cursor?: InputMaybe<HighlightWhereUniqueInput>;
+  orderBy?: Array<HighlightOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: HighlightWhereInput;
+};
+
+
+export type QueryHighlightsCountArgs = {
+  where?: HighlightWhereInput;
+};
+
+
+export type QueryHomePageArgs = {
+  where?: HomePageWhereUniqueInput;
+};
+
+
+export type QueryHomePagesArgs = {
+  cursor?: InputMaybe<HomePageWhereUniqueInput>;
+  orderBy?: Array<HomePageOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: HomePageWhereInput;
+};
+
+
+export type QueryHomePagesCountArgs = {
+  where?: HomePageWhereInput;
+};
+
+
+export type QueryImageArgs = {
+  where: ImageWhereUniqueInput;
+};
+
+
+export type QueryImagesArgs = {
+  cursor?: InputMaybe<ImageWhereUniqueInput>;
+  orderBy?: Array<ImageOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ImageWhereInput;
+};
+
+
+export type QueryImagesCountArgs = {
+  where?: ImageWhereInput;
+};
+
+
+export type QueryInternalLinkArgs = {
+  where: InternalLinkWhereUniqueInput;
+};
+
+
+export type QueryInternalLinksArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type QueryInternalLinksCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type QueryInternalSearchArgs = {
+  query?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryLocationArgs = {
+  where: LocationWhereUniqueInput;
+};
+
+
+export type QueryLocationsArgs = {
+  cursor?: InputMaybe<LocationWhereUniqueInput>;
+  orderBy?: Array<LocationOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: LocationWhereInput;
+};
+
+
+export type QueryLocationsCountArgs = {
+  where?: LocationWhereInput;
+};
+
+
+export type QueryOperatingHourArgs = {
+  where: OperatingHourWhereUniqueInput;
+};
+
+
+export type QueryOperatingHoursArgs = {
+  cursor?: InputMaybe<OperatingHourWhereUniqueInput>;
+  orderBy?: Array<OperatingHourOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OperatingHourWhereInput;
+};
+
+
+export type QueryOperatingHoursCountArgs = {
+  where?: OperatingHourWhereInput;
+};
+
+
+export type QueryOrgUnitArgs = {
+  where: OrgUnitWhereUniqueInput;
+};
+
+
+export type QueryOrgUnitDraftArgs = {
+  where: OrgUnitDraftWhereUniqueInput;
+};
+
+
+export type QueryOrgUnitDraftsArgs = {
+  cursor?: InputMaybe<OrgUnitDraftWhereUniqueInput>;
+  orderBy?: Array<OrgUnitDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitDraftWhereInput;
+};
+
+
+export type QueryOrgUnitDraftsCountArgs = {
+  where?: OrgUnitDraftWhereInput;
+};
+
+
+export type QueryOrgUnitVersionArgs = {
+  where: OrgUnitVersionWhereUniqueInput;
+};
+
+
+export type QueryOrgUnitVersionsArgs = {
+  cursor?: InputMaybe<OrgUnitVersionWhereUniqueInput>;
+  orderBy?: Array<OrgUnitVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitVersionWhereInput;
+};
+
+
+export type QueryOrgUnitVersionsCountArgs = {
+  where?: OrgUnitVersionWhereInput;
+};
+
+
+export type QueryOrgUnitsArgs = {
+  cursor?: InputMaybe<OrgUnitWhereUniqueInput>;
+  orderBy?: Array<OrgUnitOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitWhereInput;
+};
+
+
+export type QueryOrgUnitsCountArgs = {
+  where?: OrgUnitWhereInput;
+};
+
+
+export type QueryParkArgs = {
+  where: ParkWhereUniqueInput;
+};
+
+
+export type QueryParkDraftArgs = {
+  where: ParkDraftWhereUniqueInput;
+};
+
+
+export type QueryParkDraftsArgs = {
+  cursor?: InputMaybe<ParkDraftWhereUniqueInput>;
+  orderBy?: Array<ParkDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ParkDraftWhereInput;
+};
+
+
+export type QueryParkDraftsCountArgs = {
+  where?: ParkDraftWhereInput;
+};
+
+
+export type QueryParkVersionArgs = {
+  where: ParkVersionWhereUniqueInput;
+};
+
+
+export type QueryParkVersionsArgs = {
+  cursor?: InputMaybe<ParkVersionWhereUniqueInput>;
+  orderBy?: Array<ParkVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ParkVersionWhereInput;
+};
+
+
+export type QueryParkVersionsCountArgs = {
+  where?: ParkVersionWhereInput;
+};
+
+
+export type QueryParksArgs = {
+  cursor?: InputMaybe<ParkWhereUniqueInput>;
+  orderBy?: Array<ParkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ParkWhereInput;
+};
+
+
+export type QueryParksCountArgs = {
+  where?: ParkWhereInput;
+};
+
+
+export type QueryPublicNoticeArgs = {
+  where: PublicNoticeWhereUniqueInput;
+};
+
+
+export type QueryPublicNoticeDraftArgs = {
+  where: PublicNoticeDraftWhereUniqueInput;
+};
+
+
+export type QueryPublicNoticeDraftsArgs = {
+  cursor?: InputMaybe<PublicNoticeDraftWhereUniqueInput>;
+  orderBy?: Array<PublicNoticeDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: PublicNoticeDraftWhereInput;
+};
+
+
+export type QueryPublicNoticeDraftsCountArgs = {
+  where?: PublicNoticeDraftWhereInput;
+};
+
+
+export type QueryPublicNoticeVersionArgs = {
+  where: PublicNoticeVersionWhereUniqueInput;
+};
+
+
+export type QueryPublicNoticeVersionsArgs = {
+  cursor?: InputMaybe<PublicNoticeVersionWhereUniqueInput>;
+  orderBy?: Array<PublicNoticeVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: PublicNoticeVersionWhereInput;
+};
+
+
+export type QueryPublicNoticeVersionsCountArgs = {
+  where?: PublicNoticeVersionWhereInput;
+};
+
+
+export type QueryPublicNoticesArgs = {
+  cursor?: InputMaybe<PublicNoticeWhereUniqueInput>;
+  orderBy?: Array<PublicNoticeOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: PublicNoticeWhereInput;
+};
+
+
+export type QueryPublicNoticesCountArgs = {
+  where?: PublicNoticeWhereInput;
+};
+
+
+export type QueryServiceArgs = {
+  where: ServiceWhereUniqueInput;
+};
+
+
+export type QueryServiceDraftArgs = {
+  where: ServiceDraftWhereUniqueInput;
+};
+
+
+export type QueryServiceDraftsArgs = {
+  cursor?: InputMaybe<ServiceDraftWhereUniqueInput>;
+  orderBy?: Array<ServiceDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceDraftWhereInput;
+};
+
+
+export type QueryServiceDraftsCountArgs = {
+  where?: ServiceDraftWhereInput;
+};
+
+
+export type QueryServiceVersionArgs = {
+  where: ServiceVersionWhereUniqueInput;
+};
+
+
+export type QueryServiceVersionsArgs = {
+  cursor?: InputMaybe<ServiceVersionWhereUniqueInput>;
+  orderBy?: Array<ServiceVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceVersionWhereInput;
+};
+
+
+export type QueryServiceVersionsCountArgs = {
+  where?: ServiceVersionWhereInput;
+};
+
+
+export type QueryServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type QueryServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type QueryTagArgs = {
+  where: TagWhereUniqueInput;
+};
+
+
+export type QueryTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type QueryTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type QueryTopicArgs = {
+  where: TopicWhereUniqueInput;
+};
+
+
+export type QueryTopicDraftArgs = {
+  where: TopicDraftWhereUniqueInput;
+};
+
+
+export type QueryTopicDraftsArgs = {
+  cursor?: InputMaybe<TopicDraftWhereUniqueInput>;
+  orderBy?: Array<TopicDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicDraftWhereInput;
+};
+
+
+export type QueryTopicDraftsCountArgs = {
+  where?: TopicDraftWhereInput;
+};
+
+
+export type QueryTopicVersionArgs = {
+  where: TopicVersionWhereUniqueInput;
+};
+
+
+export type QueryTopicVersionsArgs = {
+  cursor?: InputMaybe<TopicVersionWhereUniqueInput>;
+  orderBy?: Array<TopicVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicVersionWhereInput;
+};
+
+
+export type QueryTopicVersionsCountArgs = {
+  where?: TopicVersionWhereInput;
+};
+
+
+export type QueryTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type QueryTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type QueryTrailArgs = {
+  where: TrailWhereUniqueInput;
+};
+
+
+export type QueryTrailDraftArgs = {
+  where: TrailDraftWhereUniqueInput;
+};
+
+
+export type QueryTrailDraftsArgs = {
+  cursor?: InputMaybe<TrailDraftWhereUniqueInput>;
+  orderBy?: Array<TrailDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailDraftWhereInput;
+};
+
+
+export type QueryTrailDraftsCountArgs = {
+  where?: TrailDraftWhereInput;
+};
+
+
+export type QueryTrailVersionArgs = {
+  where: TrailVersionWhereUniqueInput;
+};
+
+
+export type QueryTrailVersionsArgs = {
+  cursor?: InputMaybe<TrailVersionWhereUniqueInput>;
+  orderBy?: Array<TrailVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailVersionWhereInput;
+};
+
+
+export type QueryTrailVersionsCountArgs = {
+  where?: TrailVersionWhereInput;
+};
+
+
+export type QueryTrailsArgs = {
+  cursor?: InputMaybe<TrailWhereUniqueInput>;
+  orderBy?: Array<TrailOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailWhereInput;
+};
+
+
+export type QueryTrailsCountArgs = {
+  where?: TrailWhereInput;
+};
+
+
+export type QueryUrlArgs = {
+  where: UrlWhereUniqueInput;
+};
+
+
+export type QueryUrlsArgs = {
+  cursor?: InputMaybe<UrlWhereUniqueInput>;
+  orderBy?: Array<UrlOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UrlWhereInput;
+};
+
+
+export type QueryUrlsCountArgs = {
+  where?: UrlWhereInput;
+};
+
+
+export type QueryUserArgs = {
+  where: UserWhereUniqueInput;
+};
+
+
+export type QueryUserGroupArgs = {
+  where: UserGroupWhereUniqueInput;
+};
+
+
+export type QueryUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type QueryUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+
+export type QueryUsersArgs = {
+  cursor?: InputMaybe<UserWhereUniqueInput>;
+  orderBy?: Array<UserOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserWhereInput;
+};
+
+
+export type QueryUsersCountArgs = {
+  where?: UserWhereInput;
+};
+
+export enum QueryMode {
+  Default = 'default',
+  Insensitive = 'insensitive'
+}
+
+export type Service = {
+  __typename?: 'Service';
+  body?: Maybe<Scalars['String']['output']>;
+  communities?: Maybe<Array<Community>>;
+  communitiesCount?: Maybe<Scalars['Int']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  currentVersion?: Maybe<ServiceVersion>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  drafts?: Maybe<Array<ServiceDraft>>;
+  draftsCount?: Maybe<Scalars['Int']['output']>;
+  editorNotes?: Maybe<Scalars['String']['output']>;
+  facilities?: Maybe<Array<Facility>>;
+  facilitiesCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  makeDrafts?: Maybe<Scalars['String']['output']>;
+  orgUnits?: Maybe<Array<OrgUnit>>;
+  orgUnitsCount?: Maybe<Scalars['Int']['output']>;
+  owner?: Maybe<User>;
+  parks?: Maybe<Array<Park>>;
+  parksCount?: Maybe<Scalars['Int']['output']>;
+  primaryAction?: Maybe<ExternalLink>;
+  primaryContact?: Maybe<Contact>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  secondaryActions?: Maybe<Array<ExternalLink>>;
+  secondaryActionsCount?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  trails?: Maybe<Array<Trail>>;
+  trailsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+  versions?: Maybe<Array<ServiceVersion>>;
+  versionsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type ServiceCommunitiesArgs = {
+  cursor?: InputMaybe<CommunityWhereUniqueInput>;
+  orderBy?: Array<CommunityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityWhereInput;
+};
+
+
+export type ServiceCommunitiesCountArgs = {
+  where?: CommunityWhereInput;
+};
+
+
+export type ServiceContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type ServiceContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type ServiceDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type ServiceDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type ServiceDraftsArgs = {
+  cursor?: InputMaybe<ServiceDraftWhereUniqueInput>;
+  orderBy?: Array<ServiceDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceDraftWhereInput;
+};
+
+
+export type ServiceDraftsCountArgs = {
+  where?: ServiceDraftWhereInput;
+};
+
+
+export type ServiceFacilitiesArgs = {
+  cursor?: InputMaybe<FacilityWhereUniqueInput>;
+  orderBy?: Array<FacilityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityWhereInput;
+};
+
+
+export type ServiceFacilitiesCountArgs = {
+  where?: FacilityWhereInput;
+};
+
+
+export type ServiceOrgUnitsArgs = {
+  cursor?: InputMaybe<OrgUnitWhereUniqueInput>;
+  orderBy?: Array<OrgUnitOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitWhereInput;
+};
+
+
+export type ServiceOrgUnitsCountArgs = {
+  where?: OrgUnitWhereInput;
+};
+
+
+export type ServiceParksArgs = {
+  cursor?: InputMaybe<ParkWhereUniqueInput>;
+  orderBy?: Array<ParkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ParkWhereInput;
+};
+
+
+export type ServiceParksCountArgs = {
+  where?: ParkWhereInput;
+};
+
+
+export type ServiceSecondaryActionsArgs = {
+  cursor?: InputMaybe<ExternalLinkWhereUniqueInput>;
+  orderBy?: Array<ExternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ExternalLinkWhereInput;
+};
+
+
+export type ServiceSecondaryActionsCountArgs = {
+  where?: ExternalLinkWhereInput;
+};
+
+
+export type ServiceTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type ServiceTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type ServiceTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type ServiceTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type ServiceTrailsArgs = {
+  cursor?: InputMaybe<TrailWhereUniqueInput>;
+  orderBy?: Array<TrailOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailWhereInput;
+};
+
+
+export type ServiceTrailsCountArgs = {
+  where?: TrailWhereInput;
+};
+
+
+export type ServiceUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type ServiceUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+
+export type ServiceVersionsArgs = {
+  cursor?: InputMaybe<ServiceVersionWhereUniqueInput>;
+  orderBy?: Array<ServiceVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceVersionWhereInput;
+};
+
+
+export type ServiceVersionsCountArgs = {
+  where?: ServiceVersionWhereInput;
+};
+
+export type ServiceCreateInput = {
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForCreateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<ServiceVersionRelateToOneForCreateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  drafts?: InputMaybe<ServiceDraftRelateToManyForCreateInput>;
+  editorNotes?: InputMaybe<Scalars['String']['input']>;
+  facilities?: InputMaybe<FacilityRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  parks?: InputMaybe<ParkRelateToManyForCreateInput>;
+  primaryAction?: InputMaybe<ExternalLinkRelateToOneForCreateInput>;
+  primaryContact?: InputMaybe<ContactRelateToOneForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  secondaryActions?: InputMaybe<ExternalLinkRelateToManyForCreateInput>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  trails?: InputMaybe<TrailRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+  versions?: InputMaybe<ServiceVersionRelateToManyForCreateInput>;
+};
+
+export type ServiceDraft = {
+  __typename?: 'ServiceDraft';
+  body?: Maybe<Scalars['String']['output']>;
+  communities?: Maybe<Array<Community>>;
+  communitiesCount?: Maybe<Scalars['Int']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  editorNotes?: Maybe<Scalars['String']['output']>;
+  facilities?: Maybe<Array<Facility>>;
+  facilitiesCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  orgUnits?: Maybe<Array<OrgUnit>>;
+  orgUnitsCount?: Maybe<Scalars['Int']['output']>;
+  original?: Maybe<Service>;
+  owner?: Maybe<User>;
+  parks?: Maybe<Array<Park>>;
+  parksCount?: Maybe<Scalars['Int']['output']>;
+  primaryAction?: Maybe<ExternalLink>;
+  primaryContact?: Maybe<Contact>;
+  publish?: Maybe<Scalars['String']['output']>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  secondaryActions?: Maybe<Array<ExternalLink>>;
+  secondaryActionsCount?: Maybe<Scalars['Int']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  trails?: Maybe<Array<Trail>>;
+  trailsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type ServiceDraftCommunitiesArgs = {
+  cursor?: InputMaybe<CommunityWhereUniqueInput>;
+  orderBy?: Array<CommunityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityWhereInput;
+};
+
+
+export type ServiceDraftCommunitiesCountArgs = {
+  where?: CommunityWhereInput;
+};
+
+
+export type ServiceDraftContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type ServiceDraftContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type ServiceDraftDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type ServiceDraftDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type ServiceDraftFacilitiesArgs = {
+  cursor?: InputMaybe<FacilityWhereUniqueInput>;
+  orderBy?: Array<FacilityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityWhereInput;
+};
+
+
+export type ServiceDraftFacilitiesCountArgs = {
+  where?: FacilityWhereInput;
+};
+
+
+export type ServiceDraftOrgUnitsArgs = {
+  cursor?: InputMaybe<OrgUnitWhereUniqueInput>;
+  orderBy?: Array<OrgUnitOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitWhereInput;
+};
+
+
+export type ServiceDraftOrgUnitsCountArgs = {
+  where?: OrgUnitWhereInput;
+};
+
+
+export type ServiceDraftParksArgs = {
+  cursor?: InputMaybe<ParkWhereUniqueInput>;
+  orderBy?: Array<ParkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ParkWhereInput;
+};
+
+
+export type ServiceDraftParksCountArgs = {
+  where?: ParkWhereInput;
+};
+
+
+export type ServiceDraftSecondaryActionsArgs = {
+  cursor?: InputMaybe<ExternalLinkWhereUniqueInput>;
+  orderBy?: Array<ExternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ExternalLinkWhereInput;
+};
+
+
+export type ServiceDraftSecondaryActionsCountArgs = {
+  where?: ExternalLinkWhereInput;
+};
+
+
+export type ServiceDraftTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type ServiceDraftTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type ServiceDraftTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type ServiceDraftTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type ServiceDraftTrailsArgs = {
+  cursor?: InputMaybe<TrailWhereUniqueInput>;
+  orderBy?: Array<TrailOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailWhereInput;
+};
+
+
+export type ServiceDraftTrailsCountArgs = {
+  where?: TrailWhereInput;
+};
+
+
+export type ServiceDraftUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type ServiceDraftUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type ServiceDraftCreateInput = {
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForCreateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  editorNotes?: InputMaybe<Scalars['String']['input']>;
+  facilities?: InputMaybe<FacilityRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForCreateInput>;
+  original?: InputMaybe<ServiceRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  parks?: InputMaybe<ParkRelateToManyForCreateInput>;
+  primaryAction?: InputMaybe<ExternalLinkRelateToOneForCreateInput>;
+  primaryContact?: InputMaybe<ContactRelateToOneForCreateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  secondaryActions?: InputMaybe<ExternalLinkRelateToManyForCreateInput>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  trails?: InputMaybe<TrailRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type ServiceDraftManyRelationFilter = {
+  every?: InputMaybe<ServiceDraftWhereInput>;
+  none?: InputMaybe<ServiceDraftWhereInput>;
+  some?: InputMaybe<ServiceDraftWhereInput>;
+};
+
+export type ServiceDraftOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  editorNotes?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  publish?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type ServiceDraftRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<ServiceDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<ServiceDraftCreateInput>>;
+};
+
+export type ServiceDraftRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<ServiceDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<ServiceDraftCreateInput>>;
+  disconnect?: InputMaybe<Array<ServiceDraftWhereUniqueInput>>;
+  set?: InputMaybe<Array<ServiceDraftWhereUniqueInput>>;
+};
+
+export type ServiceDraftUpdateArgs = {
+  data: ServiceDraftUpdateInput;
+  where: ServiceDraftWhereUniqueInput;
+};
+
+export type ServiceDraftUpdateInput = {
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForUpdateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  editorNotes?: InputMaybe<Scalars['String']['input']>;
+  facilities?: InputMaybe<FacilityRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForUpdateInput>;
+  original?: InputMaybe<ServiceRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  parks?: InputMaybe<ParkRelateToManyForUpdateInput>;
+  primaryAction?: InputMaybe<ExternalLinkRelateToOneForUpdateInput>;
+  primaryContact?: InputMaybe<ContactRelateToOneForUpdateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  secondaryActions?: InputMaybe<ExternalLinkRelateToManyForUpdateInput>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  trails?: InputMaybe<TrailRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type ServiceDraftWhereInput = {
+  AND?: InputMaybe<Array<ServiceDraftWhereInput>>;
+  NOT?: InputMaybe<Array<ServiceDraftWhereInput>>;
+  OR?: InputMaybe<Array<ServiceDraftWhereInput>>;
+  body?: InputMaybe<MyStringFilter>;
+  communities?: InputMaybe<CommunityManyRelationFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  editorNotes?: InputMaybe<StringFilter>;
+  facilities?: InputMaybe<FacilityManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  orgUnits?: InputMaybe<OrgUnitManyRelationFilter>;
+  original?: InputMaybe<ServiceWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  parks?: InputMaybe<ParkManyRelationFilter>;
+  primaryAction?: InputMaybe<ExternalLinkWhereInput>;
+  primaryContact?: InputMaybe<ContactWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  secondaryActions?: InputMaybe<ExternalLinkManyRelationFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  trails?: InputMaybe<TrailManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type ServiceDraftWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type ServiceManyRelationFilter = {
+  every?: InputMaybe<ServiceWhereInput>;
+  none?: InputMaybe<ServiceWhereInput>;
+  some?: InputMaybe<ServiceWhereInput>;
+};
+
+export type ServiceOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  editorNotes?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  makeDrafts?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  slug?: InputMaybe<OrderDirection>;
+  status?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type ServiceRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<ServiceWhereUniqueInput>>;
+  create?: InputMaybe<Array<ServiceCreateInput>>;
+};
+
+export type ServiceRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<ServiceWhereUniqueInput>>;
+  create?: InputMaybe<Array<ServiceCreateInput>>;
+  disconnect?: InputMaybe<Array<ServiceWhereUniqueInput>>;
+  set?: InputMaybe<Array<ServiceWhereUniqueInput>>;
+};
+
+export type ServiceRelateToOneForCreateInput = {
+  connect?: InputMaybe<ServiceWhereUniqueInput>;
+  create?: InputMaybe<ServiceCreateInput>;
+};
+
+export type ServiceRelateToOneForUpdateInput = {
+  connect?: InputMaybe<ServiceWhereUniqueInput>;
+  create?: InputMaybe<ServiceCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type ServiceUpdateArgs = {
+  data: ServiceUpdateInput;
+  where: ServiceWhereUniqueInput;
+};
+
+export type ServiceUpdateInput = {
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForUpdateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<ServiceVersionRelateToOneForUpdateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  drafts?: InputMaybe<ServiceDraftRelateToManyForUpdateInput>;
+  editorNotes?: InputMaybe<Scalars['String']['input']>;
+  facilities?: InputMaybe<FacilityRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  parks?: InputMaybe<ParkRelateToManyForUpdateInput>;
+  primaryAction?: InputMaybe<ExternalLinkRelateToOneForUpdateInput>;
+  primaryContact?: InputMaybe<ContactRelateToOneForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  secondaryActions?: InputMaybe<ExternalLinkRelateToManyForUpdateInput>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  trails?: InputMaybe<TrailRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+  versions?: InputMaybe<ServiceVersionRelateToManyForUpdateInput>;
+};
+
+export type ServiceVersion = {
+  __typename?: 'ServiceVersion';
+  body?: Maybe<Scalars['String']['output']>;
+  communities?: Maybe<Array<Community>>;
+  communitiesCount?: Maybe<Scalars['Int']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  editorNotes?: Maybe<Scalars['String']['output']>;
+  facilities?: Maybe<Array<Facility>>;
+  facilitiesCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  isLive?: Maybe<Service>;
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  orgUnits?: Maybe<Array<OrgUnit>>;
+  orgUnitsCount?: Maybe<Scalars['Int']['output']>;
+  original?: Maybe<Service>;
+  owner?: Maybe<User>;
+  parks?: Maybe<Array<Park>>;
+  parksCount?: Maybe<Scalars['Int']['output']>;
+  primaryAction?: Maybe<ExternalLink>;
+  primaryContact?: Maybe<Contact>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  republish?: Maybe<Scalars['String']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  secondaryActions?: Maybe<Array<ExternalLink>>;
+  secondaryActionsCount?: Maybe<Scalars['Int']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  trails?: Maybe<Array<Trail>>;
+  trailsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type ServiceVersionCommunitiesArgs = {
+  cursor?: InputMaybe<CommunityWhereUniqueInput>;
+  orderBy?: Array<CommunityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityWhereInput;
+};
+
+
+export type ServiceVersionCommunitiesCountArgs = {
+  where?: CommunityWhereInput;
+};
+
+
+export type ServiceVersionContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type ServiceVersionContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type ServiceVersionDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type ServiceVersionDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type ServiceVersionFacilitiesArgs = {
+  cursor?: InputMaybe<FacilityWhereUniqueInput>;
+  orderBy?: Array<FacilityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityWhereInput;
+};
+
+
+export type ServiceVersionFacilitiesCountArgs = {
+  where?: FacilityWhereInput;
+};
+
+
+export type ServiceVersionOrgUnitsArgs = {
+  cursor?: InputMaybe<OrgUnitWhereUniqueInput>;
+  orderBy?: Array<OrgUnitOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitWhereInput;
+};
+
+
+export type ServiceVersionOrgUnitsCountArgs = {
+  where?: OrgUnitWhereInput;
+};
+
+
+export type ServiceVersionParksArgs = {
+  cursor?: InputMaybe<ParkWhereUniqueInput>;
+  orderBy?: Array<ParkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ParkWhereInput;
+};
+
+
+export type ServiceVersionParksCountArgs = {
+  where?: ParkWhereInput;
+};
+
+
+export type ServiceVersionSecondaryActionsArgs = {
+  cursor?: InputMaybe<ExternalLinkWhereUniqueInput>;
+  orderBy?: Array<ExternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ExternalLinkWhereInput;
+};
+
+
+export type ServiceVersionSecondaryActionsCountArgs = {
+  where?: ExternalLinkWhereInput;
+};
+
+
+export type ServiceVersionTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type ServiceVersionTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type ServiceVersionTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type ServiceVersionTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type ServiceVersionTrailsArgs = {
+  cursor?: InputMaybe<TrailWhereUniqueInput>;
+  orderBy?: Array<TrailOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailWhereInput;
+};
+
+
+export type ServiceVersionTrailsCountArgs = {
+  where?: TrailWhereInput;
+};
+
+
+export type ServiceVersionUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type ServiceVersionUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type ServiceVersionCreateInput = {
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForCreateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  editorNotes?: InputMaybe<Scalars['String']['input']>;
+  facilities?: InputMaybe<FacilityRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  isLive?: InputMaybe<ServiceRelateToOneForCreateInput>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForCreateInput>;
+  original?: InputMaybe<ServiceRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  parks?: InputMaybe<ParkRelateToManyForCreateInput>;
+  primaryAction?: InputMaybe<ExternalLinkRelateToOneForCreateInput>;
+  primaryContact?: InputMaybe<ContactRelateToOneForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  secondaryActions?: InputMaybe<ExternalLinkRelateToManyForCreateInput>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  trails?: InputMaybe<TrailRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type ServiceVersionManyRelationFilter = {
+  every?: InputMaybe<ServiceVersionWhereInput>;
+  none?: InputMaybe<ServiceVersionWhereInput>;
+  some?: InputMaybe<ServiceVersionWhereInput>;
+};
+
+export type ServiceVersionOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  editorNotes?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  republish?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type ServiceVersionRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<ServiceVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<ServiceVersionCreateInput>>;
+};
+
+export type ServiceVersionRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<ServiceVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<ServiceVersionCreateInput>>;
+  disconnect?: InputMaybe<Array<ServiceVersionWhereUniqueInput>>;
+  set?: InputMaybe<Array<ServiceVersionWhereUniqueInput>>;
+};
+
+export type ServiceVersionRelateToOneForCreateInput = {
+  connect?: InputMaybe<ServiceVersionWhereUniqueInput>;
+  create?: InputMaybe<ServiceVersionCreateInput>;
+};
+
+export type ServiceVersionRelateToOneForUpdateInput = {
+  connect?: InputMaybe<ServiceVersionWhereUniqueInput>;
+  create?: InputMaybe<ServiceVersionCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type ServiceVersionUpdateArgs = {
+  data: ServiceVersionUpdateInput;
+  where: ServiceVersionWhereUniqueInput;
+};
+
+export type ServiceVersionUpdateInput = {
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForUpdateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  editorNotes?: InputMaybe<Scalars['String']['input']>;
+  facilities?: InputMaybe<FacilityRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  isLive?: InputMaybe<ServiceRelateToOneForUpdateInput>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForUpdateInput>;
+  original?: InputMaybe<ServiceRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  parks?: InputMaybe<ParkRelateToManyForUpdateInput>;
+  primaryAction?: InputMaybe<ExternalLinkRelateToOneForUpdateInput>;
+  primaryContact?: InputMaybe<ContactRelateToOneForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  secondaryActions?: InputMaybe<ExternalLinkRelateToManyForUpdateInput>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  trails?: InputMaybe<TrailRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type ServiceVersionWhereInput = {
+  AND?: InputMaybe<Array<ServiceVersionWhereInput>>;
+  NOT?: InputMaybe<Array<ServiceVersionWhereInput>>;
+  OR?: InputMaybe<Array<ServiceVersionWhereInput>>;
+  body?: InputMaybe<MyStringFilter>;
+  communities?: InputMaybe<CommunityManyRelationFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  editorNotes?: InputMaybe<StringFilter>;
+  facilities?: InputMaybe<FacilityManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  isLive?: InputMaybe<ServiceWhereInput>;
+  orgUnits?: InputMaybe<OrgUnitManyRelationFilter>;
+  original?: InputMaybe<ServiceWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  parks?: InputMaybe<ParkManyRelationFilter>;
+  primaryAction?: InputMaybe<ExternalLinkWhereInput>;
+  primaryContact?: InputMaybe<ContactWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  secondaryActions?: InputMaybe<ExternalLinkManyRelationFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  trails?: InputMaybe<TrailManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type ServiceVersionWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  isLive?: InputMaybe<ServiceWhereUniqueInput>;
+};
+
+export type ServiceWhereInput = {
+  AND?: InputMaybe<Array<ServiceWhereInput>>;
+  NOT?: InputMaybe<Array<ServiceWhereInput>>;
+  OR?: InputMaybe<Array<ServiceWhereInput>>;
+  body?: InputMaybe<MyStringFilter>;
+  communities?: InputMaybe<CommunityManyRelationFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  currentVersion?: InputMaybe<ServiceVersionWhereInput>;
+  description?: InputMaybe<StringFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  drafts?: InputMaybe<ServiceDraftManyRelationFilter>;
+  editorNotes?: InputMaybe<StringFilter>;
+  facilities?: InputMaybe<FacilityManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  orgUnits?: InputMaybe<OrgUnitManyRelationFilter>;
+  owner?: InputMaybe<UserWhereInput>;
+  parks?: InputMaybe<ParkManyRelationFilter>;
+  primaryAction?: InputMaybe<ExternalLinkWhereInput>;
+  primaryContact?: InputMaybe<ContactWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  secondaryActions?: InputMaybe<ExternalLinkManyRelationFilter>;
+  slug?: InputMaybe<StringFilter>;
+  status?: InputMaybe<StringFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  trails?: InputMaybe<TrailManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+  versions?: InputMaybe<ServiceVersionManyRelationFilter>;
+};
+
+export type ServiceWhereUniqueInput = {
+  currentVersion?: InputMaybe<ServiceVersionWhereUniqueInput>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type StringFilter = {
+  contains?: InputMaybe<Scalars['String']['input']>;
+  endsWith?: InputMaybe<Scalars['String']['input']>;
+  equals?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
+  mode?: InputMaybe<QueryMode>;
+  not?: InputMaybe<NestedStringFilter>;
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+  startsWith?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type StringNullableFilter = {
+  contains?: InputMaybe<Scalars['String']['input']>;
+  endsWith?: InputMaybe<Scalars['String']['input']>;
+  equals?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
+  mode?: InputMaybe<QueryMode>;
+  not?: InputMaybe<StringNullableFilter>;
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+  startsWith?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type Tag = {
+  __typename?: 'Tag';
+  id: Scalars['ID']['output'];
+  name?: Maybe<Scalars['String']['output']>;
+};
+
+export type TagCreateInput = {
+  name?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type TagManyRelationFilter = {
+  every?: InputMaybe<TagWhereInput>;
+  none?: InputMaybe<TagWhereInput>;
+  some?: InputMaybe<TagWhereInput>;
+};
+
+export type TagOrderByInput = {
+  id?: InputMaybe<OrderDirection>;
+  name?: InputMaybe<OrderDirection>;
+};
+
+export type TagRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<TagWhereUniqueInput>>;
+  create?: InputMaybe<Array<TagCreateInput>>;
+};
+
+export type TagRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<TagWhereUniqueInput>>;
+  create?: InputMaybe<Array<TagCreateInput>>;
+  disconnect?: InputMaybe<Array<TagWhereUniqueInput>>;
+  set?: InputMaybe<Array<TagWhereUniqueInput>>;
+};
+
+export type TagUpdateArgs = {
+  data: TagUpdateInput;
+  where: TagWhereUniqueInput;
+};
+
+export type TagUpdateInput = {
+  name?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type TagWhereInput = {
+  AND?: InputMaybe<Array<TagWhereInput>>;
+  NOT?: InputMaybe<Array<TagWhereInput>>;
+  OR?: InputMaybe<Array<TagWhereInput>>;
+  id?: InputMaybe<IdFilter>;
+  name?: InputMaybe<StringFilter>;
+};
+
+export type TagWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type Topic = {
+  __typename?: 'Topic';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  boards?: Maybe<Array<Board>>;
+  boardsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  communities?: Maybe<Array<Community>>;
+  communitiesCount?: Maybe<Scalars['Int']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  currentVersion?: Maybe<TopicVersion>;
+  description?: Maybe<Scalars['String']['output']>;
+  districts?: Maybe<Array<AssemblyDistrict>>;
+  districtsCount?: Maybe<Scalars['Int']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  drafts?: Maybe<Array<TopicDraft>>;
+  draftsCount?: Maybe<Scalars['Int']['output']>;
+  facilities?: Maybe<Array<Facility>>;
+  facilitiesCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  highlights?: Maybe<Array<Highlight>>;
+  highlightsCount?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  makeDrafts?: Maybe<Scalars['String']['output']>;
+  orgUnits?: Maybe<Array<OrgUnit>>;
+  orgUnitsCount?: Maybe<Scalars['Int']['output']>;
+  owner?: Maybe<User>;
+  parks?: Maybe<Array<Park>>;
+  parksCount?: Maybe<Scalars['Int']['output']>;
+  publicNotices?: Maybe<Array<PublicNotice>>;
+  publicNoticesCount?: Maybe<Scalars['Int']['output']>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  trails?: Maybe<Array<Trail>>;
+  trailsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+  versions?: Maybe<Array<TopicVersion>>;
+  versionsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type TopicActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type TopicActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type TopicBoardsArgs = {
+  cursor?: InputMaybe<BoardWhereUniqueInput>;
+  orderBy?: Array<BoardOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: BoardWhereInput;
+};
+
+
+export type TopicBoardsCountArgs = {
+  where?: BoardWhereInput;
+};
+
+
+export type TopicCommunitiesArgs = {
+  cursor?: InputMaybe<CommunityWhereUniqueInput>;
+  orderBy?: Array<CommunityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityWhereInput;
+};
+
+
+export type TopicCommunitiesCountArgs = {
+  where?: CommunityWhereInput;
+};
+
+
+export type TopicContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type TopicContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type TopicDistrictsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type TopicDistrictsCountArgs = {
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type TopicDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type TopicDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type TopicDraftsArgs = {
+  cursor?: InputMaybe<TopicDraftWhereUniqueInput>;
+  orderBy?: Array<TopicDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicDraftWhereInput;
+};
+
+
+export type TopicDraftsCountArgs = {
+  where?: TopicDraftWhereInput;
+};
+
+
+export type TopicFacilitiesArgs = {
+  cursor?: InputMaybe<FacilityWhereUniqueInput>;
+  orderBy?: Array<FacilityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityWhereInput;
+};
+
+
+export type TopicFacilitiesCountArgs = {
+  where?: FacilityWhereInput;
+};
+
+
+export type TopicHighlightsArgs = {
+  cursor?: InputMaybe<HighlightWhereUniqueInput>;
+  orderBy?: Array<HighlightOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: HighlightWhereInput;
+};
+
+
+export type TopicHighlightsCountArgs = {
+  where?: HighlightWhereInput;
+};
+
+
+export type TopicOrgUnitsArgs = {
+  cursor?: InputMaybe<OrgUnitWhereUniqueInput>;
+  orderBy?: Array<OrgUnitOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitWhereInput;
+};
+
+
+export type TopicOrgUnitsCountArgs = {
+  where?: OrgUnitWhereInput;
+};
+
+
+export type TopicParksArgs = {
+  cursor?: InputMaybe<ParkWhereUniqueInput>;
+  orderBy?: Array<ParkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ParkWhereInput;
+};
+
+
+export type TopicParksCountArgs = {
+  where?: ParkWhereInput;
+};
+
+
+export type TopicPublicNoticesArgs = {
+  cursor?: InputMaybe<PublicNoticeWhereUniqueInput>;
+  orderBy?: Array<PublicNoticeOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: PublicNoticeWhereInput;
+};
+
+
+export type TopicPublicNoticesCountArgs = {
+  where?: PublicNoticeWhereInput;
+};
+
+
+export type TopicServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type TopicServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type TopicTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type TopicTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type TopicTrailsArgs = {
+  cursor?: InputMaybe<TrailWhereUniqueInput>;
+  orderBy?: Array<TrailOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailWhereInput;
+};
+
+
+export type TopicTrailsCountArgs = {
+  where?: TrailWhereInput;
+};
+
+
+export type TopicUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type TopicUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+
+export type TopicVersionsArgs = {
+  cursor?: InputMaybe<TopicVersionWhereUniqueInput>;
+  orderBy?: Array<TopicVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicVersionWhereInput;
+};
+
+
+export type TopicVersionsCountArgs = {
+  where?: TopicVersionWhereInput;
+};
+
+export type TopicCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  boards?: InputMaybe<BoardRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForCreateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<TopicVersionRelateToOneForCreateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForCreateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  drafts?: InputMaybe<TopicDraftRelateToManyForCreateInput>;
+  facilities?: InputMaybe<FacilityRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  highlights?: InputMaybe<HighlightRelateToManyForCreateInput>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  parks?: InputMaybe<ParkRelateToManyForCreateInput>;
+  publicNotices?: InputMaybe<PublicNoticeRelateToManyForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  trails?: InputMaybe<TrailRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+  versions?: InputMaybe<TopicVersionRelateToManyForCreateInput>;
+};
+
+export type TopicDraft = {
+  __typename?: 'TopicDraft';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  boards?: Maybe<Array<Board>>;
+  boardsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  communities?: Maybe<Array<Community>>;
+  communitiesCount?: Maybe<Scalars['Int']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  districts?: Maybe<Array<AssemblyDistrict>>;
+  districtsCount?: Maybe<Scalars['Int']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  facilities?: Maybe<Array<Facility>>;
+  facilitiesCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  highlights?: Maybe<Array<Highlight>>;
+  highlightsCount?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  orgUnits?: Maybe<Array<OrgUnit>>;
+  orgUnitsCount?: Maybe<Scalars['Int']['output']>;
+  original?: Maybe<Topic>;
+  owner?: Maybe<User>;
+  parks?: Maybe<Array<Park>>;
+  parksCount?: Maybe<Scalars['Int']['output']>;
+  publicNotices?: Maybe<Array<PublicNotice>>;
+  publicNoticesCount?: Maybe<Scalars['Int']['output']>;
+  publish?: Maybe<Scalars['String']['output']>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  trails?: Maybe<Array<Trail>>;
+  trailsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type TopicDraftActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type TopicDraftActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type TopicDraftBoardsArgs = {
+  cursor?: InputMaybe<BoardWhereUniqueInput>;
+  orderBy?: Array<BoardOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: BoardWhereInput;
+};
+
+
+export type TopicDraftBoardsCountArgs = {
+  where?: BoardWhereInput;
+};
+
+
+export type TopicDraftCommunitiesArgs = {
+  cursor?: InputMaybe<CommunityWhereUniqueInput>;
+  orderBy?: Array<CommunityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityWhereInput;
+};
+
+
+export type TopicDraftCommunitiesCountArgs = {
+  where?: CommunityWhereInput;
+};
+
+
+export type TopicDraftContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type TopicDraftContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type TopicDraftDistrictsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type TopicDraftDistrictsCountArgs = {
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type TopicDraftDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type TopicDraftDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type TopicDraftFacilitiesArgs = {
+  cursor?: InputMaybe<FacilityWhereUniqueInput>;
+  orderBy?: Array<FacilityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityWhereInput;
+};
+
+
+export type TopicDraftFacilitiesCountArgs = {
+  where?: FacilityWhereInput;
+};
+
+
+export type TopicDraftHighlightsArgs = {
+  cursor?: InputMaybe<HighlightWhereUniqueInput>;
+  orderBy?: Array<HighlightOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: HighlightWhereInput;
+};
+
+
+export type TopicDraftHighlightsCountArgs = {
+  where?: HighlightWhereInput;
+};
+
+
+export type TopicDraftOrgUnitsArgs = {
+  cursor?: InputMaybe<OrgUnitWhereUniqueInput>;
+  orderBy?: Array<OrgUnitOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitWhereInput;
+};
+
+
+export type TopicDraftOrgUnitsCountArgs = {
+  where?: OrgUnitWhereInput;
+};
+
+
+export type TopicDraftParksArgs = {
+  cursor?: InputMaybe<ParkWhereUniqueInput>;
+  orderBy?: Array<ParkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ParkWhereInput;
+};
+
+
+export type TopicDraftParksCountArgs = {
+  where?: ParkWhereInput;
+};
+
+
+export type TopicDraftPublicNoticesArgs = {
+  cursor?: InputMaybe<PublicNoticeWhereUniqueInput>;
+  orderBy?: Array<PublicNoticeOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: PublicNoticeWhereInput;
+};
+
+
+export type TopicDraftPublicNoticesCountArgs = {
+  where?: PublicNoticeWhereInput;
+};
+
+
+export type TopicDraftServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type TopicDraftServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type TopicDraftTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type TopicDraftTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type TopicDraftTrailsArgs = {
+  cursor?: InputMaybe<TrailWhereUniqueInput>;
+  orderBy?: Array<TrailOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailWhereInput;
+};
+
+
+export type TopicDraftTrailsCountArgs = {
+  where?: TrailWhereInput;
+};
+
+
+export type TopicDraftUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type TopicDraftUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type TopicDraftCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  boards?: InputMaybe<BoardRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForCreateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForCreateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  facilities?: InputMaybe<FacilityRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  highlights?: InputMaybe<HighlightRelateToManyForCreateInput>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForCreateInput>;
+  original?: InputMaybe<TopicRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  parks?: InputMaybe<ParkRelateToManyForCreateInput>;
+  publicNotices?: InputMaybe<PublicNoticeRelateToManyForCreateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  trails?: InputMaybe<TrailRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type TopicDraftManyRelationFilter = {
+  every?: InputMaybe<TopicDraftWhereInput>;
+  none?: InputMaybe<TopicDraftWhereInput>;
+  some?: InputMaybe<TopicDraftWhereInput>;
+};
+
+export type TopicDraftOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  publish?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type TopicDraftRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<TopicDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<TopicDraftCreateInput>>;
+};
+
+export type TopicDraftRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<TopicDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<TopicDraftCreateInput>>;
+  disconnect?: InputMaybe<Array<TopicDraftWhereUniqueInput>>;
+  set?: InputMaybe<Array<TopicDraftWhereUniqueInput>>;
+};
+
+export type TopicDraftUpdateArgs = {
+  data: TopicDraftUpdateInput;
+  where: TopicDraftWhereUniqueInput;
+};
+
+export type TopicDraftUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  boards?: InputMaybe<BoardRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForUpdateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForUpdateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  facilities?: InputMaybe<FacilityRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  highlights?: InputMaybe<HighlightRelateToManyForUpdateInput>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForUpdateInput>;
+  original?: InputMaybe<TopicRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  parks?: InputMaybe<ParkRelateToManyForUpdateInput>;
+  publicNotices?: InputMaybe<PublicNoticeRelateToManyForUpdateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  trails?: InputMaybe<TrailRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type TopicDraftWhereInput = {
+  AND?: InputMaybe<Array<TopicDraftWhereInput>>;
+  NOT?: InputMaybe<Array<TopicDraftWhereInput>>;
+  OR?: InputMaybe<Array<TopicDraftWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  boards?: InputMaybe<BoardManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  communities?: InputMaybe<CommunityManyRelationFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  districts?: InputMaybe<AssemblyDistrictManyRelationFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  facilities?: InputMaybe<FacilityManyRelationFilter>;
+  highlights?: InputMaybe<HighlightManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  orgUnits?: InputMaybe<OrgUnitManyRelationFilter>;
+  original?: InputMaybe<TopicWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  parks?: InputMaybe<ParkManyRelationFilter>;
+  publicNotices?: InputMaybe<PublicNoticeManyRelationFilter>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  trails?: InputMaybe<TrailManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type TopicDraftWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type TopicManyRelationFilter = {
+  every?: InputMaybe<TopicWhereInput>;
+  none?: InputMaybe<TopicWhereInput>;
+  some?: InputMaybe<TopicWhereInput>;
+};
+
+export type TopicOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  makeDrafts?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  slug?: InputMaybe<OrderDirection>;
+  status?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type TopicRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<TopicWhereUniqueInput>>;
+  create?: InputMaybe<Array<TopicCreateInput>>;
+};
+
+export type TopicRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<TopicWhereUniqueInput>>;
+  create?: InputMaybe<Array<TopicCreateInput>>;
+  disconnect?: InputMaybe<Array<TopicWhereUniqueInput>>;
+  set?: InputMaybe<Array<TopicWhereUniqueInput>>;
+};
+
+export type TopicRelateToOneForCreateInput = {
+  connect?: InputMaybe<TopicWhereUniqueInput>;
+  create?: InputMaybe<TopicCreateInput>;
+};
+
+export type TopicRelateToOneForUpdateInput = {
+  connect?: InputMaybe<TopicWhereUniqueInput>;
+  create?: InputMaybe<TopicCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type TopicUpdateArgs = {
+  data: TopicUpdateInput;
+  where: TopicWhereUniqueInput;
+};
+
+export type TopicUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  boards?: InputMaybe<BoardRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForUpdateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  currentVersion?: InputMaybe<TopicVersionRelateToOneForUpdateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForUpdateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  drafts?: InputMaybe<TopicDraftRelateToManyForUpdateInput>;
+  facilities?: InputMaybe<FacilityRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  highlights?: InputMaybe<HighlightRelateToManyForUpdateInput>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  parks?: InputMaybe<ParkRelateToManyForUpdateInput>;
+  publicNotices?: InputMaybe<PublicNoticeRelateToManyForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  trails?: InputMaybe<TrailRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+  versions?: InputMaybe<TopicVersionRelateToManyForUpdateInput>;
+};
+
+export type TopicVersion = {
+  __typename?: 'TopicVersion';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  boards?: Maybe<Array<Board>>;
+  boardsCount?: Maybe<Scalars['Int']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  communities?: Maybe<Array<Community>>;
+  communitiesCount?: Maybe<Scalars['Int']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  districts?: Maybe<Array<AssemblyDistrict>>;
+  districtsCount?: Maybe<Scalars['Int']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  facilities?: Maybe<Array<Facility>>;
+  facilitiesCount?: Maybe<Scalars['Int']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  highlights?: Maybe<Array<Highlight>>;
+  highlightsCount?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  isLive?: Maybe<Topic>;
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  orgUnits?: Maybe<Array<OrgUnit>>;
+  orgUnitsCount?: Maybe<Scalars['Int']['output']>;
+  original?: Maybe<Topic>;
+  owner?: Maybe<User>;
+  parks?: Maybe<Array<Park>>;
+  parksCount?: Maybe<Scalars['Int']['output']>;
+  publicNotices?: Maybe<Array<PublicNotice>>;
+  publicNoticesCount?: Maybe<Scalars['Int']['output']>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  republish?: Maybe<Scalars['String']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  trails?: Maybe<Array<Trail>>;
+  trailsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type TopicVersionActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type TopicVersionActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type TopicVersionBoardsArgs = {
+  cursor?: InputMaybe<BoardWhereUniqueInput>;
+  orderBy?: Array<BoardOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: BoardWhereInput;
+};
+
+
+export type TopicVersionBoardsCountArgs = {
+  where?: BoardWhereInput;
+};
+
+
+export type TopicVersionCommunitiesArgs = {
+  cursor?: InputMaybe<CommunityWhereUniqueInput>;
+  orderBy?: Array<CommunityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: CommunityWhereInput;
+};
+
+
+export type TopicVersionCommunitiesCountArgs = {
+  where?: CommunityWhereInput;
+};
+
+
+export type TopicVersionContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type TopicVersionContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type TopicVersionDistrictsArgs = {
+  cursor?: InputMaybe<AssemblyDistrictWhereUniqueInput>;
+  orderBy?: Array<AssemblyDistrictOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type TopicVersionDistrictsCountArgs = {
+  where?: AssemblyDistrictWhereInput;
+};
+
+
+export type TopicVersionDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type TopicVersionDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type TopicVersionFacilitiesArgs = {
+  cursor?: InputMaybe<FacilityWhereUniqueInput>;
+  orderBy?: Array<FacilityOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: FacilityWhereInput;
+};
+
+
+export type TopicVersionFacilitiesCountArgs = {
+  where?: FacilityWhereInput;
+};
+
+
+export type TopicVersionHighlightsArgs = {
+  cursor?: InputMaybe<HighlightWhereUniqueInput>;
+  orderBy?: Array<HighlightOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: HighlightWhereInput;
+};
+
+
+export type TopicVersionHighlightsCountArgs = {
+  where?: HighlightWhereInput;
+};
+
+
+export type TopicVersionOrgUnitsArgs = {
+  cursor?: InputMaybe<OrgUnitWhereUniqueInput>;
+  orderBy?: Array<OrgUnitOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: OrgUnitWhereInput;
+};
+
+
+export type TopicVersionOrgUnitsCountArgs = {
+  where?: OrgUnitWhereInput;
+};
+
+
+export type TopicVersionParksArgs = {
+  cursor?: InputMaybe<ParkWhereUniqueInput>;
+  orderBy?: Array<ParkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ParkWhereInput;
+};
+
+
+export type TopicVersionParksCountArgs = {
+  where?: ParkWhereInput;
+};
+
+
+export type TopicVersionPublicNoticesArgs = {
+  cursor?: InputMaybe<PublicNoticeWhereUniqueInput>;
+  orderBy?: Array<PublicNoticeOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: PublicNoticeWhereInput;
+};
+
+
+export type TopicVersionPublicNoticesCountArgs = {
+  where?: PublicNoticeWhereInput;
+};
+
+
+export type TopicVersionServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type TopicVersionServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type TopicVersionTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type TopicVersionTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type TopicVersionTrailsArgs = {
+  cursor?: InputMaybe<TrailWhereUniqueInput>;
+  orderBy?: Array<TrailOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailWhereInput;
+};
+
+
+export type TopicVersionTrailsCountArgs = {
+  where?: TrailWhereInput;
+};
+
+
+export type TopicVersionUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type TopicVersionUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type TopicVersionCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  boards?: InputMaybe<BoardRelateToManyForCreateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForCreateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForCreateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  facilities?: InputMaybe<FacilityRelateToManyForCreateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  highlights?: InputMaybe<HighlightRelateToManyForCreateInput>;
+  isLive?: InputMaybe<TopicRelateToOneForCreateInput>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForCreateInput>;
+  original?: InputMaybe<TopicRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  parks?: InputMaybe<ParkRelateToManyForCreateInput>;
+  publicNotices?: InputMaybe<PublicNoticeRelateToManyForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  trails?: InputMaybe<TrailRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+};
+
+export type TopicVersionManyRelationFilter = {
+  every?: InputMaybe<TopicVersionWhereInput>;
+  none?: InputMaybe<TopicVersionWhereInput>;
+  some?: InputMaybe<TopicVersionWhereInput>;
+};
+
+export type TopicVersionOrderByInput = {
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  republish?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type TopicVersionRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<TopicVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<TopicVersionCreateInput>>;
+};
+
+export type TopicVersionRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<TopicVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<TopicVersionCreateInput>>;
+  disconnect?: InputMaybe<Array<TopicVersionWhereUniqueInput>>;
+  set?: InputMaybe<Array<TopicVersionWhereUniqueInput>>;
+};
+
+export type TopicVersionRelateToOneForCreateInput = {
+  connect?: InputMaybe<TopicVersionWhereUniqueInput>;
+  create?: InputMaybe<TopicVersionCreateInput>;
+};
+
+export type TopicVersionRelateToOneForUpdateInput = {
+  connect?: InputMaybe<TopicVersionWhereUniqueInput>;
+  create?: InputMaybe<TopicVersionCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type TopicVersionUpdateArgs = {
+  data: TopicVersionUpdateInput;
+  where: TopicVersionWhereUniqueInput;
+};
+
+export type TopicVersionUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  boards?: InputMaybe<BoardRelateToManyForUpdateInput>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  communities?: InputMaybe<CommunityRelateToManyForUpdateInput>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  districts?: InputMaybe<AssemblyDistrictRelateToManyForUpdateInput>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  facilities?: InputMaybe<FacilityRelateToManyForUpdateInput>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  highlights?: InputMaybe<HighlightRelateToManyForUpdateInput>;
+  isLive?: InputMaybe<TopicRelateToOneForUpdateInput>;
+  orgUnits?: InputMaybe<OrgUnitRelateToManyForUpdateInput>;
+  original?: InputMaybe<TopicRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  parks?: InputMaybe<ParkRelateToManyForUpdateInput>;
+  publicNotices?: InputMaybe<PublicNoticeRelateToManyForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  trails?: InputMaybe<TrailRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+};
+
+export type TopicVersionWhereInput = {
+  AND?: InputMaybe<Array<TopicVersionWhereInput>>;
+  NOT?: InputMaybe<Array<TopicVersionWhereInput>>;
+  OR?: InputMaybe<Array<TopicVersionWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  boards?: InputMaybe<BoardManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  communities?: InputMaybe<CommunityManyRelationFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  districts?: InputMaybe<AssemblyDistrictManyRelationFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  facilities?: InputMaybe<FacilityManyRelationFilter>;
+  highlights?: InputMaybe<HighlightManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  isLive?: InputMaybe<TopicWhereInput>;
+  orgUnits?: InputMaybe<OrgUnitManyRelationFilter>;
+  original?: InputMaybe<TopicWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  parks?: InputMaybe<ParkManyRelationFilter>;
+  publicNotices?: InputMaybe<PublicNoticeManyRelationFilter>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  trails?: InputMaybe<TrailManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+};
+
+export type TopicVersionWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  isLive?: InputMaybe<TopicWhereUniqueInput>;
+};
+
+export type TopicWhereInput = {
+  AND?: InputMaybe<Array<TopicWhereInput>>;
+  NOT?: InputMaybe<Array<TopicWhereInput>>;
+  OR?: InputMaybe<Array<TopicWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  boards?: InputMaybe<BoardManyRelationFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  communities?: InputMaybe<CommunityManyRelationFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  currentVersion?: InputMaybe<TopicVersionWhereInput>;
+  description?: InputMaybe<StringFilter>;
+  districts?: InputMaybe<AssemblyDistrictManyRelationFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  drafts?: InputMaybe<TopicDraftManyRelationFilter>;
+  facilities?: InputMaybe<FacilityManyRelationFilter>;
+  highlights?: InputMaybe<HighlightManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  orgUnits?: InputMaybe<OrgUnitManyRelationFilter>;
+  owner?: InputMaybe<UserWhereInput>;
+  parks?: InputMaybe<ParkManyRelationFilter>;
+  publicNotices?: InputMaybe<PublicNoticeManyRelationFilter>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  slug?: InputMaybe<StringFilter>;
+  status?: InputMaybe<StringFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  trails?: InputMaybe<TrailManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+  versions?: InputMaybe<TopicVersionManyRelationFilter>;
+};
+
+export type TopicWhereUniqueInput = {
+  currentVersion?: InputMaybe<TopicVersionWhereUniqueInput>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type Trail = {
+  __typename?: 'Trail';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  address?: Maybe<Location>;
+  atv?: Maybe<Scalars['Boolean']['output']>;
+  biking?: Maybe<Scalars['Boolean']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  crossCountrySkiing?: Maybe<Scalars['Boolean']['output']>;
+  currentVersion?: Maybe<TrailVersion>;
+  description?: Maybe<Scalars['String']['output']>;
+  difficulty?: Maybe<Scalars['String']['output']>;
+  dirtBiking?: Maybe<Scalars['Boolean']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  dogWalking?: Maybe<Scalars['Boolean']['output']>;
+  drafts?: Maybe<Array<TrailDraft>>;
+  draftsCount?: Maybe<Scalars['Int']['output']>;
+  elevationChange?: Maybe<Scalars['String']['output']>;
+  fall?: Maybe<Scalars['Boolean']['output']>;
+  frisbeeGolf?: Maybe<Scalars['Boolean']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  hiking?: Maybe<Scalars['Boolean']['output']>;
+  horsebackRiding?: Maybe<Scalars['Boolean']['output']>;
+  id: Scalars['ID']['output'];
+  length?: Maybe<Scalars['String']['output']>;
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  makeDrafts?: Maybe<Scalars['String']['output']>;
+  mushing?: Maybe<Scalars['Boolean']['output']>;
+  open?: Maybe<Scalars['Boolean']['output']>;
+  owner?: Maybe<User>;
+  park?: Maybe<Park>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  running?: Maybe<Scalars['Boolean']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  snowMachining?: Maybe<Scalars['Boolean']['output']>;
+  snowshoeing?: Maybe<Scalars['Boolean']['output']>;
+  spring?: Maybe<Scalars['Boolean']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  summer?: Maybe<Scalars['Boolean']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+  versions?: Maybe<Array<TrailVersion>>;
+  versionsCount?: Maybe<Scalars['Int']['output']>;
+  winter?: Maybe<Scalars['Boolean']['output']>;
+};
+
+
+export type TrailActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type TrailActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type TrailContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type TrailContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type TrailDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type TrailDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type TrailDraftsArgs = {
+  cursor?: InputMaybe<TrailDraftWhereUniqueInput>;
+  orderBy?: Array<TrailDraftOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailDraftWhereInput;
+};
+
+
+export type TrailDraftsCountArgs = {
+  where?: TrailDraftWhereInput;
+};
+
+
+export type TrailServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type TrailServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type TrailTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type TrailTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type TrailTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type TrailTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type TrailUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type TrailUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+
+export type TrailVersionsArgs = {
+  cursor?: InputMaybe<TrailVersionWhereUniqueInput>;
+  orderBy?: Array<TrailVersionOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TrailVersionWhereInput;
+};
+
+
+export type TrailVersionsCountArgs = {
+  where?: TrailVersionWhereInput;
+};
+
+export type TrailCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  address?: InputMaybe<LocationRelateToOneForCreateInput>;
+  atv?: InputMaybe<Scalars['Boolean']['input']>;
+  biking?: InputMaybe<Scalars['Boolean']['input']>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  crossCountrySkiing?: InputMaybe<Scalars['Boolean']['input']>;
+  currentVersion?: InputMaybe<TrailVersionRelateToOneForCreateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  difficulty?: InputMaybe<Scalars['String']['input']>;
+  dirtBiking?: InputMaybe<Scalars['Boolean']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  dogWalking?: InputMaybe<Scalars['Boolean']['input']>;
+  drafts?: InputMaybe<TrailDraftRelateToManyForCreateInput>;
+  elevationChange?: InputMaybe<Scalars['String']['input']>;
+  fall?: InputMaybe<Scalars['Boolean']['input']>;
+  frisbeeGolf?: InputMaybe<Scalars['Boolean']['input']>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hiking?: InputMaybe<Scalars['Boolean']['input']>;
+  horsebackRiding?: InputMaybe<Scalars['Boolean']['input']>;
+  length?: InputMaybe<Scalars['String']['input']>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  mushing?: InputMaybe<Scalars['Boolean']['input']>;
+  open?: InputMaybe<Scalars['Boolean']['input']>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  park?: InputMaybe<ParkRelateToOneForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  running?: InputMaybe<Scalars['Boolean']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  snowMachining?: InputMaybe<Scalars['Boolean']['input']>;
+  snowshoeing?: InputMaybe<Scalars['Boolean']['input']>;
+  spring?: InputMaybe<Scalars['Boolean']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  summer?: InputMaybe<Scalars['Boolean']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+  versions?: InputMaybe<TrailVersionRelateToManyForCreateInput>;
+  winter?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type TrailDraft = {
+  __typename?: 'TrailDraft';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  address?: Maybe<Location>;
+  atv?: Maybe<Scalars['Boolean']['output']>;
+  biking?: Maybe<Scalars['Boolean']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  crossCountrySkiing?: Maybe<Scalars['Boolean']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  difficulty?: Maybe<Scalars['String']['output']>;
+  dirtBiking?: Maybe<Scalars['Boolean']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  dogWalking?: Maybe<Scalars['Boolean']['output']>;
+  elevationChange?: Maybe<Scalars['String']['output']>;
+  fall?: Maybe<Scalars['Boolean']['output']>;
+  frisbeeGolf?: Maybe<Scalars['Boolean']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  hiking?: Maybe<Scalars['Boolean']['output']>;
+  horsebackRiding?: Maybe<Scalars['Boolean']['output']>;
+  id: Scalars['ID']['output'];
+  length?: Maybe<Scalars['String']['output']>;
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  mushing?: Maybe<Scalars['Boolean']['output']>;
+  open?: Maybe<Scalars['Boolean']['output']>;
+  original?: Maybe<Trail>;
+  owner?: Maybe<User>;
+  park?: Maybe<Park>;
+  publish?: Maybe<Scalars['String']['output']>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  running?: Maybe<Scalars['Boolean']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  snowMachining?: Maybe<Scalars['Boolean']['output']>;
+  snowshoeing?: Maybe<Scalars['Boolean']['output']>;
+  spring?: Maybe<Scalars['Boolean']['output']>;
+  summer?: Maybe<Scalars['Boolean']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+  winter?: Maybe<Scalars['Boolean']['output']>;
+};
+
+
+export type TrailDraftActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type TrailDraftActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type TrailDraftContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type TrailDraftContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type TrailDraftDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type TrailDraftDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type TrailDraftServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type TrailDraftServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type TrailDraftTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type TrailDraftTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type TrailDraftTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type TrailDraftTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type TrailDraftUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type TrailDraftUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type TrailDraftCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  address?: InputMaybe<LocationRelateToOneForCreateInput>;
+  atv?: InputMaybe<Scalars['Boolean']['input']>;
+  biking?: InputMaybe<Scalars['Boolean']['input']>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  crossCountrySkiing?: InputMaybe<Scalars['Boolean']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  difficulty?: InputMaybe<Scalars['String']['input']>;
+  dirtBiking?: InputMaybe<Scalars['Boolean']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  dogWalking?: InputMaybe<Scalars['Boolean']['input']>;
+  elevationChange?: InputMaybe<Scalars['String']['input']>;
+  fall?: InputMaybe<Scalars['Boolean']['input']>;
+  frisbeeGolf?: InputMaybe<Scalars['Boolean']['input']>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hiking?: InputMaybe<Scalars['Boolean']['input']>;
+  horsebackRiding?: InputMaybe<Scalars['Boolean']['input']>;
+  length?: InputMaybe<Scalars['String']['input']>;
+  mushing?: InputMaybe<Scalars['Boolean']['input']>;
+  open?: InputMaybe<Scalars['Boolean']['input']>;
+  original?: InputMaybe<TrailRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  park?: InputMaybe<ParkRelateToOneForCreateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  running?: InputMaybe<Scalars['Boolean']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  snowMachining?: InputMaybe<Scalars['Boolean']['input']>;
+  snowshoeing?: InputMaybe<Scalars['Boolean']['input']>;
+  spring?: InputMaybe<Scalars['Boolean']['input']>;
+  summer?: InputMaybe<Scalars['Boolean']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+  winter?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type TrailDraftManyRelationFilter = {
+  every?: InputMaybe<TrailDraftWhereInput>;
+  none?: InputMaybe<TrailDraftWhereInput>;
+  some?: InputMaybe<TrailDraftWhereInput>;
+};
+
+export type TrailDraftOrderByInput = {
+  atv?: InputMaybe<OrderDirection>;
+  biking?: InputMaybe<OrderDirection>;
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  crossCountrySkiing?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  difficulty?: InputMaybe<OrderDirection>;
+  dirtBiking?: InputMaybe<OrderDirection>;
+  dogWalking?: InputMaybe<OrderDirection>;
+  elevationChange?: InputMaybe<OrderDirection>;
+  fall?: InputMaybe<OrderDirection>;
+  frisbeeGolf?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  hiking?: InputMaybe<OrderDirection>;
+  horsebackRiding?: InputMaybe<OrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  length?: InputMaybe<OrderDirection>;
+  mushing?: InputMaybe<OrderDirection>;
+  open?: InputMaybe<OrderDirection>;
+  publish?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  running?: InputMaybe<OrderDirection>;
+  snowMachining?: InputMaybe<OrderDirection>;
+  snowshoeing?: InputMaybe<OrderDirection>;
+  spring?: InputMaybe<OrderDirection>;
+  summer?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+  winter?: InputMaybe<OrderDirection>;
+};
+
+export type TrailDraftRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<TrailDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<TrailDraftCreateInput>>;
+};
+
+export type TrailDraftRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<TrailDraftWhereUniqueInput>>;
+  create?: InputMaybe<Array<TrailDraftCreateInput>>;
+  disconnect?: InputMaybe<Array<TrailDraftWhereUniqueInput>>;
+  set?: InputMaybe<Array<TrailDraftWhereUniqueInput>>;
+};
+
+export type TrailDraftUpdateArgs = {
+  data: TrailDraftUpdateInput;
+  where: TrailDraftWhereUniqueInput;
+};
+
+export type TrailDraftUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  address?: InputMaybe<LocationRelateToOneForUpdateInput>;
+  atv?: InputMaybe<Scalars['Boolean']['input']>;
+  biking?: InputMaybe<Scalars['Boolean']['input']>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  crossCountrySkiing?: InputMaybe<Scalars['Boolean']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  difficulty?: InputMaybe<Scalars['String']['input']>;
+  dirtBiking?: InputMaybe<Scalars['Boolean']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  dogWalking?: InputMaybe<Scalars['Boolean']['input']>;
+  elevationChange?: InputMaybe<Scalars['String']['input']>;
+  fall?: InputMaybe<Scalars['Boolean']['input']>;
+  frisbeeGolf?: InputMaybe<Scalars['Boolean']['input']>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hiking?: InputMaybe<Scalars['Boolean']['input']>;
+  horsebackRiding?: InputMaybe<Scalars['Boolean']['input']>;
+  length?: InputMaybe<Scalars['String']['input']>;
+  mushing?: InputMaybe<Scalars['Boolean']['input']>;
+  open?: InputMaybe<Scalars['Boolean']['input']>;
+  original?: InputMaybe<TrailRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  park?: InputMaybe<ParkRelateToOneForUpdateInput>;
+  publish?: InputMaybe<Scalars['String']['input']>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  running?: InputMaybe<Scalars['Boolean']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  snowMachining?: InputMaybe<Scalars['Boolean']['input']>;
+  snowshoeing?: InputMaybe<Scalars['Boolean']['input']>;
+  spring?: InputMaybe<Scalars['Boolean']['input']>;
+  summer?: InputMaybe<Scalars['Boolean']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+  winter?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type TrailDraftWhereInput = {
+  AND?: InputMaybe<Array<TrailDraftWhereInput>>;
+  NOT?: InputMaybe<Array<TrailDraftWhereInput>>;
+  OR?: InputMaybe<Array<TrailDraftWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  address?: InputMaybe<LocationWhereInput>;
+  atv?: InputMaybe<BooleanFilter>;
+  biking?: InputMaybe<BooleanFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  crossCountrySkiing?: InputMaybe<BooleanFilter>;
+  description?: InputMaybe<StringFilter>;
+  difficulty?: InputMaybe<StringNullableFilter>;
+  dirtBiking?: InputMaybe<BooleanFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  dogWalking?: InputMaybe<BooleanFilter>;
+  elevationChange?: InputMaybe<StringFilter>;
+  fall?: InputMaybe<BooleanFilter>;
+  frisbeeGolf?: InputMaybe<BooleanFilter>;
+  hiking?: InputMaybe<BooleanFilter>;
+  horsebackRiding?: InputMaybe<BooleanFilter>;
+  id?: InputMaybe<IdFilter>;
+  length?: InputMaybe<StringFilter>;
+  mushing?: InputMaybe<BooleanFilter>;
+  open?: InputMaybe<BooleanFilter>;
+  original?: InputMaybe<TrailWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  park?: InputMaybe<ParkWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  running?: InputMaybe<BooleanFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  snowMachining?: InputMaybe<BooleanFilter>;
+  snowshoeing?: InputMaybe<BooleanFilter>;
+  spring?: InputMaybe<BooleanFilter>;
+  summer?: InputMaybe<BooleanFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+  winter?: InputMaybe<BooleanFilter>;
+};
+
+export type TrailDraftWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type TrailManyRelationFilter = {
+  every?: InputMaybe<TrailWhereInput>;
+  none?: InputMaybe<TrailWhereInput>;
+  some?: InputMaybe<TrailWhereInput>;
+};
+
+export type TrailOrderByInput = {
+  atv?: InputMaybe<OrderDirection>;
+  biking?: InputMaybe<OrderDirection>;
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  crossCountrySkiing?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  difficulty?: InputMaybe<OrderDirection>;
+  dirtBiking?: InputMaybe<OrderDirection>;
+  dogWalking?: InputMaybe<OrderDirection>;
+  elevationChange?: InputMaybe<OrderDirection>;
+  fall?: InputMaybe<OrderDirection>;
+  frisbeeGolf?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  hiking?: InputMaybe<OrderDirection>;
+  horsebackRiding?: InputMaybe<OrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  length?: InputMaybe<OrderDirection>;
+  makeDrafts?: InputMaybe<OrderDirection>;
+  mushing?: InputMaybe<OrderDirection>;
+  open?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  running?: InputMaybe<OrderDirection>;
+  slug?: InputMaybe<OrderDirection>;
+  snowMachining?: InputMaybe<OrderDirection>;
+  snowshoeing?: InputMaybe<OrderDirection>;
+  spring?: InputMaybe<OrderDirection>;
+  status?: InputMaybe<OrderDirection>;
+  summer?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+  winter?: InputMaybe<OrderDirection>;
+};
+
+export type TrailRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<TrailWhereUniqueInput>>;
+  create?: InputMaybe<Array<TrailCreateInput>>;
+};
+
+export type TrailRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<TrailWhereUniqueInput>>;
+  create?: InputMaybe<Array<TrailCreateInput>>;
+  disconnect?: InputMaybe<Array<TrailWhereUniqueInput>>;
+  set?: InputMaybe<Array<TrailWhereUniqueInput>>;
+};
+
+export type TrailRelateToOneForCreateInput = {
+  connect?: InputMaybe<TrailWhereUniqueInput>;
+  create?: InputMaybe<TrailCreateInput>;
+};
+
+export type TrailRelateToOneForUpdateInput = {
+  connect?: InputMaybe<TrailWhereUniqueInput>;
+  create?: InputMaybe<TrailCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type TrailUpdateArgs = {
+  data: TrailUpdateInput;
+  where: TrailWhereUniqueInput;
+};
+
+export type TrailUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  address?: InputMaybe<LocationRelateToOneForUpdateInput>;
+  atv?: InputMaybe<Scalars['Boolean']['input']>;
+  biking?: InputMaybe<Scalars['Boolean']['input']>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  crossCountrySkiing?: InputMaybe<Scalars['Boolean']['input']>;
+  currentVersion?: InputMaybe<TrailVersionRelateToOneForUpdateInput>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  difficulty?: InputMaybe<Scalars['String']['input']>;
+  dirtBiking?: InputMaybe<Scalars['Boolean']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  dogWalking?: InputMaybe<Scalars['Boolean']['input']>;
+  drafts?: InputMaybe<TrailDraftRelateToManyForUpdateInput>;
+  elevationChange?: InputMaybe<Scalars['String']['input']>;
+  fall?: InputMaybe<Scalars['Boolean']['input']>;
+  frisbeeGolf?: InputMaybe<Scalars['Boolean']['input']>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hiking?: InputMaybe<Scalars['Boolean']['input']>;
+  horsebackRiding?: InputMaybe<Scalars['Boolean']['input']>;
+  length?: InputMaybe<Scalars['String']['input']>;
+  makeDrafts?: InputMaybe<Scalars['String']['input']>;
+  mushing?: InputMaybe<Scalars['Boolean']['input']>;
+  open?: InputMaybe<Scalars['Boolean']['input']>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  park?: InputMaybe<ParkRelateToOneForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  running?: InputMaybe<Scalars['Boolean']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  snowMachining?: InputMaybe<Scalars['Boolean']['input']>;
+  snowshoeing?: InputMaybe<Scalars['Boolean']['input']>;
+  spring?: InputMaybe<Scalars['Boolean']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  summer?: InputMaybe<Scalars['Boolean']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+  versions?: InputMaybe<TrailVersionRelateToManyForUpdateInput>;
+  winter?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type TrailVersion = {
+  __typename?: 'TrailVersion';
+  actions?: Maybe<Array<InternalLink>>;
+  actionsCount?: Maybe<Scalars['Int']['output']>;
+  address?: Maybe<Location>;
+  atv?: Maybe<Scalars['Boolean']['output']>;
+  biking?: Maybe<Scalars['Boolean']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  contacts?: Maybe<Array<Contact>>;
+  contactsCount?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  crossCountrySkiing?: Maybe<Scalars['Boolean']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  difficulty?: Maybe<Scalars['String']['output']>;
+  dirtBiking?: Maybe<Scalars['Boolean']['output']>;
+  documents?: Maybe<Array<Document>>;
+  documentsCount?: Maybe<Scalars['Int']['output']>;
+  dogWalking?: Maybe<Scalars['Boolean']['output']>;
+  elevationChange?: Maybe<Scalars['String']['output']>;
+  fall?: Maybe<Scalars['Boolean']['output']>;
+  frisbeeGolf?: Maybe<Scalars['Boolean']['output']>;
+  heroImage?: Maybe<Scalars['String']['output']>;
+  hiking?: Maybe<Scalars['Boolean']['output']>;
+  horsebackRiding?: Maybe<Scalars['Boolean']['output']>;
+  id: Scalars['ID']['output'];
+  isLive?: Maybe<Trail>;
+  length?: Maybe<Scalars['String']['output']>;
+  liveUrl?: Maybe<Scalars['String']['output']>;
+  mushing?: Maybe<Scalars['Boolean']['output']>;
+  open?: Maybe<Scalars['Boolean']['output']>;
+  original?: Maybe<Trail>;
+  owner?: Maybe<User>;
+  park?: Maybe<Park>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  republish?: Maybe<Scalars['String']['output']>;
+  reviewDate?: Maybe<Scalars['DateTime']['output']>;
+  running?: Maybe<Scalars['Boolean']['output']>;
+  services?: Maybe<Array<Service>>;
+  servicesCount?: Maybe<Scalars['Int']['output']>;
+  snowMachining?: Maybe<Scalars['Boolean']['output']>;
+  snowshoeing?: Maybe<Scalars['Boolean']['output']>;
+  spring?: Maybe<Scalars['Boolean']['output']>;
+  summer?: Maybe<Scalars['Boolean']['output']>;
+  tags?: Maybe<Array<Tag>>;
+  tagsCount?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  topics?: Maybe<Array<Topic>>;
+  topicsCount?: Maybe<Scalars['Int']['output']>;
+  unpublishAt?: Maybe<Scalars['DateTime']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  userGroups?: Maybe<Array<UserGroup>>;
+  userGroupsCount?: Maybe<Scalars['Int']['output']>;
+  winter?: Maybe<Scalars['Boolean']['output']>;
+};
+
+
+export type TrailVersionActionsArgs = {
+  cursor?: InputMaybe<InternalLinkWhereUniqueInput>;
+  orderBy?: Array<InternalLinkOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: InternalLinkWhereInput;
+};
+
+
+export type TrailVersionActionsCountArgs = {
+  where?: InternalLinkWhereInput;
+};
+
+
+export type TrailVersionContactsArgs = {
+  cursor?: InputMaybe<ContactWhereUniqueInput>;
+  orderBy?: Array<ContactOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: ContactWhereInput;
+};
+
+
+export type TrailVersionContactsCountArgs = {
+  where?: ContactWhereInput;
+};
+
+
+export type TrailVersionDocumentsArgs = {
+  cursor?: InputMaybe<DocumentWhereUniqueInput>;
+  orderBy?: Array<DocumentOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
+  where?: DocumentWhereInput;
+};
+
+
+export type TrailVersionDocumentsCountArgs = {
+  where?: DocumentWhereInput;
+};
+
+
+export type TrailVersionServicesArgs = {
+  cursor?: InputMaybe<ServiceWhereUniqueInput>;
+  orderBy?: Array<ServiceOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: ServiceWhereInput;
+};
+
+
+export type TrailVersionServicesCountArgs = {
+  where?: ServiceWhereInput;
+};
+
+
+export type TrailVersionTagsArgs = {
+  cursor?: InputMaybe<TagWhereUniqueInput>;
+  orderBy?: Array<TagOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TagWhereInput;
+};
+
+
+export type TrailVersionTagsCountArgs = {
+  where?: TagWhereInput;
+};
+
+
+export type TrailVersionTopicsArgs = {
+  cursor?: InputMaybe<TopicWhereUniqueInput>;
+  orderBy?: Array<TopicOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: TopicWhereInput;
+};
+
+
+export type TrailVersionTopicsCountArgs = {
+  where?: TopicWhereInput;
+};
+
+
+export type TrailVersionUserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type TrailVersionUserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type TrailVersionCreateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForCreateInput>;
+  address?: InputMaybe<LocationRelateToOneForCreateInput>;
+  atv?: InputMaybe<Scalars['Boolean']['input']>;
+  biking?: InputMaybe<Scalars['Boolean']['input']>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForCreateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  crossCountrySkiing?: InputMaybe<Scalars['Boolean']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  difficulty?: InputMaybe<Scalars['String']['input']>;
+  dirtBiking?: InputMaybe<Scalars['Boolean']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForCreateInput>;
+  dogWalking?: InputMaybe<Scalars['Boolean']['input']>;
+  elevationChange?: InputMaybe<Scalars['String']['input']>;
+  fall?: InputMaybe<Scalars['Boolean']['input']>;
+  frisbeeGolf?: InputMaybe<Scalars['Boolean']['input']>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hiking?: InputMaybe<Scalars['Boolean']['input']>;
+  horsebackRiding?: InputMaybe<Scalars['Boolean']['input']>;
+  isLive?: InputMaybe<TrailRelateToOneForCreateInput>;
+  length?: InputMaybe<Scalars['String']['input']>;
+  mushing?: InputMaybe<Scalars['Boolean']['input']>;
+  open?: InputMaybe<Scalars['Boolean']['input']>;
+  original?: InputMaybe<TrailRelateToOneForCreateInput>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  park?: InputMaybe<ParkRelateToOneForCreateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  running?: InputMaybe<Scalars['Boolean']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForCreateInput>;
+  snowMachining?: InputMaybe<Scalars['Boolean']['input']>;
+  snowshoeing?: InputMaybe<Scalars['Boolean']['input']>;
+  spring?: InputMaybe<Scalars['Boolean']['input']>;
+  summer?: InputMaybe<Scalars['Boolean']['input']>;
+  tags?: InputMaybe<TagRelateToManyForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForCreateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+  winter?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type TrailVersionManyRelationFilter = {
+  every?: InputMaybe<TrailVersionWhereInput>;
+  none?: InputMaybe<TrailVersionWhereInput>;
+  some?: InputMaybe<TrailVersionWhereInput>;
+};
+
+export type TrailVersionOrderByInput = {
+  atv?: InputMaybe<OrderDirection>;
+  biking?: InputMaybe<OrderDirection>;
+  body?: InputMaybe<MyOrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  crossCountrySkiing?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  difficulty?: InputMaybe<OrderDirection>;
+  dirtBiking?: InputMaybe<OrderDirection>;
+  dogWalking?: InputMaybe<OrderDirection>;
+  elevationChange?: InputMaybe<OrderDirection>;
+  fall?: InputMaybe<OrderDirection>;
+  frisbeeGolf?: InputMaybe<OrderDirection>;
+  heroImage?: InputMaybe<BlueHarvestImageOrderDirection>;
+  hiking?: InputMaybe<OrderDirection>;
+  horsebackRiding?: InputMaybe<OrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  length?: InputMaybe<OrderDirection>;
+  mushing?: InputMaybe<OrderDirection>;
+  open?: InputMaybe<OrderDirection>;
+  publishAt?: InputMaybe<OrderDirection>;
+  republish?: InputMaybe<OrderDirection>;
+  reviewDate?: InputMaybe<OrderDirection>;
+  running?: InputMaybe<OrderDirection>;
+  snowMachining?: InputMaybe<OrderDirection>;
+  snowshoeing?: InputMaybe<OrderDirection>;
+  spring?: InputMaybe<OrderDirection>;
+  summer?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  unpublishAt?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+  winter?: InputMaybe<OrderDirection>;
+};
+
+export type TrailVersionRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<TrailVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<TrailVersionCreateInput>>;
+};
+
+export type TrailVersionRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<TrailVersionWhereUniqueInput>>;
+  create?: InputMaybe<Array<TrailVersionCreateInput>>;
+  disconnect?: InputMaybe<Array<TrailVersionWhereUniqueInput>>;
+  set?: InputMaybe<Array<TrailVersionWhereUniqueInput>>;
+};
+
+export type TrailVersionRelateToOneForCreateInput = {
+  connect?: InputMaybe<TrailVersionWhereUniqueInput>;
+  create?: InputMaybe<TrailVersionCreateInput>;
+};
+
+export type TrailVersionRelateToOneForUpdateInput = {
+  connect?: InputMaybe<TrailVersionWhereUniqueInput>;
+  create?: InputMaybe<TrailVersionCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type TrailVersionUpdateArgs = {
+  data: TrailVersionUpdateInput;
+  where: TrailVersionWhereUniqueInput;
+};
+
+export type TrailVersionUpdateInput = {
+  actions?: InputMaybe<InternalLinkRelateToManyForUpdateInput>;
+  address?: InputMaybe<LocationRelateToOneForUpdateInput>;
+  atv?: InputMaybe<Scalars['Boolean']['input']>;
+  biking?: InputMaybe<Scalars['Boolean']['input']>;
+  body?: InputMaybe<Scalars['String']['input']>;
+  contacts?: InputMaybe<ContactRelateToManyForUpdateInput>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  crossCountrySkiing?: InputMaybe<Scalars['Boolean']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  difficulty?: InputMaybe<Scalars['String']['input']>;
+  dirtBiking?: InputMaybe<Scalars['Boolean']['input']>;
+  documents?: InputMaybe<DocumentRelateToManyForUpdateInput>;
+  dogWalking?: InputMaybe<Scalars['Boolean']['input']>;
+  elevationChange?: InputMaybe<Scalars['String']['input']>;
+  fall?: InputMaybe<Scalars['Boolean']['input']>;
+  frisbeeGolf?: InputMaybe<Scalars['Boolean']['input']>;
+  heroImage?: InputMaybe<Scalars['String']['input']>;
+  hiking?: InputMaybe<Scalars['Boolean']['input']>;
+  horsebackRiding?: InputMaybe<Scalars['Boolean']['input']>;
+  isLive?: InputMaybe<TrailRelateToOneForUpdateInput>;
+  length?: InputMaybe<Scalars['String']['input']>;
+  mushing?: InputMaybe<Scalars['Boolean']['input']>;
+  open?: InputMaybe<Scalars['Boolean']['input']>;
+  original?: InputMaybe<TrailRelateToOneForUpdateInput>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  park?: InputMaybe<ParkRelateToOneForUpdateInput>;
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  republish?: InputMaybe<Scalars['String']['input']>;
+  reviewDate?: InputMaybe<Scalars['DateTime']['input']>;
+  running?: InputMaybe<Scalars['Boolean']['input']>;
+  services?: InputMaybe<ServiceRelateToManyForUpdateInput>;
+  snowMachining?: InputMaybe<Scalars['Boolean']['input']>;
+  snowshoeing?: InputMaybe<Scalars['Boolean']['input']>;
+  spring?: InputMaybe<Scalars['Boolean']['input']>;
+  summer?: InputMaybe<Scalars['Boolean']['input']>;
+  tags?: InputMaybe<TagRelateToManyForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  topics?: InputMaybe<TopicRelateToManyForUpdateInput>;
+  unpublishAt?: InputMaybe<Scalars['DateTime']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  userGroups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+  winter?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type TrailVersionWhereInput = {
+  AND?: InputMaybe<Array<TrailVersionWhereInput>>;
+  NOT?: InputMaybe<Array<TrailVersionWhereInput>>;
+  OR?: InputMaybe<Array<TrailVersionWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  address?: InputMaybe<LocationWhereInput>;
+  atv?: InputMaybe<BooleanFilter>;
+  biking?: InputMaybe<BooleanFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  crossCountrySkiing?: InputMaybe<BooleanFilter>;
+  description?: InputMaybe<StringFilter>;
+  difficulty?: InputMaybe<StringNullableFilter>;
+  dirtBiking?: InputMaybe<BooleanFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  dogWalking?: InputMaybe<BooleanFilter>;
+  elevationChange?: InputMaybe<StringFilter>;
+  fall?: InputMaybe<BooleanFilter>;
+  frisbeeGolf?: InputMaybe<BooleanFilter>;
+  hiking?: InputMaybe<BooleanFilter>;
+  horsebackRiding?: InputMaybe<BooleanFilter>;
+  id?: InputMaybe<IdFilter>;
+  isLive?: InputMaybe<TrailWhereInput>;
+  length?: InputMaybe<StringFilter>;
+  mushing?: InputMaybe<BooleanFilter>;
+  open?: InputMaybe<BooleanFilter>;
+  original?: InputMaybe<TrailWhereInput>;
+  owner?: InputMaybe<UserWhereInput>;
+  park?: InputMaybe<ParkWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  running?: InputMaybe<BooleanFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  snowMachining?: InputMaybe<BooleanFilter>;
+  snowshoeing?: InputMaybe<BooleanFilter>;
+  spring?: InputMaybe<BooleanFilter>;
+  summer?: InputMaybe<BooleanFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+  winter?: InputMaybe<BooleanFilter>;
+};
+
+export type TrailVersionWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  isLive?: InputMaybe<TrailWhereUniqueInput>;
+};
+
+export type TrailWhereInput = {
+  AND?: InputMaybe<Array<TrailWhereInput>>;
+  NOT?: InputMaybe<Array<TrailWhereInput>>;
+  OR?: InputMaybe<Array<TrailWhereInput>>;
+  actions?: InputMaybe<InternalLinkManyRelationFilter>;
+  address?: InputMaybe<LocationWhereInput>;
+  atv?: InputMaybe<BooleanFilter>;
+  biking?: InputMaybe<BooleanFilter>;
+  body?: InputMaybe<MyStringFilter>;
+  contacts?: InputMaybe<ContactManyRelationFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  crossCountrySkiing?: InputMaybe<BooleanFilter>;
+  currentVersion?: InputMaybe<TrailVersionWhereInput>;
+  description?: InputMaybe<StringFilter>;
+  difficulty?: InputMaybe<StringNullableFilter>;
+  dirtBiking?: InputMaybe<BooleanFilter>;
+  documents?: InputMaybe<DocumentManyRelationFilter>;
+  dogWalking?: InputMaybe<BooleanFilter>;
+  drafts?: InputMaybe<TrailDraftManyRelationFilter>;
+  elevationChange?: InputMaybe<StringFilter>;
+  fall?: InputMaybe<BooleanFilter>;
+  frisbeeGolf?: InputMaybe<BooleanFilter>;
+  hiking?: InputMaybe<BooleanFilter>;
+  horsebackRiding?: InputMaybe<BooleanFilter>;
+  id?: InputMaybe<IdFilter>;
+  length?: InputMaybe<StringFilter>;
+  mushing?: InputMaybe<BooleanFilter>;
+  open?: InputMaybe<BooleanFilter>;
+  owner?: InputMaybe<UserWhereInput>;
+  park?: InputMaybe<ParkWhereInput>;
+  publishAt?: InputMaybe<DateTimeNullableFilter>;
+  reviewDate?: InputMaybe<DateTimeNullableFilter>;
+  running?: InputMaybe<BooleanFilter>;
+  services?: InputMaybe<ServiceManyRelationFilter>;
+  slug?: InputMaybe<StringFilter>;
+  snowMachining?: InputMaybe<BooleanFilter>;
+  snowshoeing?: InputMaybe<BooleanFilter>;
+  spring?: InputMaybe<BooleanFilter>;
+  status?: InputMaybe<StringFilter>;
+  summer?: InputMaybe<BooleanFilter>;
+  tags?: InputMaybe<TagManyRelationFilter>;
+  title?: InputMaybe<StringFilter>;
+  topics?: InputMaybe<TopicManyRelationFilter>;
+  unpublishAt?: InputMaybe<DateTimeNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  userGroups?: InputMaybe<UserGroupManyRelationFilter>;
+  versions?: InputMaybe<TrailVersionManyRelationFilter>;
+  winter?: InputMaybe<BooleanFilter>;
+};
+
+export type TrailWhereUniqueInput = {
+  currentVersion?: InputMaybe<TrailVersionWhereUniqueInput>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type Url = {
+  __typename?: 'Url';
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  owner?: Maybe<User>;
+  title?: Maybe<Scalars['String']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  url?: Maybe<Scalars['String']['output']>;
+};
+
+export type UrlCreateInput = {
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  url?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UrlOrderByInput = {
+  createdAt?: InputMaybe<OrderDirection>;
+  description?: InputMaybe<OrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  title?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+  url?: InputMaybe<OrderDirection>;
+};
+
+export type UrlRelateToOneForCreateInput = {
+  connect?: InputMaybe<UrlWhereUniqueInput>;
+  create?: InputMaybe<UrlCreateInput>;
+};
+
+export type UrlRelateToOneForUpdateInput = {
+  connect?: InputMaybe<UrlWhereUniqueInput>;
+  create?: InputMaybe<UrlCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type UrlUpdateArgs = {
+  data: UrlUpdateInput;
+  where: UrlWhereUniqueInput;
+};
+
+export type UrlUpdateInput = {
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  url?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UrlWhereInput = {
+  AND?: InputMaybe<Array<UrlWhereInput>>;
+  NOT?: InputMaybe<Array<UrlWhereInput>>;
+  OR?: InputMaybe<Array<UrlWhereInput>>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  description?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  owner?: InputMaybe<UserWhereInput>;
+  title?: InputMaybe<StringFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+  url?: InputMaybe<StringFilter>;
+};
+
+export type UrlWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  url?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type User = {
+  __typename?: 'User';
+  authId?: Maybe<Scalars['String']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  email?: Maybe<Scalars['String']['output']>;
+  groups?: Maybe<Array<UserGroup>>;
+  groupsCount?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  name?: Maybe<Scalars['String']['output']>;
+  password?: Maybe<PasswordState>;
+  role?: Maybe<Scalars['Int']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+};
+
+
+export type UserGroupsArgs = {
+  cursor?: InputMaybe<UserGroupWhereUniqueInput>;
+  orderBy?: Array<UserGroupOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserGroupWhereInput;
+};
+
+
+export type UserGroupsCountArgs = {
+  where?: UserGroupWhereInput;
+};
+
+export type UserCreateInput = {
+  authId?: InputMaybe<Scalars['String']['input']>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  email?: InputMaybe<Scalars['String']['input']>;
+  groups?: InputMaybe<UserGroupRelateToManyForCreateInput>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  password?: InputMaybe<Scalars['String']['input']>;
+  role?: InputMaybe<Scalars['Int']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+export type UserGroup = {
+  __typename?: 'UserGroup';
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  name?: Maybe<Scalars['String']['output']>;
+  owner?: Maybe<User>;
+  users?: Maybe<Array<User>>;
+  usersCount?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type UserGroupUsersArgs = {
+  cursor?: InputMaybe<UserWhereUniqueInput>;
+  orderBy?: Array<UserOrderByInput>;
+  skip?: Scalars['Int']['input'];
+  take?: InputMaybe<Scalars['Int']['input']>;
+  where?: UserWhereInput;
+};
+
+
+export type UserGroupUsersCountArgs = {
+  where?: UserWhereInput;
+};
+
+export type UserGroupCreateInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForCreateInput>;
+  users?: InputMaybe<UserRelateToManyForCreateInput>;
+};
+
+export type UserGroupManyRelationFilter = {
+  every?: InputMaybe<UserGroupWhereInput>;
+  none?: InputMaybe<UserGroupWhereInput>;
+  some?: InputMaybe<UserGroupWhereInput>;
+};
+
+export type UserGroupOrderByInput = {
+  description?: InputMaybe<OrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  name?: InputMaybe<OrderDirection>;
+};
+
+export type UserGroupRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<UserGroupWhereUniqueInput>>;
+  create?: InputMaybe<Array<UserGroupCreateInput>>;
+};
+
+export type UserGroupRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<UserGroupWhereUniqueInput>>;
+  create?: InputMaybe<Array<UserGroupCreateInput>>;
+  disconnect?: InputMaybe<Array<UserGroupWhereUniqueInput>>;
+  set?: InputMaybe<Array<UserGroupWhereUniqueInput>>;
+};
+
+export type UserGroupUpdateArgs = {
+  data: UserGroupUpdateInput;
+  where: UserGroupWhereUniqueInput;
+};
+
+export type UserGroupUpdateInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  owner?: InputMaybe<UserRelateToOneForUpdateInput>;
+  users?: InputMaybe<UserRelateToManyForUpdateInput>;
+};
+
+export type UserGroupWhereInput = {
+  AND?: InputMaybe<Array<UserGroupWhereInput>>;
+  NOT?: InputMaybe<Array<UserGroupWhereInput>>;
+  OR?: InputMaybe<Array<UserGroupWhereInput>>;
+  description?: InputMaybe<StringFilter>;
+  id?: InputMaybe<IdFilter>;
+  name?: InputMaybe<StringFilter>;
+  owner?: InputMaybe<UserWhereInput>;
+  users?: InputMaybe<UserManyRelationFilter>;
+};
+
+export type UserGroupWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type UserManyRelationFilter = {
+  every?: InputMaybe<UserWhereInput>;
+  none?: InputMaybe<UserWhereInput>;
+  some?: InputMaybe<UserWhereInput>;
+};
+
+export type UserOrderByInput = {
+  authId?: InputMaybe<OrderDirection>;
+  createdAt?: InputMaybe<OrderDirection>;
+  email?: InputMaybe<OrderDirection>;
+  id?: InputMaybe<OrderDirection>;
+  name?: InputMaybe<OrderDirection>;
+  role?: InputMaybe<OrderDirection>;
+  updatedAt?: InputMaybe<OrderDirection>;
+};
+
+export type UserRelateToManyForCreateInput = {
+  connect?: InputMaybe<Array<UserWhereUniqueInput>>;
+  create?: InputMaybe<Array<UserCreateInput>>;
+};
+
+export type UserRelateToManyForUpdateInput = {
+  connect?: InputMaybe<Array<UserWhereUniqueInput>>;
+  create?: InputMaybe<Array<UserCreateInput>>;
+  disconnect?: InputMaybe<Array<UserWhereUniqueInput>>;
+  set?: InputMaybe<Array<UserWhereUniqueInput>>;
+};
+
+export type UserRelateToOneForCreateInput = {
+  connect?: InputMaybe<UserWhereUniqueInput>;
+  create?: InputMaybe<UserCreateInput>;
+};
+
+export type UserRelateToOneForUpdateInput = {
+  connect?: InputMaybe<UserWhereUniqueInput>;
+  create?: InputMaybe<UserCreateInput>;
+  disconnect?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type UserUpdateArgs = {
+  data: UserUpdateInput;
+  where: UserWhereUniqueInput;
+};
+
+export type UserUpdateInput = {
+  authId?: InputMaybe<Scalars['String']['input']>;
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>;
+  email?: InputMaybe<Scalars['String']['input']>;
+  groups?: InputMaybe<UserGroupRelateToManyForUpdateInput>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  password?: InputMaybe<Scalars['String']['input']>;
+  role?: InputMaybe<Scalars['Int']['input']>;
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+export type UserWhereInput = {
+  AND?: InputMaybe<Array<UserWhereInput>>;
+  NOT?: InputMaybe<Array<UserWhereInput>>;
+  OR?: InputMaybe<Array<UserWhereInput>>;
+  authId?: InputMaybe<StringFilter>;
+  createdAt?: InputMaybe<DateTimeNullableFilter>;
+  email?: InputMaybe<StringFilter>;
+  groups?: InputMaybe<UserGroupManyRelationFilter>;
+  id?: InputMaybe<IdFilter>;
+  name?: InputMaybe<StringFilter>;
+  password?: InputMaybe<PasswordFilter>;
+  role?: InputMaybe<IntNullableFilter>;
+  updatedAt?: InputMaybe<DateTimeNullableFilter>;
+};
+
+export type UserWhereUniqueInput = {
+  authId?: InputMaybe<Scalars['String']['input']>;
+  email?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type CreateDocumentsMutationVariables = Exact<{
+  data: Array<DocumentCreateInput> | DocumentCreateInput;
+}>;
+
+
+export type CreateDocumentsMutation = { __typename?: 'Mutation', createDocuments?: Array<{ __typename?: 'Document', id: string, title?: string | null, file?: { __typename?: 'FileFieldOutput', filename: string, filesize: number, url: string } | null, tags?: Array<{ __typename?: 'Tag', id: string, name?: string | null }> | null } | null> | null };
+
+export type TagsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TagsQuery = { __typename?: 'Query', tags?: Array<{ __typename?: 'Tag', id: string, name?: string | null }> | null };
+
+export type QueryQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type QueryQuery = { __typename?: 'Query', documentCollections?: Array<{ __typename?: 'DocumentCollection', id: string, title?: string | null }> | null };
+
+export type GetServicesQueryVariables = Exact<{
+  where: ServiceWhereInput;
+}>;
+
+
+export type GetServicesQuery = { __typename?: 'Query', services?: Array<{ __typename?: 'Service', title?: string | null, slug?: string | null, id: string }> | null };
+
+export type DocumentCollectionQueryVariables = Exact<{
+  where: DocumentCollectionWhereUniqueInput;
+}>;
+
+
+export type DocumentCollectionQuery = { __typename?: 'Query', documentCollection?: { __typename?: 'DocumentCollection', id: string, title?: string | null, documents?: Array<{ __typename?: 'Document', id: string, title?: string | null, file?: { __typename?: 'FileFieldOutput', filename: string, filesize: number, url: string } | null }> | null } | null };
+
+export type DocumentCollectionsQueryVariables = Exact<{
+  where: DocumentCollectionWhereInput;
+}>;
+
+
+export type DocumentCollectionsQuery = { __typename?: 'Query', documentCollections?: Array<{ __typename?: 'DocumentCollection', id: string, title?: string | null }> | null };
+
+export type GetInternalLinkQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+  type: Scalars['String']['input'];
+}>;
+
+
+export type GetInternalLinkQuery = { __typename?: 'Query', getInternalLink?: { __typename: 'AssemblyDistrict', title?: string | null } | { __typename: 'Board', title?: string | null } | { __typename: 'BoardPage', title?: string | null } | { __typename: 'Community', title?: string | null } | { __typename: 'Facility', title?: string | null } | { __typename: 'HomePage', title?: string | null } | { __typename: 'OrgUnit', title?: string | null } | { __typename: 'Park', title?: string | null } | { __typename: 'PublicNotice', title?: string | null } | { __typename: 'Service', title?: string | null } | { __typename: 'Trail', title?: string | null } | { __typename: 'Url', title?: string | null } | null };
+
+export type LinkSearchQueryVariables = Exact<{
+  query?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type LinkSearchQuery = { __typename?: 'Query', internalSearch?: Array<{ __typename: 'AssemblyDistrict', id: string, title?: string | null } | { __typename: 'Board', id: string, title?: string | null } | { __typename: 'BoardPage', id: string, title?: string | null } | { __typename: 'Community', id: string, title?: string | null } | { __typename: 'Facility', id: string, title?: string | null } | { __typename: 'HomePage', id: string, title?: string | null } | { __typename: 'OrgUnit', id: string, title?: string | null } | { __typename: 'Park', id: string, title?: string | null } | { __typename: 'PublicNotice', id: string, title?: string | null } | { __typename: 'Service', id: string, title?: string | null } | { __typename: 'Trail', id: string, title?: string | null } | { __typename: 'Url', id: string, title?: string | null } | null> | null };
+
+
+export const CreateDocumentsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateDocuments"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"data"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"DocumentCreateInput"}}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createDocuments"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"data"},"value":{"kind":"Variable","name":{"kind":"Name","value":"data"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"file"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"filename"}},{"kind":"Field","name":{"kind":"Name","value":"filesize"}},{"kind":"Field","name":{"kind":"Name","value":"url"}}]}},{"kind":"Field","name":{"kind":"Name","value":"tags"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]}}]} as unknown as DocumentNode<CreateDocumentsMutation, CreateDocumentsMutationVariables>;
+export const TagsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Tags"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"tags"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<TagsQuery, TagsQueryVariables>;
+export const QueryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Query"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"documentCollections"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}}]}}]} as unknown as DocumentNode<QueryQuery, QueryQueryVariables>;
+export const GetServicesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetServices"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"where"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ServiceWhereInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"services"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"Variable","name":{"kind":"Name","value":"where"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"slug"}},{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<GetServicesQuery, GetServicesQueryVariables>;
+export const DocumentCollectionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"DocumentCollection"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"where"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"DocumentCollectionWhereUniqueInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"documentCollection"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"Variable","name":{"kind":"Name","value":"where"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"documents"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"file"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"filename"}},{"kind":"Field","name":{"kind":"Name","value":"filesize"}},{"kind":"Field","name":{"kind":"Name","value":"url"}}]}}]}}]}}]}}]} as unknown as DocumentNode<DocumentCollectionQuery, DocumentCollectionQueryVariables>;
+export const DocumentCollectionsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"DocumentCollections"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"where"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"DocumentCollectionWhereInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"documentCollections"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"Variable","name":{"kind":"Name","value":"where"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}}]}}]} as unknown as DocumentNode<DocumentCollectionsQuery, DocumentCollectionsQueryVariables>;
+export const GetInternalLinkDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetInternalLink"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"type"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getInternalLink"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}},{"kind":"Argument","name":{"kind":"Name","value":"type"},"value":{"kind":"Variable","name":{"kind":"Name","value":"type"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"AssemblyDistrict"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Board"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"BoardPage"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Community"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Facility"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"HomePage"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"OrgUnit"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Park"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PublicNotice"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Service"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Trail"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Url"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}}]}}]}}]}}]} as unknown as DocumentNode<GetInternalLinkQuery, GetInternalLinkQueryVariables>;
+export const LinkSearchDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"LinkSearch"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"query"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"internalSearch"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"query"},"value":{"kind":"Variable","name":{"kind":"Name","value":"query"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"AssemblyDistrict"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Board"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"BoardPage"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Community"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Facility"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"HomePage"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"OrgUnit"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Park"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"PublicNotice"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Service"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Trail"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Url"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}}]}}]}}]} as unknown as DocumentNode<LinkSearchQuery, LinkSearchQueryVariables>;

--- a/apps/cms/src/graphql/index.ts
+++ b/apps/cms/src/graphql/index.ts
@@ -1,0 +1,2 @@
+export * from "./fragment-masking";
+export * from "./gql";

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ export default tseslint.config(
   }),
   {
     files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'],
+    ignores: ['apps/cms/src/graphql/**'],
     languageOptions: { globals: { ...globals.browser, ...globals.node } },
     rules: {
       ...pluginJs.configs.recommended.rules,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,13 +70,13 @@ importers:
         version: 2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@keystone-6/auth':
         specifier: ^8.1.0
-        version: 8.1.0(@keystone-6/core@6.5.1(@prisma/generator-helper@5.22.0)(@types/express@4.17.22)(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1)))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 8.1.0(@keystone-6/core@6.5.1(@babel/core@7.27.4)(@prisma/generator-helper@5.22.0)(@types/express@4.17.22)(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1)))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@keystone-6/core':
         specifier: ^6.5.1
-        version: 6.5.1(@prisma/generator-helper@5.22.0)(@types/express@4.17.22)(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1))
+        version: 6.5.1(@babel/core@7.27.4)(@prisma/generator-helper@5.22.0)(@types/express@4.17.22)(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1))
       '@keystone-6/fields-document':
         specifier: ^9.1.1
-        version: 9.1.1(@keystone-6/core@6.5.1(@prisma/generator-helper@5.22.0)(@types/express@4.17.22)(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1)))(slate-dom@0.112.2(slate@0.110.2))
+        version: 9.1.1(@keystone-6/core@6.5.1(@babel/core@7.27.4)(@prisma/generator-helper@5.22.0)(@types/express@4.17.22)(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1)))(slate-dom@0.112.2(slate@0.110.2))
       '@keystone-ui/button':
         specifier: ^7.0.2
         version: 7.0.2(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))
@@ -127,10 +127,10 @@ importers:
         version: 5.6.1
       next:
         specifier: ^14.2.29
-        version: 14.2.29(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.29(@babel/core@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: ^4.24.11
-        version: 4.24.11(next@14.2.29(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.11(next@14.2.29(@babel/core@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openid-client:
         specifier: ^5.7.1
         version: 5.7.1
@@ -174,6 +174,9 @@ importers:
       '@faker-js/faker':
         specifier: ^9.8.0
         version: 9.8.0
+      '@graphql-codegen/cli':
+        specifier: ^5.0.7
+        version: 5.0.7(@types/node@22.15.29)(graphql@16.11.0)(typescript@5.8.3)
       '@iconify/json':
         specifier: ^2.2.345
         version: 2.2.345
@@ -342,6 +345,12 @@ packages:
   '@apollo/utils.withrequired@2.0.1':
     resolution: {integrity: sha512-YBDiuAX9i1lLc6GeTy1m7DGLFn/gMnvXqlalOIMjM7DeOgIacEjjfwPqb0M1CQ2v11HhR15d1NmxJoRCfrNqcA==}
     engines: {node: '>=14'}
+
+  '@ardatan/relay-compiler@12.0.3':
+    resolution: {integrity: sha512-mBDFOGvAoVlWaWqs3hm1AciGHSQE1rqFc/liZTyYz/Oek9yZdT5H26pH2zAFuEiTiBVPPyMuqf5VjOFPI2DGsQ==}
+    hasBin: true
+    peerDependencies:
+      graphql: '*'
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -512,12 +521,34 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.27.5':
+    resolution: {integrity: sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.27.4':
+    resolution: {integrity: sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/generator@7.27.3':
     resolution: {integrity: sha512-xnlJYj5zepml8NXtjkG0WquFUv8RskFqyFcVgTBp5k+NaA/8uw/K+OSVf8AMGw5e9HKP2ETd5xpK5MLZQD6b4Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-compilation-targets@7.27.2':
+    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-imports@7.27.1':
     resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.27.3':
+    resolution: {integrity: sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.27.1':
+    resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
@@ -528,10 +559,24 @@ packages:
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.27.6':
+    resolution: {integrity: sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.27.4':
     resolution: {integrity: sha512-BRmLHGwpUqLFR2jzx9orBuX/ABDkj2jLKOXrHDTN2aOKL+jFDDKaRNo9nyYsIl9h/UE/7lMKdDjKQQyxKKDZ7g==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/plugin-syntax-import-assertions@7.27.1':
+    resolution: {integrity: sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/runtime@7.27.4':
     resolution: {integrity: sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==}
@@ -547,6 +592,10 @@ packages:
 
   '@babel/types@7.27.3':
     resolution: {integrity: sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.27.6':
+    resolution: {integrity: sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==}
     engines: {node: '>=6.9.0'}
 
   '@braintree/sanitize-url@7.0.4':
@@ -714,6 +763,18 @@ packages:
 
   '@emotion/weak-memoize@0.4.0':
     resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
+
+  '@envelop/core@5.2.3':
+    resolution: {integrity: sha512-KfoGlYD/XXQSc3BkM1/k15+JQbkQ4ateHazeZoWl9P71FsLTDXSjGy6j7QqfhpIDSbxNISqhPMfZHYSbDFOofQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@envelop/instrumentation@1.0.0':
+    resolution: {integrity: sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@envelop/types@5.2.1':
+    resolution: {integrity: sha512-CsFmA3u3c2QoLDTfEpGr4t25fjMU31nyvse7IzWTvb0ZycuPjMjb0fjlheh+PbhBYb9YLugnT2uY6Mwcg1o+Zg==}
+    engines: {node: '>=18.0.0'}
 
   '@esbuild/aix-ppc64@0.24.2':
     resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
@@ -1066,6 +1127,9 @@ packages:
     resolution: {integrity: sha512-U9wpuSrJC93jZBxx/Qq2wPjCuYISBueyVUGK7qqdmj7r/nxaxwW8AQDCLeRO7wZnjj94sh3p246cAYjUKuqgfg==}
     engines: {node: '>=18.0.0', npm: '>=9.0.0'}
 
+  '@fastify/busboy@3.1.1':
+    resolution: {integrity: sha512-5DGmA8FTdB2XbDeEwc/5ZXBl6UbBAyBOOLlPuBnZ/N1SwdH9Ii+cOX3tBROlDgcTXxjOYnLMVoKk9+FXAw0CJw==}
+
   '@floating-ui/core@1.7.1':
     resolution: {integrity: sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==}
 
@@ -1093,6 +1157,188 @@ packages:
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
+  '@graphql-codegen/add@5.0.3':
+    resolution: {integrity: sha512-SxXPmramkth8XtBlAHu4H4jYcYXM/o3p01+psU+0NADQowA8jtYkK6MW5rV6T+CxkEaNZItfSmZRPgIuypcqnA==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  '@graphql-codegen/cli@5.0.7':
+    resolution: {integrity: sha512-h/sxYvSaWtxZxo8GtaA8SvcHTyViaaPd7dweF/hmRDpaQU1o3iU3EZxlcJ+oLTunU0tSMFsnrIXm/mhXxI11Cw==}
+    engines: {node: '>=16'}
+    hasBin: true
+    peerDependencies:
+      '@parcel/watcher': ^2.1.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    peerDependenciesMeta:
+      '@parcel/watcher':
+        optional: true
+
+  '@graphql-codegen/client-preset@4.8.2':
+    resolution: {integrity: sha512-YoH2obkNLorgT7bs5cbveg6A1fM4ZW5AE/CWLaSzViMTAXk51q0z/5+sTrDW2Ft6Or3mTxFLEByCgXhPgAj2Lw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql-sock: ^1.0.0
+    peerDependenciesMeta:
+      graphql-sock:
+        optional: true
+
+  '@graphql-codegen/core@4.0.2':
+    resolution: {integrity: sha512-IZbpkhwVqgizcjNiaVzNAzm/xbWT6YnGgeOLwVjm4KbJn3V2jchVtuzHH09G5/WkkLSk2wgbXNdwjM41JxO6Eg==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  '@graphql-codegen/gql-tag-operations@4.0.17':
+    resolution: {integrity: sha512-2pnvPdIG6W9OuxkrEZ6hvZd142+O3B13lvhrZ48yyEBh2ujtmKokw0eTwDHtlXUqjVS0I3q7+HB2y12G/m69CA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  '@graphql-codegen/plugin-helpers@5.1.1':
+    resolution: {integrity: sha512-28GHODK2HY1NhdyRcPP3sCz0Kqxyfiz7boIZ8qIxFYmpLYnlDgiYok5fhFLVSZihyOpCs4Fa37gVHf/Q4I2FEg==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  '@graphql-codegen/schema-ast@4.1.0':
+    resolution: {integrity: sha512-kZVn0z+th9SvqxfKYgztA6PM7mhnSZaj4fiuBWvMTqA+QqQ9BBed6Pz41KuD/jr0gJtnlr2A4++/0VlpVbCTmQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  '@graphql-codegen/typed-document-node@5.1.1':
+    resolution: {integrity: sha512-Bp/BrMZDKRwzuVeLv+pSljneqONM7gqu57ZaV34Jbncu2hZWMRDMfizTKghoEwwZbRCYYfJO9tA0sYVVIfI1kg==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  '@graphql-codegen/typescript-operations@4.6.1':
+    resolution: {integrity: sha512-k92laxhih7s0WZ8j5WMIbgKwhe64C0As6x+PdcvgZFMudDJ7rPJ/hFqJ9DCRxNjXoHmSjnr6VUuQZq4lT1RzCA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql-sock: ^1.0.0
+    peerDependenciesMeta:
+      graphql-sock:
+        optional: true
+
+  '@graphql-codegen/typescript@4.1.6':
+    resolution: {integrity: sha512-vpw3sfwf9A7S+kIUjyFxuvrywGxd4lmwmyYnnDVjVE4kSQ6Td3DpqaPTy8aNQ6O96vFoi/bxbZS2BW49PwSUUA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  '@graphql-codegen/visitor-plugin-common@5.8.0':
+    resolution: {integrity: sha512-lC1E1Kmuzi3WZUlYlqB4fP6+CvbKH9J+haU1iWmgsBx5/sO2ROeXJG4Dmt8gP03bI2BwjiwV5WxCEMlyeuzLnA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  '@graphql-hive/signal@1.0.0':
+    resolution: {integrity: sha512-RiwLMc89lTjvyLEivZ/qxAC5nBHoS2CtsWFSOsN35sxG9zoo5Z+JsFHM8MlvmO9yt+MJNIyC5MLE1rsbOphlag==}
+    engines: {node: '>=18.0.0'}
+
+  '@graphql-tools/apollo-engine-loader@8.0.20':
+    resolution: {integrity: sha512-m5k9nXSyjq31yNsEqDXLyykEjjn3K3Mo73oOKI+Xjy8cpnsgbT4myeUJIYYQdLrp7fr9Y9p7ZgwT5YcnwmnAbA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/batch-execute@9.0.17':
+    resolution: {integrity: sha512-i7BqBkUP2+ex8zrQrCQTEt6nYHQmIey9qg7CMRRa1hXCY2X8ZCVjxsvbsi7gOLwyI/R3NHxSRDxmzZevE2cPLg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/code-file-loader@8.1.20':
+    resolution: {integrity: sha512-GzIbjjWJIc04KWnEr8VKuPe0FA2vDTlkaeub5p4lLimljnJ6C0QSkOyCUnFmsB9jetQcHm0Wfmn/akMnFUG+wA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/delegate@10.2.19':
+    resolution: {integrity: sha512-aaCGAALTQmKctHwumbtz0c5XehGjYLSfoDx1IB2vdPt76Q0MKz2AiEDlENgzTVr4JHH7fd9YNrd+IO3D8tFlIg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/documents@1.0.1':
+    resolution: {integrity: sha512-aweoMH15wNJ8g7b2r4C4WRuJxZ0ca8HtNO54rkye/3duxTkW4fGBEutCx03jCIr5+a1l+4vFJNP859QnAVBVCA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/executor-common@0.0.4':
+    resolution: {integrity: sha512-SEH/OWR+sHbknqZyROCFHcRrbZeUAyjCsgpVWCRjqjqRbiJiXq6TxNIIOmpXgkrXWW/2Ev4Wms6YSGJXjdCs6Q==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/executor-graphql-ws@2.0.5':
+    resolution: {integrity: sha512-gI/D9VUzI1Jt1G28GYpvm5ckupgJ5O8mi5Y657UyuUozX34ErfVdZ81g6oVcKFQZ60LhCzk7jJeykK48gaLhDw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/executor-http@1.3.3':
+    resolution: {integrity: sha512-LIy+l08/Ivl8f8sMiHW2ebyck59JzyzO/yF9SFS4NH6MJZUezA1xThUXCDIKhHiD56h/gPojbkpcFvM2CbNE7A==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/executor-legacy-ws@1.1.17':
+    resolution: {integrity: sha512-TvltY6eL4DY1Vt66Z8kt9jVmNcI+WkvVPQZrPbMCM3rv2Jw/sWvSwzUBezRuWX0sIckMifYVh23VPcGBUKX/wg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/executor@1.4.7':
+    resolution: {integrity: sha512-U0nK9jzJRP9/9Izf1+0Gggd6K6RNRsheFo1gC/VWzfnsr0qjcOSS9qTjY0OTC5iTPt4tQ+W5Zpw/uc7mebI6aA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/git-loader@8.0.24':
+    resolution: {integrity: sha512-ypLC9N2bKNC0QNbrEBTbWKwbV607f7vK2rSGi9uFeGr8E29tWplo6or9V/+TM0ZfIkUsNp/4QX/zKTgo8SbwQg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/github-loader@8.0.20':
+    resolution: {integrity: sha512-Icch8bKZ1iP3zXCB9I0ded1hda9NPskSSalw7ZM21kXvLiOR5nZhdqPF65gCFkIKo+O4NR4Bp51MkKj+wl+vpg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/graphql-file-loader@8.0.20':
+    resolution: {integrity: sha512-inds4My+JJxmg5mxKWYtMIJNRxa7MtX+XIYqqD/nu6G4LzQ5KGaBJg6wEl103KxXli7qNOWeVAUmEjZeYhwNEg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/graphql-tag-pluck@8.3.19':
+    resolution: {integrity: sha512-LEw/6IYOUz48HjbWntZXDCzSXsOIM1AyWZrlLoJOrA8QAlhFd8h5Tny7opCypj8FO9VvpPFugWoNDh5InPOEQA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/import@7.0.19':
+    resolution: {integrity: sha512-Xtku8G4bxnrr6I3hVf8RrBFGYIbQ1OYVjl7jgcy092aBkNZvy1T6EDmXmYXn5F+oLd9Bks3K3WaMm8gma/nM/Q==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/json-file-loader@8.0.18':
+    resolution: {integrity: sha512-JjjIxxewgk8HeMR3npR3YbOkB7fxmdgmqB9kZLWdkRKBxrRXVzhryyq+mhmI0Evzt6pNoHIc3vqwmSctG2sddg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/load@8.1.0':
+    resolution: {integrity: sha512-OGfOm09VyXdNGJS/rLqZ6ztCiG2g6AMxhwtET8GZXTbnjptFc17GtKwJ3Jv5w7mjJ8dn0BHydvIuEKEUK4ciYw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
   '@graphql-tools/merge@8.4.2':
     resolution: {integrity: sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==}
     peerDependencies:
@@ -1100,6 +1346,24 @@ packages:
 
   '@graphql-tools/merge@9.0.24':
     resolution: {integrity: sha512-NzWx/Afl/1qHT3Nm1bghGG2l4jub28AdvtG11PoUlmjcIjnFBJMv4vqL0qnxWe8A82peWo4/TkVdjJRLXwgGEw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/optimize@2.0.0':
+    resolution: {integrity: sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/prisma-loader@8.0.17':
+    resolution: {integrity: sha512-fnuTLeQhqRbA156pAyzJYN0KxCjKYRU5bz1q/SKOwElSnAU4k7/G1kyVsWLh7fneY78LoMNH5n+KlFV8iQlnyg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/relay-operation-optimizer@7.0.19':
+    resolution: {integrity: sha512-xnjLpfzw63yIX1bo+BVh4j1attSwqEkUbpJ+HAhdiSUa3FOQFfpWgijRju+3i87CwhjBANqdTZbcsqLT1hEXig==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -1115,6 +1379,12 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
+  '@graphql-tools/url-loader@8.0.31':
+    resolution: {integrity: sha512-QGP3py6DAdKERHO5D38Oi+6j+v0O3rkBbnLpyOo87rmIRbwE6sOkL5JeHegHs7EEJ279fBX6lMt8ry0wBMGtyA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
   '@graphql-tools/utils@10.8.6':
     resolution: {integrity: sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==}
     engines: {node: '>=16.0.0'}
@@ -1123,6 +1393,12 @@ packages:
 
   '@graphql-tools/utils@9.2.1':
     resolution: {integrity: sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/wrap@10.1.0':
+    resolution: {integrity: sha512-M7QolM/cJwM2PNAJS1vphT2/PDVSKtmg5m+fxHrFfKpp2RRosJSvYPzUD/PVPqF2rXTtnCwkgh1s5KIsOPCz+w==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
@@ -1736,6 +2012,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  '@repeaterjs/repeater@3.0.6':
+    resolution: {integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==}
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -2176,6 +2455,9 @@ packages:
   '@types/http-errors@2.0.4':
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -2268,6 +2550,9 @@ packages:
   '@types/voca@1.4.6':
     resolution: {integrity: sha512-ubfCfFxlTOhBBUP2v8lzD8AQVKKu9erZ2t9/8hLpuYHYib3CM/lOwTII3mi527j5UeRDaVjIiAx+iTIWgVCWKQ==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/eslint-plugin@8.34.0':
     resolution: {integrity: sha512-QXwAlHlbcAwNlEEMKQS2RCgJsgXrTJdjXT08xEgbPFa2yYQgVjBymxP5DrfrE7X7iodSzd9qBUHUycdyVJTW1w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2356,6 +2641,18 @@ packages:
   '@vue/shared@3.5.16':
     resolution: {integrity: sha512-c/0fWy3Jw6Z8L9FmTyYfkpM5zklnqqa9+a6dz3DvONRKW2NEbh46BP0FHuLFSWi2TnQEtp91Z6zOWNrU6QiyPg==}
 
+  '@whatwg-node/disposablestack@0.0.6':
+    resolution: {integrity: sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==}
+    engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/fetch@0.10.8':
+    resolution: {integrity: sha512-Rw9z3ctmeEj8QIB9MavkNJqekiu9usBCSMZa+uuAvM0lF3v70oQVCXNppMIqaV6OTZbdaHF1M2HLow58DEw+wg==}
+    engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/node-fetch@0.7.21':
+    resolution: {integrity: sha512-QC16IdsEyIW7kZd77aodrMO7zAoDyyqRCTLg+qG4wqtP4JV9AA+p7/lgqMdD29XyiYdVvIdFrfI9yh7B1QvRvw==}
+    engines: {node: '>=18.0.0'}
+
   '@whatwg-node/promise-helpers@1.3.2':
     resolution: {integrity: sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==}
     engines: {node: '>=16.0.0'}
@@ -2421,6 +2718,10 @@ packages:
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
   ansi-escapes@7.0.0:
     resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
     engines: {node: '>=18'}
@@ -2477,6 +2778,10 @@ packages:
     resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
     engines: {node: '>= 0.4'}
 
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+
   array.prototype.findlast@1.2.5:
     resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
     engines: {node: '>= 0.4'}
@@ -2501,6 +2806,13 @@ packages:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
     engines: {node: '>=0.10.0'}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -2522,6 +2834,10 @@ packages:
   attr-accept@2.2.5:
     resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
     engines: {node: '>=4'}
+
+  auto-bind@4.0.0:
+    resolution: {integrity: sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==}
+    engines: {node: '>=8'}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -2549,6 +2865,9 @@ packages:
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -2568,6 +2887,14 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  browserslist@4.25.0:
+    resolution: {integrity: sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  bser@2.1.1:
+    resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
   buffer@5.6.0:
     resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
@@ -2599,6 +2926,9 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camel-case@4.1.2:
+    resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
+
   camelcase-keys@6.2.2:
     resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
     engines: {node: '>=8'}
@@ -2609,6 +2939,9 @@ packages:
 
   caniuse-lite@1.0.30001720:
     resolution: {integrity: sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==}
+
+  capital-case@1.0.4:
+    resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
 
   ccount@1.1.0:
     resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
@@ -2627,6 +2960,12 @@ packages:
   chalk@5.4.1:
     resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  change-case-all@1.0.15:
+    resolution: {integrity: sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==}
+
+  change-case@4.1.2:
+    resolution: {integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==}
 
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -2653,6 +2992,9 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  chardet@0.7.0:
+    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -2669,14 +3011,30 @@ packages:
     resolution: {integrity: sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==}
     engines: {node: '>=14.16'}
 
+  cli-cursor@3.1.0:
+    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
+    engines: {node: '>=8'}
+
   cli-highlight@2.1.11:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
 
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+
   cli-table3@0.6.5:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
     engines: {node: 10.* || >= 12.*}
+
+  cli-truncate@2.1.0:
+    resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
+    engines: {node: '>=8'}
+
+  cli-width@3.0.0:
+    resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
+    engines: {node: '>= 10'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -2690,6 +3048,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clone@1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -2715,6 +3077,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -2722,6 +3087,10 @@ packages:
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
+
+  common-tags@1.8.2:
+    resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
+    engines: {node: '>=4.0.0'}
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
@@ -2744,6 +3113,9 @@ packages:
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+
+  constant-case@3.0.4:
+    resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
 
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
@@ -2778,6 +3150,9 @@ packages:
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
@@ -2807,6 +3182,15 @@ packages:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
 
+  cosmiconfig@8.3.6:
+    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   cosmiconfig@9.0.0:
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
     engines: {node: '>=14'}
@@ -2822,6 +3206,9 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
 
   cross-fetch@4.1.0:
     resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
@@ -2845,6 +3232,10 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -2871,6 +3262,9 @@ packages:
   debounce-fn@4.0.0:
     resolution: {integrity: sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==}
     engines: {node: '>=10'}
+
+  debounce@1.2.1:
+    resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -2910,6 +3304,9 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  defaults@1.0.4:
+    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
@@ -2930,6 +3327,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dependency-graph@0.11.0:
+    resolution: {integrity: sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==}
+    engines: {node: '>= 0.6.0'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -2937,6 +3338,10 @@ packages:
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  detect-indent@6.1.0:
+    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
 
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
@@ -2966,6 +3371,9 @@ packages:
   dompurify@3.2.6:
     resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
 
+  dot-case@3.0.4:
+    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
+
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
@@ -2994,6 +3402,9 @@ packages:
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  electron-to-chromium@1.5.166:
+    resolution: {integrity: sha512-QPWqHL0BglzPYyJJ1zSSmwFFL6MFXhbACOCcsCdUMCkzPdS9/OIBVxg516X/Ado2qwAq8k0nJJ7phQPCqiaFAw==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -3187,6 +3598,10 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  external-editor@3.1.0:
+    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
+    engines: {node: '>=4'}
+
   extract-files@11.0.0:
     resolution: {integrity: sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==}
     engines: {node: ^12.20 || >= 14.13}
@@ -3228,9 +3643,26 @@ packages:
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
+  fb-watchman@2.0.2:
+    resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  fbjs-css-vars@1.0.2:
+    resolution: {integrity: sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==}
+
+  fbjs@3.0.5:
+    resolution: {integrity: sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==}
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
     engines: {node: '>=4'}
+
+  figures@3.2.0:
+    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
+    engines: {node: '>=8'}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -3314,6 +3746,10 @@ packages:
     resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
     engines: {node: '>= 6'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -3355,6 +3791,10 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -3426,6 +3866,10 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+
   globby@14.1.0:
     resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
     engines: {node: '>=18'}
@@ -3442,6 +3886,21 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  graphql-config@5.1.5:
+    resolution: {integrity: sha512-mG2LL1HccpU8qg5ajLROgdsBzx/o2M6kgI3uAmoaXiSH9PCUbtIyLomLqUtCFaAeG2YCFsl0M5cfQ9rKmDoMVA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      cosmiconfig-toml-loader: ^1.0.0
+      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    peerDependenciesMeta:
+      cosmiconfig-toml-loader:
+        optional: true
+
+  graphql-request@6.1.0:
+    resolution: {integrity: sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==}
+    peerDependencies:
+      graphql: 14 - 16
 
   graphql-tag@2.12.6:
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
@@ -3522,6 +3981,9 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  header-case@2.0.4:
+    resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
+
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
@@ -3594,6 +4056,10 @@ packages:
   immer@10.1.1:
     resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
 
+  immutable@3.7.6:
+    resolution: {integrity: sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==}
+    engines: {node: '>=0.8.0'}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -3601,6 +4067,10 @@ packages:
   import-from-esm@2.0.0:
     resolution: {integrity: sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==}
     engines: {node: '>=18.20'}
+
+  import-from@4.0.0:
+    resolution: {integrity: sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==}
+    engines: {node: '>=12.2'}
 
   import-meta-resolve@4.1.0:
     resolution: {integrity: sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==}
@@ -3631,6 +4101,10 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  inquirer@8.2.6:
+    resolution: {integrity: sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==}
+    engines: {node: '>=12.0.0'}
+
   install@0.13.0:
     resolution: {integrity: sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==}
     engines: {node: '>= 0.10'}
@@ -3646,6 +4120,9 @@ packages:
     resolution: {integrity: sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==}
     engines: {node: '>=12'}
 
+  invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
   ioredis@5.6.1:
     resolution: {integrity: sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==}
     engines: {node: '>=12.22.0'}
@@ -3653,6 +4130,10 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  is-absolute@1.0.0:
+    resolution: {integrity: sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==}
+    engines: {node: '>=0.10.0'}
 
   is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
@@ -3736,6 +4217,13 @@ packages:
   is-hotkey@0.2.0:
     resolution: {integrity: sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw==}
 
+  is-interactive@1.0.0:
+    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
+    engines: {node: '>=8'}
+
+  is-lower-case@2.0.2:
+    resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
+
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
@@ -3772,6 +4260,10 @@ packages:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
 
+  is-relative@1.0.0:
+    resolution: {integrity: sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==}
+    engines: {node: '>=0.10.0'}
+
   is-set@2.0.3:
     resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
     engines: {node: '>= 0.4'}
@@ -3804,9 +4296,20 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
+  is-unc-path@1.0.0:
+    resolution: {integrity: sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
+
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
+
+  is-upper-case@2.0.2:
+    resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -3820,6 +4323,10 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  is-windows@1.0.2:
+    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
+    engines: {node: '>=0.10.0'}
+
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
@@ -3828,6 +4335,11 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
 
   issue-parser@7.0.1:
     resolution: {integrity: sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==}
@@ -3841,12 +4353,19 @@ packages:
     resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
     engines: {node: '>= 0.6.0'}
 
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+    hasBin: true
+
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3880,6 +4399,15 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json-to-pretty-yaml@1.2.2:
+    resolution: {integrity: sha512-rvm6hunfCcqegwYaG5T4yKJWxc9FXFgBVrcTZ4XfSVRwa5HA/Xs+vB/Eo9treYYHCeNM0nrSUr82V/M31Urc7A==}
+    engines: {node: '>= 0.2.0'}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
@@ -3977,6 +4505,15 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  listr2@4.0.5:
+    resolution: {integrity: sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      enquirer: '>= 2.3.0 < 3'
+    peerDependenciesMeta:
+      enquirer:
+        optional: true
+
   load-json-file@4.0.0:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
     engines: {node: '>=4'}
@@ -4046,6 +4583,14 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
+  log-symbols@4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
+
+  log-update@4.0.0:
+    resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}
+    engines: {node: '>=10'}
+
   loglevel@1.9.2:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
     engines: {node: '>= 0.6.0'}
@@ -4063,8 +4608,17 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lower-case-first@2.0.2:
+    resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
+
+  lower-case@2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -4080,6 +4634,10 @@ packages:
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  map-cache@0.2.2:
+    resolution: {integrity: sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==}
+    engines: {node: '>=0.10.0'}
 
   map-obj@1.0.1:
     resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}
@@ -4194,6 +4752,15 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  meros@1.3.0:
+    resolution: {integrity: sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==}
+    engines: {node: '>=13'}
+    peerDependencies:
+      '@types/node': '>=13'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -4379,6 +4946,9 @@ packages:
   msgpackr@1.11.4:
     resolution: {integrity: sha512-uaff7RG9VIC4jacFW9xzL3jc0iM32DNHe4jYVycBcjUePT/Klnfj7pqtWJt9khvDFizmjN2TlYniYmSS2LIaZg==}
 
+  mute-stream@0.0.8:
+    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -4446,8 +5016,16 @@ packages:
       sass:
         optional: true
 
+  no-case@3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
@@ -4462,9 +5040,19 @@ packages:
       encoding:
         optional: true
 
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
+
+  node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+
+  node-releases@2.0.19:
+    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -4476,6 +5064,10 @@ packages:
   normalize-package-data@6.0.2:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
     engines: {node: ^16.14.0 || >=18.0.0}
+
+  normalize-path@2.1.1:
+    resolution: {integrity: sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==}
+    engines: {node: '>=0.10.0'}
 
   normalize-url@8.0.2:
     resolution: {integrity: sha512-Ee/R3SyN4BuynXcnTaekmaVdbDAEiNrHqjQIA37mHU8G9pf7aaAD4ZX3XjBLo6rsdcxA/gtkcNYZLt30ACgynw==}
@@ -4567,6 +5159,9 @@ packages:
       - which
       - write-file-atomic
 
+  nullthrows@1.1.1:
+    resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
+
   oauth@0.9.15:
     resolution: {integrity: sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==}
 
@@ -4640,8 +5235,16 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  ora@5.4.1:
+    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
+    engines: {node: '>=10'}
+
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
+  os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -4687,6 +5290,10 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  p-map@4.0.0:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
+    engines: {node: '>=10'}
+
   p-map@7.0.3:
     resolution: {integrity: sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==}
     engines: {node: '>=18'}
@@ -4710,6 +5317,9 @@ packages:
   package-manager-detector@1.3.0:
     resolution: {integrity: sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==}
 
+  param-case@3.0.4:
+    resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -4719,6 +5329,10 @@ packages:
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse-filepath@1.0.2:
+    resolution: {integrity: sha512-FwdRXKCohSVeXqwtYonZTXtbGJKrn+HNyWDYVcp5yuJlesTwNH4rsmRZ+GrKAPJ5bLpRxESMeS+Rl0VCHRvB2Q==}
+    engines: {node: '>=0.8'}
 
   parse-json@4.0.0:
     resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
@@ -4749,6 +5363,9 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  pascal-case@3.1.2:
+    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
+
   passport-strategy@1.0.0:
     resolution: {integrity: sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==}
     engines: {node: '>= 0.4.0'}
@@ -4756,6 +5373,9 @@ packages:
   passport@0.7.0:
     resolution: {integrity: sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==}
     engines: {node: '>= 0.4.0'}
+
+  path-case@3.0.4:
+    resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
 
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
@@ -4775,6 +5395,14 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-root-regex@0.1.2:
+    resolution: {integrity: sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==}
+    engines: {node: '>=0.10.0'}
+
+  path-root@0.1.1:
+    resolution: {integrity: sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==}
+    engines: {node: '>=0.10.0'}
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
@@ -4944,6 +5572,9 @@ packages:
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  promise@7.3.1:
+    resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -5222,6 +5853,9 @@ packages:
       react:
         optional: true
 
+  relay-runtime@12.0.0:
+    resolution: {integrity: sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==}
+
   remark-directive@4.0.0:
     resolution: {integrity: sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==}
 
@@ -5243,8 +5877,17 @@ packages:
   remark@15.0.1:
     resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
 
+  remedial@1.0.8:
+    resolution: {integrity: sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==}
+
   remove-accents@0.5.0:
     resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
+
+  remove-trailing-separator@1.1.0:
+    resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
+
+  remove-trailing-spaces@1.0.9:
+    resolution: {integrity: sha512-xzG7w5IRijvIkHIjDk65URsJJ7k4J95wmcArY5PRcmjldIOl7oTvG8+X2Ag690R7SfwiOcHrWZKVc1Pp5WIOzA==}
 
   repeat-string@1.6.1:
     resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
@@ -5278,6 +5921,10 @@ packages:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
 
+  restore-cursor@3.1.0:
+    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
+    engines: {node: '>=8'}
+
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
@@ -5286,11 +5933,21 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
+  run-async@2.4.1:
+    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
+    engines: {node: '>=0.12.0'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
@@ -5323,6 +5980,9 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
+  scuid@1.1.0:
+    resolution: {integrity: sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==}
+
   semantic-release@24.2.5:
     resolution: {integrity: sha512-9xV49HNY8C0/WmPWxTlaNleiXhWb//qfMzG2c5X8/k7tuWcu8RssbuS+sujb/h7PiWSXv53mrQvV9hrO9b7vuQ==}
     engines: {node: '>=20.8.1'}
@@ -5353,6 +6013,9 @@ packages:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
 
+  sentence-case@3.0.4:
+    resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
+
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
@@ -5369,6 +6032,9 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -5383,6 +6049,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -5411,11 +6081,18 @@ packages:
     resolution: {integrity: sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==}
     engines: {node: '>=6'}
 
+  signedsource@1.0.0:
+    resolution: {integrity: sha512-6+eerH9fEnNmi/hyM1DXcRK3pWdoMQtlkQ+ns0ntzunjKqp5i3sKCc80ym8Fib3iaYhdJUOPdhlJWj1tvge2Ww==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
   slash@5.1.0:
@@ -5442,6 +6119,17 @@ packages:
 
   slate@0.110.2:
     resolution: {integrity: sha512-4xGULnyMCiEQ0Ml7JAC1A6HVE6MNpPJU7Eq4cXh1LxlrR0dFXC3XC+rNfQtUJ7chHoPkws57x7DDiWiZAt+PBA==}
+
+  slice-ansi@3.0.0:
+    resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
+    engines: {node: '>=8'}
+
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
+
+  snake-case@3.0.4:
+    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
   sonic-boom@4.2.0:
     resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
@@ -5480,6 +6168,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  sponge-case@1.0.1:
+    resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
+
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
@@ -5500,6 +6191,9 @@ packages:
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+
+  string-env-interpolation@1.0.1:
+    resolution: {integrity: sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -5611,9 +6305,16 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swap-case@2.0.2:
+    resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
+
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
+
+  sync-fetch@0.6.0-2:
+    resolution: {integrity: sha512-c7AfkZ9udatCuAy9RSfiGPpeOKKUAUK5e1cXadLOGUjasdxqYqAK0jTNkM/FSEyJ3a5Ra27j/tw/PS0qLmaF/A==}
+    engines: {node: '>=18'}
 
   tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
@@ -5650,9 +6351,16 @@ packages:
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
   time-span@5.1.0:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
+
+  timeout-signal@2.0.0:
+    resolution: {integrity: sha512-YBGpG4bWsHoPvofT6y/5iqulfXIiIErl5B0LdtHT1mGXDFTAhhRrbUpTvBgYbovr+3cKblya2WAOcpoy90XguA==}
+    engines: {node: '>=16'}
 
   tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
@@ -5662,6 +6370,13 @@ packages:
 
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
+
+  title-case@3.0.3:
+    resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
+
+  tmp@0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -5698,6 +6413,12 @@ packages:
   ts-invariant@0.10.3:
     resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
     engines: {node: '>=8'}
+
+  ts-log@2.2.7:
+    resolution: {integrity: sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg==}
+
+  tslib@2.6.3:
+    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -5747,6 +6468,10 @@ packages:
 
   type-fest@0.18.1:
     resolution: {integrity: sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==}
+    engines: {node: '>=10'}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
   type-fest@0.6.0:
@@ -5807,6 +6532,10 @@ packages:
     peerDependencies:
       '@babel/runtime': ^7.23.2
 
+  ua-parser-js@1.0.40:
+    resolution: {integrity: sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==}
+    hasBin: true
+
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
@@ -5826,6 +6555,10 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  unc-path-regex@0.1.2:
+    resolution: {integrity: sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==}
+    engines: {node: '>=0.10.0'}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -5880,9 +6613,25 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unixify@1.0.0:
+    resolution: {integrity: sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==}
+    engines: {node: '>=0.10.0'}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  update-browserslist-db@1.1.3:
+    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  upper-case-first@2.0.2:
+    resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
+
+  upper-case@2.0.2:
+    resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -5890,6 +6639,9 @@ packages:
   url-join@5.0.0:
     resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  urlpattern-polyfill@10.1.0:
+    resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -5978,12 +6730,23 @@ packages:
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
+  wcwidth@1.0.1:
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -6016,6 +6779,10 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -6040,6 +6807,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
@@ -6047,9 +6817,17 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  yaml-ast-parser@0.0.43:
+    resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
+
   yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
+
+  yaml@2.8.0:
+    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
@@ -6239,6 +7017,22 @@ snapshots:
       graphql: 16.11.0
 
   '@apollo/utils.withrequired@2.0.1': {}
+
+  '@ardatan/relay-compiler@12.0.3(graphql@16.11.0)':
+    dependencies:
+      '@babel/generator': 7.27.3
+      '@babel/parser': 7.27.4
+      '@babel/runtime': 7.27.4
+      chalk: 4.1.2
+      fb-watchman: 2.0.2
+      graphql: 16.11.0
+      immutable: 3.7.6
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      relay-runtime: 12.0.0
+      signedsource: 1.0.0
+    transitivePeerDependencies:
+      - encoding
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -6734,6 +7528,28 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/compat-data@7.27.5': {}
+
+  '@babel/core@7.27.4':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.27.3
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.27.4)
+      '@babel/helpers': 7.27.6
+      '@babel/parser': 7.27.4
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.27.4
+      '@babel/types': 7.27.3
+      convert-source-map: 2.0.0
+      debug: 4.4.1
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/generator@7.27.3':
     dependencies:
       '@babel/parser': 7.27.4
@@ -6742,6 +7558,14 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
 
+  '@babel/helper-compilation-targets@7.27.2':
+    dependencies:
+      '@babel/compat-data': 7.27.5
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.25.0
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
   '@babel/helper-module-imports@7.27.1':
     dependencies:
       '@babel/traverse': 7.27.4
@@ -6749,13 +7573,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.27.3(@babel/core@7.27.4)':
+    dependencies:
+      '@babel/core': 7.27.4
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/traverse': 7.27.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.27.1': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.27.1': {}
 
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.27.6':
+    dependencies:
+      '@babel/template': 7.27.2
+      '@babel/types': 7.27.6
+
   '@babel/parser@7.27.4':
     dependencies:
       '@babel/types': 7.27.3
+
+  '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.27.4)':
+    dependencies:
+      '@babel/core': 7.27.4
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/runtime@7.27.4': {}
 
@@ -6778,6 +7625,11 @@ snapshots:
       - supports-color
 
   '@babel/types@7.27.3':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
+  '@babel/types@7.27.6':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
@@ -7129,6 +7981,23 @@ snapshots:
 
   '@emotion/weak-memoize@0.4.0': {}
 
+  '@envelop/core@5.2.3':
+    dependencies:
+      '@envelop/instrumentation': 1.0.0
+      '@envelop/types': 5.2.1
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@envelop/instrumentation@1.0.0':
+    dependencies:
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@envelop/types@5.2.1':
+    dependencies:
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
   '@esbuild/aix-ppc64@0.24.2':
     optional: true
 
@@ -7329,6 +8198,8 @@ snapshots:
 
   '@faker-js/faker@9.8.0': {}
 
+  '@fastify/busboy@3.1.1': {}
+
   '@floating-ui/core@1.7.1':
     dependencies:
       '@floating-ui/utils': 0.2.9
@@ -7362,6 +8233,345 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
+  '@graphql-codegen/add@5.0.3(graphql@16.11.0)':
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 5.1.1(graphql@16.11.0)
+      graphql: 16.11.0
+      tslib: 2.6.3
+
+  '@graphql-codegen/cli@5.0.7(@types/node@22.15.29)(graphql@16.11.0)(typescript@5.8.3)':
+    dependencies:
+      '@babel/generator': 7.27.3
+      '@babel/template': 7.27.2
+      '@babel/types': 7.27.3
+      '@graphql-codegen/client-preset': 4.8.2(graphql@16.11.0)
+      '@graphql-codegen/core': 4.0.2(graphql@16.11.0)
+      '@graphql-codegen/plugin-helpers': 5.1.1(graphql@16.11.0)
+      '@graphql-tools/apollo-engine-loader': 8.0.20(graphql@16.11.0)
+      '@graphql-tools/code-file-loader': 8.1.20(graphql@16.11.0)
+      '@graphql-tools/git-loader': 8.0.24(graphql@16.11.0)
+      '@graphql-tools/github-loader': 8.0.20(@types/node@22.15.29)(graphql@16.11.0)
+      '@graphql-tools/graphql-file-loader': 8.0.20(graphql@16.11.0)
+      '@graphql-tools/json-file-loader': 8.0.18(graphql@16.11.0)
+      '@graphql-tools/load': 8.1.0(graphql@16.11.0)
+      '@graphql-tools/prisma-loader': 8.0.17(@types/node@22.15.29)(graphql@16.11.0)
+      '@graphql-tools/url-loader': 8.0.31(@types/node@22.15.29)(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      '@whatwg-node/fetch': 0.10.8
+      chalk: 4.1.2
+      cosmiconfig: 8.3.6(typescript@5.8.3)
+      debounce: 1.2.1
+      detect-indent: 6.1.0
+      graphql: 16.11.0
+      graphql-config: 5.1.5(@types/node@22.15.29)(graphql@16.11.0)(typescript@5.8.3)
+      inquirer: 8.2.6
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      json-to-pretty-yaml: 1.2.2
+      listr2: 4.0.5
+      log-symbols: 4.1.0
+      micromatch: 4.0.8
+      shell-quote: 1.8.3
+      string-env-interpolation: 1.0.1
+      ts-log: 2.2.7
+      tslib: 2.8.1
+      yaml: 2.8.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@fastify/websocket'
+      - '@types/node'
+      - bufferutil
+      - cosmiconfig-toml-loader
+      - encoding
+      - enquirer
+      - graphql-sock
+      - supports-color
+      - typescript
+      - uWebSockets.js
+      - utf-8-validate
+
+  '@graphql-codegen/client-preset@4.8.2(graphql@16.11.0)':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/template': 7.27.2
+      '@graphql-codegen/add': 5.0.3(graphql@16.11.0)
+      '@graphql-codegen/gql-tag-operations': 4.0.17(graphql@16.11.0)
+      '@graphql-codegen/plugin-helpers': 5.1.1(graphql@16.11.0)
+      '@graphql-codegen/typed-document-node': 5.1.1(graphql@16.11.0)
+      '@graphql-codegen/typescript': 4.1.6(graphql@16.11.0)
+      '@graphql-codegen/typescript-operations': 4.6.1(graphql@16.11.0)
+      '@graphql-codegen/visitor-plugin-common': 5.8.0(graphql@16.11.0)
+      '@graphql-tools/documents': 1.0.1(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.11.0)
+      graphql: 16.11.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+
+  '@graphql-codegen/core@4.0.2(graphql@16.11.0)':
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 5.1.1(graphql@16.11.0)
+      '@graphql-tools/schema': 10.0.23(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      graphql: 16.11.0
+      tslib: 2.6.3
+
+  '@graphql-codegen/gql-tag-operations@4.0.17(graphql@16.11.0)':
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 5.1.1(graphql@16.11.0)
+      '@graphql-codegen/visitor-plugin-common': 5.8.0(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      auto-bind: 4.0.0
+      graphql: 16.11.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+
+  '@graphql-codegen/plugin-helpers@5.1.1(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      change-case-all: 1.0.15
+      common-tags: 1.8.2
+      graphql: 16.11.0
+      import-from: 4.0.0
+      lodash: 4.17.21
+      tslib: 2.6.3
+
+  '@graphql-codegen/schema-ast@4.1.0(graphql@16.11.0)':
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 5.1.1(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      graphql: 16.11.0
+      tslib: 2.6.3
+
+  '@graphql-codegen/typed-document-node@5.1.1(graphql@16.11.0)':
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 5.1.1(graphql@16.11.0)
+      '@graphql-codegen/visitor-plugin-common': 5.8.0(graphql@16.11.0)
+      auto-bind: 4.0.0
+      change-case-all: 1.0.15
+      graphql: 16.11.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+
+  '@graphql-codegen/typescript-operations@4.6.1(graphql@16.11.0)':
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 5.1.1(graphql@16.11.0)
+      '@graphql-codegen/typescript': 4.1.6(graphql@16.11.0)
+      '@graphql-codegen/visitor-plugin-common': 5.8.0(graphql@16.11.0)
+      auto-bind: 4.0.0
+      graphql: 16.11.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+
+  '@graphql-codegen/typescript@4.1.6(graphql@16.11.0)':
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 5.1.1(graphql@16.11.0)
+      '@graphql-codegen/schema-ast': 4.1.0(graphql@16.11.0)
+      '@graphql-codegen/visitor-plugin-common': 5.8.0(graphql@16.11.0)
+      auto-bind: 4.0.0
+      graphql: 16.11.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+
+  '@graphql-codegen/visitor-plugin-common@5.8.0(graphql@16.11.0)':
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 5.1.1(graphql@16.11.0)
+      '@graphql-tools/optimize': 2.0.0(graphql@16.11.0)
+      '@graphql-tools/relay-operation-optimizer': 7.0.19(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      auto-bind: 4.0.0
+      change-case-all: 1.0.15
+      dependency-graph: 0.11.0
+      graphql: 16.11.0
+      graphql-tag: 2.12.6(graphql@16.11.0)
+      parse-filepath: 1.0.2
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+
+  '@graphql-hive/signal@1.0.0': {}
+
+  '@graphql-tools/apollo-engine-loader@8.0.20(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      '@whatwg-node/fetch': 0.10.8
+      graphql: 16.11.0
+      sync-fetch: 0.6.0-2
+      tslib: 2.8.1
+
+  '@graphql-tools/batch-execute@9.0.17(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      '@whatwg-node/promise-helpers': 1.3.2
+      dataloader: 2.2.3
+      graphql: 16.11.0
+      tslib: 2.8.1
+
+  '@graphql-tools/code-file-loader@8.1.20(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/graphql-tag-pluck': 8.3.19(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      globby: 11.1.0
+      graphql: 16.11.0
+      tslib: 2.8.1
+      unixify: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@graphql-tools/delegate@10.2.19(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/batch-execute': 9.0.17(graphql@16.11.0)
+      '@graphql-tools/executor': 1.4.7(graphql@16.11.0)
+      '@graphql-tools/schema': 10.0.23(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      '@repeaterjs/repeater': 3.0.6
+      '@whatwg-node/promise-helpers': 1.3.2
+      dataloader: 2.2.3
+      dset: 3.1.4
+      graphql: 16.11.0
+      tslib: 2.8.1
+
+  '@graphql-tools/documents@1.0.1(graphql@16.11.0)':
+    dependencies:
+      graphql: 16.11.0
+      lodash.sortby: 4.7.0
+      tslib: 2.8.1
+
+  '@graphql-tools/executor-common@0.0.4(graphql@16.11.0)':
+    dependencies:
+      '@envelop/core': 5.2.3
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      graphql: 16.11.0
+
+  '@graphql-tools/executor-graphql-ws@2.0.5(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/executor-common': 0.0.4(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      '@whatwg-node/disposablestack': 0.0.6
+      graphql: 16.11.0
+      graphql-ws: 6.0.4(graphql@16.11.0)(ws@8.18.1)
+      isomorphic-ws: 5.0.0(ws@8.18.1)
+      tslib: 2.8.1
+      ws: 8.18.1
+    transitivePeerDependencies:
+      - '@fastify/websocket'
+      - bufferutil
+      - uWebSockets.js
+      - utf-8-validate
+
+  '@graphql-tools/executor-http@1.3.3(@types/node@22.15.29)(graphql@16.11.0)':
+    dependencies:
+      '@graphql-hive/signal': 1.0.0
+      '@graphql-tools/executor-common': 0.0.4(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      '@repeaterjs/repeater': 3.0.6
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/fetch': 0.10.8
+      '@whatwg-node/promise-helpers': 1.3.2
+      graphql: 16.11.0
+      meros: 1.3.0(@types/node@22.15.29)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@graphql-tools/executor-legacy-ws@1.1.17(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      '@types/ws': 8.18.1
+      graphql: 16.11.0
+      isomorphic-ws: 5.0.0(ws@8.18.1)
+      tslib: 2.8.1
+      ws: 8.18.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@graphql-tools/executor@1.4.7(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.11.0)
+      '@repeaterjs/repeater': 3.0.6
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/promise-helpers': 1.3.2
+      graphql: 16.11.0
+      tslib: 2.8.1
+
+  '@graphql-tools/git-loader@8.0.24(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/graphql-tag-pluck': 8.3.19(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      graphql: 16.11.0
+      is-glob: 4.0.3
+      micromatch: 4.0.8
+      tslib: 2.8.1
+      unixify: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@graphql-tools/github-loader@8.0.20(@types/node@22.15.29)(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/executor-http': 1.3.3(@types/node@22.15.29)(graphql@16.11.0)
+      '@graphql-tools/graphql-tag-pluck': 8.3.19(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      '@whatwg-node/fetch': 0.10.8
+      '@whatwg-node/promise-helpers': 1.3.2
+      graphql: 16.11.0
+      sync-fetch: 0.6.0-2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+
+  '@graphql-tools/graphql-file-loader@8.0.20(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/import': 7.0.19(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      globby: 11.1.0
+      graphql: 16.11.0
+      tslib: 2.8.1
+      unixify: 1.0.0
+
+  '@graphql-tools/graphql-tag-pluck@8.3.19(graphql@16.11.0)':
+    dependencies:
+      '@babel/core': 7.27.4
+      '@babel/parser': 7.27.4
+      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.27.4)
+      '@babel/traverse': 7.27.4
+      '@babel/types': 7.27.3
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      graphql: 16.11.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@graphql-tools/import@7.0.19(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      graphql: 16.11.0
+      resolve-from: 5.0.0
+      tslib: 2.8.1
+
+  '@graphql-tools/json-file-loader@8.0.18(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      globby: 11.1.0
+      graphql: 16.11.0
+      tslib: 2.8.1
+      unixify: 1.0.0
+
+  '@graphql-tools/load@8.1.0(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/schema': 10.0.23(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      graphql: 16.11.0
+      p-limit: 3.1.0
+      tslib: 2.8.1
+
   '@graphql-tools/merge@8.4.2(graphql@16.11.0)':
     dependencies:
       '@graphql-tools/utils': 9.2.1(graphql@16.11.0)
@@ -7373,6 +8583,48 @@ snapshots:
       '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
       graphql: 16.11.0
       tslib: 2.8.1
+
+  '@graphql-tools/optimize@2.0.0(graphql@16.11.0)':
+    dependencies:
+      graphql: 16.11.0
+      tslib: 2.8.1
+
+  '@graphql-tools/prisma-loader@8.0.17(@types/node@22.15.29)(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/url-loader': 8.0.31(@types/node@22.15.29)(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      '@types/js-yaml': 4.0.9
+      '@whatwg-node/fetch': 0.10.8
+      chalk: 4.1.2
+      debug: 4.4.1
+      dotenv: 16.5.0
+      graphql: 16.11.0
+      graphql-request: 6.1.0(graphql@16.11.0)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      jose: 5.10.0
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      scuid: 1.1.0
+      tslib: 2.8.1
+      yaml-ast-parser: 0.0.43
+    transitivePeerDependencies:
+      - '@fastify/websocket'
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - supports-color
+      - uWebSockets.js
+      - utf-8-validate
+
+  '@graphql-tools/relay-operation-optimizer@7.0.19(graphql@16.11.0)':
+    dependencies:
+      '@ardatan/relay-compiler': 12.0.3(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      graphql: 16.11.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - encoding
 
   '@graphql-tools/schema@10.0.23(graphql@16.11.0)':
     dependencies:
@@ -7389,6 +8641,28 @@ snapshots:
       tslib: 2.8.1
       value-or-promise: 1.0.12
 
+  '@graphql-tools/url-loader@8.0.31(@types/node@22.15.29)(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/executor-graphql-ws': 2.0.5(graphql@16.11.0)
+      '@graphql-tools/executor-http': 1.3.3(@types/node@22.15.29)(graphql@16.11.0)
+      '@graphql-tools/executor-legacy-ws': 1.1.17(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      '@graphql-tools/wrap': 10.1.0(graphql@16.11.0)
+      '@types/ws': 8.18.1
+      '@whatwg-node/fetch': 0.10.8
+      '@whatwg-node/promise-helpers': 1.3.2
+      graphql: 16.11.0
+      isomorphic-ws: 5.0.0(ws@8.18.1)
+      sync-fetch: 0.6.0-2
+      tslib: 2.8.1
+      ws: 8.18.1
+    transitivePeerDependencies:
+      - '@fastify/websocket'
+      - '@types/node'
+      - bufferutil
+      - uWebSockets.js
+      - utf-8-validate
+
   '@graphql-tools/utils@10.8.6(graphql@16.11.0)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.11.0)
@@ -7401,6 +8675,15 @@ snapshots:
   '@graphql-tools/utils@9.2.1(graphql@16.11.0)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.11.0)
+      graphql: 16.11.0
+      tslib: 2.8.1
+
+  '@graphql-tools/wrap@10.1.0(graphql@16.11.0)':
+    dependencies:
+      '@graphql-tools/delegate': 10.2.19(graphql@16.11.0)
+      '@graphql-tools/schema': 10.0.23(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.11.0
       tslib: 2.8.1
 
@@ -7517,10 +8800,10 @@ snapshots:
 
   '@juggle/resize-observer@3.4.0': {}
 
-  '@keystone-6/auth@8.1.0(@keystone-6/core@6.5.1(@prisma/generator-helper@5.22.0)(@types/express@4.17.22)(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1)))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@keystone-6/auth@8.1.0(@keystone-6/core@6.5.1(@babel/core@7.27.4)(@prisma/generator-helper@5.22.0)(@types/express@4.17.22)(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1)))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.27.4
-      '@keystone-6/core': 6.5.1(@prisma/generator-helper@5.22.0)(@types/express@4.17.22)(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1))
+      '@keystone-6/core': 6.5.1(@babel/core@7.27.4)(@prisma/generator-helper@5.22.0)(@types/express@4.17.22)(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1))
       '@keystone-ui/button': 7.0.2(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))
       '@keystone-ui/core': 5.0.2(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@keystone-ui/fields': 7.2.0(@types/react@18.3.23)
@@ -7536,7 +8819,7 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@keystone-6/core@6.5.1(@prisma/generator-helper@5.22.0)(@types/express@4.17.22)(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1))':
+  '@keystone-6/core@6.5.1(@babel/core@7.27.4)(@prisma/generator-helper@5.22.0)(@types/express@4.17.22)(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1))':
     dependencies:
       '@apollo/cache-control-types': 1.0.3(graphql@16.11.0)
       '@apollo/client': 3.13.8(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1))(graphql@16.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7594,7 +8877,7 @@ snapshots:
       inflection: 3.0.2
       intersection-observer: 0.12.2
       meow: 9.0.0
-      next: 14.2.29(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.29(@babel/core@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       pluralize: 8.0.0
       prisma: 5.22.0
       prompts: 2.4.2
@@ -7622,7 +8905,7 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@keystone-6/fields-document@9.1.1(@keystone-6/core@6.5.1(@prisma/generator-helper@5.22.0)(@types/express@4.17.22)(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1)))(slate-dom@0.112.2(slate@0.110.2))':
+  '@keystone-6/fields-document@9.1.1(@keystone-6/core@6.5.1(@babel/core@7.27.4)(@prisma/generator-helper@5.22.0)(@types/express@4.17.22)(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1)))(slate-dom@0.112.2(slate@0.110.2))':
     dependencies:
       '@babel/runtime': 7.27.4
       '@braintree/sanitize-url': 7.0.4
@@ -7630,7 +8913,7 @@ snapshots:
       '@dnd-kit/modifiers': 7.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@emotion/weak-memoize': 0.4.0
-      '@keystone-6/core': 6.5.1(@prisma/generator-helper@5.22.0)(@types/express@4.17.22)(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1))
+      '@keystone-6/core': 6.5.1(@babel/core@7.27.4)(@prisma/generator-helper@5.22.0)(@types/express@4.17.22)(@types/react@18.3.23)(graphql-ws@6.0.4(graphql@16.11.0)(ws@8.18.1))
       '@keystone-6/document-renderer': 1.1.2(react@18.3.1)
       '@keystone-ui/button': 7.0.2(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))
       '@keystone-ui/core': 5.0.2(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8522,6 +9805,8 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  '@repeaterjs/repeater@3.0.6': {}
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@semantic-release/changelog@6.0.3(semantic-release@24.2.5(typescript@5.8.3))':
@@ -9124,6 +10409,8 @@ snapshots:
 
   '@types/http-errors@2.0.4': {}
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/katex@0.16.7': {}
@@ -9213,6 +10500,10 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/voca@1.4.6': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.15.29
 
   '@typescript-eslint/eslint-plugin@8.34.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
@@ -9360,6 +10651,23 @@ snapshots:
 
   '@vue/shared@3.5.16': {}
 
+  '@whatwg-node/disposablestack@0.0.6':
+    dependencies:
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@whatwg-node/fetch@0.10.8':
+    dependencies:
+      '@whatwg-node/node-fetch': 0.7.21
+      urlpattern-polyfill: 10.1.0
+
+  '@whatwg-node/node-fetch@0.7.21':
+    dependencies:
+      '@fastify/busboy': 3.1.1
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
   '@whatwg-node/promise-helpers@1.3.2':
     dependencies:
       tslib: 2.8.1
@@ -9423,6 +10731,10 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
   ansi-escapes@7.0.0:
     dependencies:
       environment: 1.1.0
@@ -9475,6 +10787,8 @@ snapshots:
       is-string: 1.1.1
       math-intrinsics: 1.1.0
 
+  array-union@2.1.0: {}
+
   array.prototype.findlast@1.2.5:
     dependencies:
       call-bind: 1.0.8
@@ -9518,6 +10832,10 @@ snapshots:
 
   arrify@1.0.1: {}
 
+  asap@2.0.6: {}
+
+  astral-regex@2.0.0: {}
+
   async-function@1.0.0: {}
 
   async-retry@1.3.3:
@@ -9531,6 +10849,8 @@ snapshots:
   atomically@1.7.0: {}
 
   attr-accept@2.2.5: {}
+
+  auto-bind@4.0.0: {}
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -9559,6 +10879,12 @@ snapshots:
   bcryptjs@2.4.3: {}
 
   before-after-hook@4.0.0: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.6.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   body-parser@1.20.3:
     dependencies:
@@ -9593,6 +10919,17 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  browserslist@4.25.0:
+    dependencies:
+      caniuse-lite: 1.0.30001720
+      electron-to-chromium: 1.5.166
+      node-releases: 2.0.19
+      update-browserslist-db: 1.1.3(browserslist@4.25.0)
+
+  bser@2.1.1:
+    dependencies:
+      node-int64: 0.4.0
 
   buffer@5.6.0:
     dependencies:
@@ -9636,6 +10973,11 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camel-case@4.1.2:
+    dependencies:
+      pascal-case: 3.1.2
+      tslib: 2.8.1
+
   camelcase-keys@6.2.2:
     dependencies:
       camelcase: 5.3.1
@@ -9645,6 +10987,12 @@ snapshots:
   camelcase@5.3.1: {}
 
   caniuse-lite@1.0.30001720: {}
+
+  capital-case@1.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
+      upper-case-first: 2.0.2
 
   ccount@1.1.0: {}
 
@@ -9663,6 +11011,34 @@ snapshots:
 
   chalk@5.4.1: {}
 
+  change-case-all@1.0.15:
+    dependencies:
+      change-case: 4.1.2
+      is-lower-case: 2.0.2
+      is-upper-case: 2.0.2
+      lower-case: 2.0.2
+      lower-case-first: 2.0.2
+      sponge-case: 1.0.1
+      swap-case: 2.0.2
+      title-case: 3.0.3
+      upper-case: 2.0.2
+      upper-case-first: 2.0.2
+
+  change-case@4.1.2:
+    dependencies:
+      camel-case: 4.1.2
+      capital-case: 1.0.4
+      constant-case: 3.0.4
+      dot-case: 3.0.4
+      header-case: 2.0.4
+      no-case: 3.0.4
+      param-case: 3.0.4
+      pascal-case: 3.1.2
+      path-case: 3.0.4
+      sentence-case: 3.0.4
+      snake-case: 3.0.4
+      tslib: 2.8.1
+
   char-regex@1.0.2: {}
 
   character-entities-html4@2.1.0: {}
@@ -9679,6 +11055,8 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  chardet@0.7.0: {}
+
   chownr@3.0.0: {}
 
   ci-info@4.2.0: {}
@@ -9689,6 +11067,10 @@ snapshots:
     dependencies:
       escape-string-regexp: 5.0.0
 
+  cli-cursor@3.1.0:
+    dependencies:
+      restore-cursor: 3.1.0
+
   cli-highlight@2.1.11:
     dependencies:
       chalk: 4.1.2
@@ -9698,11 +11080,20 @@ snapshots:
       parse5-htmlparser2-tree-adapter: 6.0.1
       yargs: 16.2.0
 
+  cli-spinners@2.9.2: {}
+
   cli-table3@0.6.5:
     dependencies:
       string-width: 4.2.3
     optionalDependencies:
       '@colors/colors': 1.5.0
+
+  cli-truncate@2.1.0:
+    dependencies:
+      slice-ansi: 3.0.0
+      string-width: 4.2.3
+
+  cli-width@3.0.0: {}
 
   client-only@0.0.1: {}
 
@@ -9719,6 +11110,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clone@1.0.4: {}
 
   clsx@2.1.1: {}
 
@@ -9746,11 +11139,15 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colorette@2.0.20: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
 
   commander@8.3.0: {}
+
+  common-tags@1.8.2: {}
 
   compare-func@2.0.0:
     dependencies:
@@ -9783,6 +11180,12 @@ snapshots:
       ini: 1.3.8
       proto-list: 1.2.4
 
+  constant-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
+      upper-case: 2.0.2
+
   content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
@@ -9810,6 +11213,8 @@ snapshots:
 
   convert-source-map@1.9.0: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie-signature@1.0.6: {}
 
   cookie-signature@1.0.7: {}
@@ -9835,6 +11240,15 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
+  cosmiconfig@8.3.6(typescript@5.8.3):
+    dependencies:
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+    optionalDependencies:
+      typescript: 5.8.3
+
   cosmiconfig@9.0.0(typescript@5.8.3):
     dependencies:
       env-paths: 2.2.1
@@ -9849,6 +11263,12 @@ snapshots:
   cron-parser@4.9.0:
     dependencies:
       luxon: 3.6.1
+
+  cross-fetch@3.2.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   cross-fetch@4.1.0:
     dependencies:
@@ -9873,6 +11293,8 @@ snapshots:
   cssesc@3.0.0: {}
 
   csstype@3.1.3: {}
+
+  data-uri-to-buffer@4.0.1: {}
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -9904,6 +11326,8 @@ snapshots:
     dependencies:
       mimic-fn: 3.1.0
 
+  debounce@1.2.1: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -9929,6 +11353,10 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  defaults@1.0.4:
+    dependencies:
+      clone: 1.0.4
+
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.1
@@ -9947,9 +11375,13 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dependency-graph@0.11.0: {}
+
   dequal@2.0.3: {}
 
   destroy@1.2.0: {}
+
+  detect-indent@6.1.0: {}
 
   detect-libc@2.0.4: {}
 
@@ -9978,6 +11410,11 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
+  dot-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
+
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
@@ -10003,6 +11440,8 @@ snapshots:
       readable-stream: 2.3.8
 
   ee-first@1.1.1: {}
+
+  electron-to-chromium@1.5.166: {}
 
   emoji-regex@8.0.0: {}
 
@@ -10395,6 +11834,12 @@ snapshots:
 
   extend@3.0.2: {}
 
+  external-editor@3.1.0:
+    dependencies:
+      chardet: 0.7.0
+      iconv-lite: 0.4.24
+      tmp: 0.0.33
+
   extract-files@11.0.0: {}
 
   facepaint@1.2.1: {}
@@ -10435,7 +11880,34 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fb-watchman@2.0.2:
+    dependencies:
+      bser: 2.1.1
+
+  fbjs-css-vars@1.0.2: {}
+
+  fbjs@3.0.5:
+    dependencies:
+      cross-fetch: 3.2.0
+      fbjs-css-vars: 1.0.2
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      promise: 7.3.1
+      setimmediate: 1.0.5
+      ua-parser-js: 1.0.40
+    transitivePeerDependencies:
+      - encoding
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   figures@2.0.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
+
+  figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
 
@@ -10529,6 +12001,10 @@ snapshots:
       es-set-tostringtag: 2.1.0
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
@@ -10569,6 +12045,8 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -10643,6 +12121,15 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
+
   globby@14.1.0:
     dependencies:
       '@sindresorhus/merge-streams': 2.3.0
@@ -10659,6 +12146,36 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  graphql-config@5.1.5(@types/node@22.15.29)(graphql@16.11.0)(typescript@5.8.3):
+    dependencies:
+      '@graphql-tools/graphql-file-loader': 8.0.20(graphql@16.11.0)
+      '@graphql-tools/json-file-loader': 8.0.18(graphql@16.11.0)
+      '@graphql-tools/load': 8.1.0(graphql@16.11.0)
+      '@graphql-tools/merge': 9.0.24(graphql@16.11.0)
+      '@graphql-tools/url-loader': 8.0.31(@types/node@22.15.29)(graphql@16.11.0)
+      '@graphql-tools/utils': 10.8.6(graphql@16.11.0)
+      cosmiconfig: 8.3.6(typescript@5.8.3)
+      graphql: 16.11.0
+      jiti: 2.4.2
+      minimatch: 9.0.5
+      string-env-interpolation: 1.0.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@fastify/websocket'
+      - '@types/node'
+      - bufferutil
+      - typescript
+      - uWebSockets.js
+      - utf-8-validate
+
+  graphql-request@6.1.0(graphql@16.11.0):
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.11.0)
+      cross-fetch: 3.2.0
+      graphql: 16.11.0
+    transitivePeerDependencies:
+      - encoding
 
   graphql-tag@2.12.6(graphql@16.11.0):
     dependencies:
@@ -10683,7 +12200,6 @@ snapshots:
       graphql: 16.11.0
     optionalDependencies:
       ws: 8.18.1
-    optional: true
 
   graphql@16.11.0: {}
 
@@ -10721,6 +12237,11 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  header-case@2.0.4:
+    dependencies:
+      capital-case: 1.0.4
+      tslib: 2.8.1
 
   highlight.js@10.7.3: {}
 
@@ -10788,6 +12309,8 @@ snapshots:
 
   immer@10.1.1: {}
 
+  immutable@3.7.6: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -10799,6 +12322,8 @@ snapshots:
       import-meta-resolve: 4.1.0
     transitivePeerDependencies:
       - supports-color
+
+  import-from@4.0.0: {}
 
   import-meta-resolve@4.1.0: {}
 
@@ -10816,6 +12341,24 @@ snapshots:
 
   ini@1.3.8: {}
 
+  inquirer@8.2.6:
+    dependencies:
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-width: 3.0.0
+      external-editor: 3.1.0
+      figures: 3.2.0
+      lodash: 4.17.21
+      mute-stream: 0.0.8
+      ora: 5.4.1
+      run-async: 2.4.1
+      rxjs: 7.8.2
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      through: 2.3.8
+      wrap-ansi: 6.2.0
+
   install@0.13.0: {}
 
   internal-slot@1.1.0:
@@ -10830,6 +12373,10 @@ snapshots:
     dependencies:
       from2: 2.3.0
       p-is-promise: 3.0.0
+
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
 
   ioredis@5.6.1:
     dependencies:
@@ -10846,6 +12393,11 @@ snapshots:
       - supports-color
 
   ipaddr.js@1.9.1: {}
+
+  is-absolute@1.0.0:
+    dependencies:
+      is-relative: 1.0.0
+      is-windows: 1.0.2
 
   is-alphabetical@1.0.4: {}
 
@@ -10932,6 +12484,12 @@ snapshots:
 
   is-hotkey@0.2.0: {}
 
+  is-interactive@1.0.0: {}
+
+  is-lower-case@2.0.2:
+    dependencies:
+      tslib: 2.8.1
+
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
@@ -10957,6 +12515,10 @@ snapshots:
       gopd: 1.2.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  is-relative@1.0.0:
+    dependencies:
+      is-unc-path: 1.0.0
 
   is-set@2.0.3: {}
 
@@ -10985,7 +12547,17 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.19
 
+  is-unc-path@1.0.0:
+    dependencies:
+      unc-path-regex: 0.1.2
+
+  is-unicode-supported@0.1.0: {}
+
   is-unicode-supported@2.1.0: {}
+
+  is-upper-case@2.0.2:
+    dependencies:
+      tslib: 2.8.1
 
   is-weakmap@2.0.2: {}
 
@@ -10998,11 +12570,17 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  is-windows@1.0.2: {}
+
   isarray@1.0.0: {}
 
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  isomorphic-ws@5.0.0(ws@8.18.1):
+    dependencies:
+      ws: 8.18.1
 
   issue-parser@7.0.1:
     dependencies:
@@ -11023,9 +12601,13 @@ snapshots:
 
   java-properties@1.0.2: {}
 
+  jiti@1.21.7: {}
+
   jiti@2.4.2: {}
 
   jose@4.15.9: {}
+
+  jose@5.10.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -11048,6 +12630,13 @@ snapshots:
   json-schema-typed@7.0.3: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-to-pretty-yaml@1.2.2:
+    dependencies:
+      remedial: 1.0.8
+      remove-trailing-spaces: 1.0.9
+
+  json5@2.2.3: {}
 
   jsonfile@6.1.0:
     dependencies:
@@ -11128,6 +12717,17 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  listr2@4.0.5:
+    dependencies:
+      cli-truncate: 2.1.0
+      colorette: 2.0.20
+      log-update: 4.0.0
+      p-map: 4.0.0
+      rfdc: 1.4.1
+      rxjs: 7.8.2
+      through: 2.3.8
+      wrap-ansi: 7.0.0
+
   load-json-file@4.0.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -11189,6 +12789,18 @@ snapshots:
 
   lodash@4.17.21: {}
 
+  log-symbols@4.1.0:
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
+
+  log-update@4.0.0:
+    dependencies:
+      ansi-escapes: 4.3.2
+      cli-cursor: 3.1.0
+      slice-ansi: 4.0.0
+      wrap-ansi: 6.2.0
+
   loglevel@1.9.2: {}
 
   long@4.0.0: {}
@@ -11201,7 +12813,19 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lower-case-first@2.0.2:
+    dependencies:
+      tslib: 2.8.1
+
+  lower-case@2.0.2:
+    dependencies:
+      tslib: 2.8.1
+
   lru-cache@10.4.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   lru-cache@6.0.0:
     dependencies:
@@ -11214,6 +12838,8 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  map-cache@0.2.2: {}
 
   map-obj@1.0.1: {}
 
@@ -11440,6 +13066,10 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  meros@1.3.0(@types/node@22.15.29):
+    optionalDependencies:
+      '@types/node': 22.15.29
 
   methods@1.1.2: {}
 
@@ -11747,6 +13377,8 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.3
 
+  mute-stream@0.0.8: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -11769,13 +13401,13 @@ snapshots:
 
   nerf-dart@1.0.0: {}
 
-  next-auth@4.24.11(next@14.2.29(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-auth@4.24.11(next@14.2.29(@babel/core@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.27.4
       '@panva/hkdf': 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 14.2.29(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.29(@babel/core@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.26.8
@@ -11784,7 +13416,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       uuid: 8.3.2
 
-  next@14.2.29(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.29(@babel/core@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.29
       '@swc/helpers': 0.5.5
@@ -11794,7 +13426,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(react@18.3.1)
+      styled-jsx: 5.1.1(@babel/core@7.27.4)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.29
       '@next/swc-darwin-x64': 14.2.29
@@ -11809,7 +13441,14 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  no-case@3.0.4:
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.8.1
+
   node-abort-controller@3.1.1: {}
+
+  node-domexception@1.0.0: {}
 
   node-emoji@2.2.0:
     dependencies:
@@ -11822,10 +13461,20 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
       detect-libc: 2.0.4
     optional: true
+
+  node-int64@0.4.0: {}
+
+  node-releases@2.0.19: {}
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -11847,6 +13496,10 @@ snapshots:
       semver: 7.7.2
       validate-npm-package-license: 3.0.4
 
+  normalize-path@2.1.1:
+    dependencies:
+      remove-trailing-separator: 1.1.0
+
   normalize-url@8.0.2: {}
 
   npm-run-path@4.0.1:
@@ -11863,6 +13516,8 @@ snapshots:
       unicorn-magic: 0.3.0
 
   npm@10.9.2: {}
+
+  nullthrows@1.1.1: {}
 
   oauth@0.9.15: {}
 
@@ -11947,7 +13602,21 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  ora@5.4.1:
+    dependencies:
+      bl: 4.1.0
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-spinners: 2.9.2
+      is-interactive: 1.0.0
+      is-unicode-supported: 0.1.0
+      log-symbols: 4.1.0
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
+
   orderedmap@2.1.1: {}
+
+  os-tmpdir@1.0.2: {}
 
   own-keys@1.0.1:
     dependencies:
@@ -11991,6 +13660,10 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  p-map@4.0.0:
+    dependencies:
+      aggregate-error: 3.1.0
+
   p-map@7.0.3: {}
 
   p-reduce@2.1.0: {}
@@ -12002,6 +13675,11 @@ snapshots:
   p-try@2.2.0: {}
 
   package-manager-detector@1.3.0: {}
+
+  param-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.8.1
 
   parent-module@1.0.1:
     dependencies:
@@ -12025,6 +13703,12 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+
+  parse-filepath@1.0.2:
+    dependencies:
+      is-absolute: 1.0.0
+      map-cache: 0.2.2
+      path-root: 0.1.1
 
   parse-json@4.0.0:
     dependencies:
@@ -12056,6 +13740,11 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  pascal-case@3.1.2:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
+
   passport-strategy@1.0.0: {}
 
   passport@0.7.0:
@@ -12063,6 +13752,11 @@ snapshots:
       passport-strategy: 1.0.0
       pause: 0.0.1
       utils-merge: 1.0.1
+
+  path-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.8.1
 
   path-exists@3.0.0: {}
 
@@ -12073,6 +13767,12 @@ snapshots:
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
+
+  path-root-regex@0.1.2: {}
+
+  path-root@0.1.1:
+    dependencies:
+      path-root-regex: 0.1.2
 
   path-to-regexp@0.1.12: {}
 
@@ -12186,6 +13886,10 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   process-warning@5.0.0: {}
+
+  promise@7.3.1:
+    dependencies:
+      asap: 2.0.6
 
   prompts@2.4.2:
     dependencies:
@@ -12529,6 +14233,14 @@ snapshots:
       '@types/react': 18.3.23
       react: 18.3.1
 
+  relay-runtime@12.0.0:
+    dependencies:
+      '@babel/runtime': 7.27.4
+      fbjs: 3.0.5
+      invariant: 2.2.4
+    transitivePeerDependencies:
+      - encoding
+
   remark-directive@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -12588,7 +14300,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  remedial@1.0.8: {}
+
   remove-accents@0.5.0: {}
+
+  remove-trailing-separator@1.1.0: {}
+
+  remove-trailing-spaces@1.0.9: {}
 
   repeat-string@1.6.1: {}
 
@@ -12614,15 +14332,28 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  restore-cursor@3.1.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+
   retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
+  rfdc@1.4.1: {}
+
   rope-sequence@1.3.4: {}
+
+  run-async@2.4.1: {}
 
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -12658,6 +14389,8 @@ snapshots:
   scroll-into-view-if-needed@3.1.0:
     dependencies:
       compute-scroll-into-view: 3.1.1
+
+  scuid@1.1.0: {}
 
   semantic-release@24.2.5(typescript@5.8.3):
     dependencies:
@@ -12724,6 +14457,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  sentence-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
+      upper-case-first: 2.0.2
+
   serve-static@1.16.2:
     dependencies:
       encodeurl: 2.0.0
@@ -12755,6 +14494,8 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
+  setimmediate@1.0.5: {}
+
   setprototypeof@1.2.0: {}
 
   sha.js@2.4.11:
@@ -12767,6 +14508,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.3: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -12806,11 +14549,15 @@ snapshots:
       figures: 2.0.0
       pkg-conf: 2.1.0
 
+  signedsource@1.0.0: {}
+
   sisteransi@1.0.5: {}
 
   skin-tone@2.0.0:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
+
+  slash@3.0.0: {}
 
   slash@5.1.0: {}
 
@@ -12850,6 +14597,23 @@ snapshots:
       is-plain-object: 5.0.0
       tiny-warning: 1.0.3
 
+  slice-ansi@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
+  snake-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.8.1
+
   sonic-boom@4.2.0:
     dependencies:
       atomic-sleep: 1.0.0
@@ -12882,6 +14646,10 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sponge-case@1.0.1:
+    dependencies:
+      tslib: 2.8.1
+
   standard-as-callback@2.1.0: {}
 
   statuses@2.0.1: {}
@@ -12902,6 +14670,8 @@ snapshots:
       readable-stream: 2.3.8
 
   streamsearch@1.1.0: {}
+
+  string-env-interpolation@1.0.1: {}
 
   string-width@4.2.3:
     dependencies:
@@ -12995,10 +14765,12 @@ snapshots:
 
   style-mod@4.1.2: {}
 
-  styled-jsx@5.1.1(react@18.3.1):
+  styled-jsx@5.1.1(@babel/core@7.27.4)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
+    optionalDependencies:
+      '@babel/core': 7.27.4
 
   stylis@4.2.0: {}
 
@@ -13022,7 +14794,17 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swap-case@2.0.2:
+    dependencies:
+      tslib: 2.8.1
+
   symbol-observable@4.0.0: {}
+
+  sync-fetch@0.6.0-2:
+    dependencies:
+      node-fetch: 3.3.2
+      timeout-signal: 2.0.0
+      whatwg-mimetype: 4.0.0
 
   tabbable@6.2.0: {}
 
@@ -13065,15 +14847,27 @@ snapshots:
       readable-stream: 2.3.8
       xtend: 4.0.2
 
+  through@2.3.8: {}
+
   time-span@5.1.0:
     dependencies:
       convert-hrtime: 5.0.0
+
+  timeout-signal@2.0.0: {}
 
   tiny-invariant@1.3.1: {}
 
   tiny-warning@1.0.3: {}
 
   tinyexec@1.0.1: {}
+
+  title-case@3.0.3:
+    dependencies:
+      tslib: 2.8.1
+
+  tmp@0.0.33:
+    dependencies:
+      os-tmpdir: 1.0.2
 
   to-regex-range@5.0.1:
     dependencies:
@@ -13101,6 +14895,10 @@ snapshots:
   ts-invariant@0.10.3:
     dependencies:
       tslib: 2.8.1
+
+  ts-log@2.2.7: {}
+
+  tslib@2.6.3: {}
 
   tslib@2.8.1: {}
 
@@ -13143,6 +14941,8 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@0.18.1: {}
+
+  type-fest@0.21.3: {}
 
   type-fest@0.6.0: {}
 
@@ -13213,6 +15013,8 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  ua-parser-js@1.0.40: {}
+
   ufo@1.6.1: {}
 
   uglify-js@3.19.3:
@@ -13230,6 +15032,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  unc-path-regex@0.1.2: {}
 
   undici-types@6.21.0: {}
 
@@ -13292,13 +15096,33 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unixify@1.0.0:
+    dependencies:
+      normalize-path: 2.1.1
+
   unpipe@1.0.0: {}
+
+  update-browserslist-db@1.1.3(browserslist@4.25.0):
+    dependencies:
+      browserslist: 4.25.0
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  upper-case-first@2.0.2:
+    dependencies:
+      tslib: 2.8.1
+
+  upper-case@2.0.2:
+    dependencies:
+      tslib: 2.8.1
 
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
   url-join@5.0.0: {}
+
+  urlpattern-polyfill@10.1.0: {}
 
   use-callback-ref@1.3.3(@types/react@18.3.23)(react@18.3.1):
     dependencies:
@@ -13372,9 +15196,17 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  wcwidth@1.0.1:
+    dependencies:
+      defaults: 1.0.4
+
+  web-streams-polyfill@3.3.3: {}
+
   webidl-conversions@3.0.1: {}
 
   whatwg-mimetype@3.0.0: {}
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-url@5.0.0:
     dependencies:
@@ -13430,24 +15262,35 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  ws@8.18.1:
-    optional: true
+  ws@8.18.1: {}
 
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 
+  yallist@3.1.1: {}
+
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
 
+  yaml-ast-parser@0.0.43: {}
+
   yaml@1.10.2: {}
+
+  yaml@2.8.0: {}
 
   yargs-parser@20.2.9: {}
 


### PR DESCRIPTION
This pull request introduces GraphQL Code Generator (`graphql-codegen`) into the CMS application, along with updates to improve type safety and query handling. The most significant changes include adding configuration for `graphql-codegen`, updating GraphQL queries to use typed document nodes, and enhancing type safety across the codebase. 

### GraphQL Code Generator Integration:

* Added a new `codegen.ts` file with configuration for `graphql-codegen`, specifying schema, documents, and generation options. (`apps/cms/codegen.ts`)
* Updated `package.json` to include scripts for running `graphql-codegen` (`codegen` and `codegen:watch`) and added `@graphql-codegen/cli` as a `devDependency`. (`apps/cms/package.json`) [[1]](diffhunk://#diff-106448d98b53c44a4b5dd255af113298b7abe825e5dac3b89d4c45f96ad23c89L22-R24) [[2]](diffhunk://#diff-106448d98b53c44a4b5dd255af113298b7abe825e5dac3b89d4c45f96ad23c89R66)

### Query Refactoring with Typed Document Nodes:

* Replaced inline GraphQL queries with `TypedDocumentNode` for better type safety in multiple components, including `DocCollectionView`, `DocCollectionSearchView`, `InternalLinkTooltip`, and related hooks. (`apps/cms/src/components/...`) [[1]](diffhunk://#diff-e770fdfb9f110cb78312de72ca61e273269ca6707c99bdabb039f39d024ef9c5L20-R37) [[2]](diffhunk://#diff-694acbf2c093996627d4a7d20f9cd03a7044c552fa63cc9e4f424dd0e830375bL3-R19) [[3]](diffhunk://#diff-41c7cd3fa5b0ab654180026b392389e21b8610fd92691a64766d883a94b09b06L13-R22) [[4]](diffhunk://#diff-27bdc5d4fcf1fefed553455668129cabbc4d76d79dfc0186c701755709e1ef84L17-R29) [[5]](diffhunk://#diff-78d475b90ce3609f633611854aa633bfbafe7137f69082e3b023f11d13d5a7b9L1-R15)
* Updated query variables and responses to use generated types, such as `GetServicesQuery`, `DocumentCollectionsQuery`, and `LinkSearchQuery`. [[1]](diffhunk://#diff-e770fdfb9f110cb78312de72ca61e273269ca6707c99bdabb039f39d024ef9c5L37-R76) [[2]](diffhunk://#diff-694acbf2c093996627d4a7d20f9cd03a7044c552fa63cc9e4f424dd0e830375bL25-R43) [[3]](diffhunk://#diff-41c7cd3fa5b0ab654180026b392389e21b8610fd92691a64766d883a94b09b06L27-R71) [[4]](diffhunk://#diff-27bdc5d4fcf1fefed553455668129cabbc4d76d79dfc0186c701755709e1ef84L31-R43)

### Type Safety Enhancements:

* Added null-safe navigation for optional fields in components like `DocCollectionView` and `InternalLinkTooltip`. (`apps/cms/src/components/...`) [[1]](diffhunk://#diff-694acbf2c093996627d4a7d20f9cd03a7044c552fa63cc9e4f424dd0e830375bL46-R62) [[2]](diffhunk://#diff-27bdc5d4fcf1fefed553455668129cabbc4d76d79dfc0186c701755709e1ef84L242-R258)
* Introduced utility functions for fragment handling in a new `fragment-masking.ts` file to support `graphql-codegen` features. (`apps/cms/src/graphql/fragment-masking.ts`)

### Miscellaneous:

* Updated `.vscode/settings.json` to include `Codegen` in the spell-check dictionary. (`.vscode/settings.json`)