### PR TITLE
Fix/broken create pages

### DIFF
--- a/apps/cms/apollo.config.json
+++ b/apps/cms/apollo.config.json
@@ -2,6 +2,13 @@
   "client": {
     "service": {
       "localSchemaFile": "./schema.graphql"
-    }
+    },
+    "excludes": [
+      "**/node_modules",
+      "**/dist",
+      "**/build",
+      "**/graphql/**/*.ts",
+      "**/__tests__"
+    ]
   }
 }

--- a/apps/cms/src/app/DraftAndVersionsFactory.ts
+++ b/apps/cms/src/app/DraftAndVersionsFactory.ts
@@ -99,6 +99,9 @@ export function DraftAndVersionsFactory<TFields extends BaseFields<any>>(
           ui: {
             query,
             listName: listKey,
+            createView: {
+              fieldMode: 'hidden',
+            },
           },
         }),
 

--- a/apps/cms/src/app/fieldUtils.ts
+++ b/apps/cms/src/app/fieldUtils.ts
@@ -420,7 +420,7 @@ export function basePage(
     owner,
     body: customText(opts?.customTextOpts),
     tags: tags(listNamePlural),
-    userGroups: userGroups(listNamePlural),
+    userGroups: userGroups(),
 
     ...(opts?.primaryAction && {
       primaryAction: relationship({

--- a/apps/cms/src/components/customFields/drafts/views.tsx
+++ b/apps/cms/src/components/customFields/drafts/views.tsx
@@ -1,5 +1,10 @@
 'use client';
-import { gql, useMutation, useQuery } from '@keystone-6/core/admin-ui/apollo';
+import {
+  // Telling apollo and codegen to ignore the gql tag so it won't try to parse it since we're using a dynamic query
+  gql as ignoreGql,
+  useMutation,
+  useQuery,
+} from '@keystone-6/core/admin-ui/apollo';
 import { CellContainer, CellLink } from '@keystone-6/core/admin-ui/components';
 import {
   CellComponent,
@@ -26,7 +31,7 @@ export function Field({ field, value }: FieldProps<typeof controller>) {
   const listName = singular(router.pathname.split('/')[1]) + '-drafts';
 
   const { data, loading, error } = useQuery(
-    gql`
+    ignoreGql`
       query ${field.listName} ($where: ${field.listName}WhereUniqueInput!) {
         ${listKey}(where: $where) {
           ${field.query}
@@ -42,7 +47,7 @@ export function Field({ field, value }: FieldProps<typeof controller>) {
     },
   );
 
-  const [createDraft, { loading: creating }] = useMutation(gql`
+  const [createDraft, { loading: creating }] = useMutation(ignoreGql`
     mutation Create${field.listName}Draft($data: ${field.listName}DraftCreateInput!) {
       create${field.listName}Draft(data: $data) {
         id

--- a/apps/cms/src/components/customFields/liveUrl/views.tsx
+++ b/apps/cms/src/components/customFields/liveUrl/views.tsx
@@ -17,17 +17,18 @@ import { ComponentProps } from 'react';
 type LiveUrlValue = string;
 
 export function Field({ field, value }: FieldProps<typeof controller>) {
-  return (
-    <FieldContainer>
-      <FieldLabel>{field.label}</FieldLabel>
-      <FieldDescription id={`${field.path}-description`}>
-        {field.description}
-      </FieldDescription>
-      <Link href={value} target="_blank">
-        {value}
-      </Link>
-    </FieldContainer>
-  );
+  if (value?.length && typeof value === 'string')
+    return (
+      <FieldContainer>
+        <FieldLabel>{field.label}</FieldLabel>
+        <FieldDescription id={`${field.path}-description`}>
+          {field.description}
+        </FieldDescription>
+        <Link href={value} target="_blank">
+          {value}
+        </Link>
+      </FieldContainer>
+    );
 }
 
 export const Cell: CellComponent = ({

--- a/apps/cms/src/components/customFields/polymorphicRelationship/views.tsx
+++ b/apps/cms/src/components/customFields/polymorphicRelationship/views.tsx
@@ -17,7 +17,8 @@ import {
   FieldDescription,
   Select,
 } from '@keystone-ui/fields';
-import { gql, useQuery } from '@keystone-6/core/admin-ui/apollo';
+// Telling apollo and codegen to ignore the gql tag so it won't try to parse it since we're using a dynamic query
+import { gql as ignoreGql, useQuery } from '@keystone-6/core/admin-ui/apollo';
 import { CreateItemDrawer } from '@keystone-6/core/admin-ui/components';
 import { DrawerController } from '@keystone-ui/modals';
 
@@ -42,7 +43,7 @@ export function Field({
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   const { data, refetch, error } = useQuery(
-    gql`
+    ignoreGql`
       query Get${v.capitalize(plural)}($where: ${value?.itemType?.label ? v.capitalize(v.camelCase(value.itemType.label)) : ''}WhereInput!) {
         ${plural}(where: $where) {
           title


### PR DESCRIPTION
This pull request introduces several updates to the CMS application, focusing on improving query handling, dynamic query parsing, and UI enhancements. The most significant changes include adding file exclusions to the Apollo configuration, introducing dynamic query handling with `ignoreGql`, and updating UI logic for draft and polymorphic relationship fields.

### Apollo Configuration Updates:
* [`apps/cms/apollo.config.json`](diffhunk://#diff-f6d20860d68374cf09caece37e85f93f45f8af197c30af86ce8a40a93dc2a6f4L5-R12): Added an `excludes` array to the Apollo configuration to ignore specific directories (`node_modules`, `dist`, `build`, etc.) during schema generation.

### Dynamic Query Handling:
* `apps/cms/src/components/customFields/drafts/views.tsx` and `apps/cms/src/components/customFields/polymorphicRelationship/views.tsx`: Replaced `gql` with `ignoreGql` in dynamic queries to prevent Apollo and codegen from attempting to parse them. This ensures compatibility with dynamically constructed queries. [[1]](diffhunk://#diff-9761a822657a4e8b37e3ec3231f6886d887be6835ca1574933aa59716aee0c38L2-R7) [[2]](diffhunk://#diff-bf2e8c34b38f9f617f59760f834484d9f665829189662cf4d8cce47710472b81L20-R21) [[3]](diffhunk://#diff-bf2e8c34b38f9f617f59760f834484d9f665829189662cf4d8cce47710472b81L45-R46)

### UI Enhancements for Drafts:
* [`apps/cms/src/components/customFields/drafts/views.tsx`](diffhunk://#diff-9761a822657a4e8b37e3ec3231f6886d887be6835ca1574933aa59716aee0c38R33-R35): Updated the logic to conditionally display draft-related actions (e.g., "Create a new Draft" button and "View Existing Drafts" link) only when the required values (`id` and `listName`) are valid strings. [[1]](diffhunk://#diff-9761a822657a4e8b37e3ec3231f6886d887be6835ca1574933aa59716aee0c38R33-R35) [[2]](diffhunk://#diff-9761a822657a4e8b37e3ec3231f6886d887be6835ca1574933aa59716aee0c38L77-R85)

### Other UI Updates:
* [`apps/cms/src/app/DraftAndVersionsFactory.ts`](diffhunk://#diff-455709121fa3de77a3a8aec439fd10e00893ba9ee1d4d6037a02908a19cfa8c0R102-R104): Added a `createView` configuration to hide certain fields in the UI for draft creation.
* [`apps/cms/src/app/fieldUtils.ts`](diffhunk://#diff-b3154a531adf10e42c506c5993b5288373ccf4ca7af569930dd7e36c60b639c4L423-R423): Simplified the `userGroups` function call by removing the `listNamePlural` argument.

### Minor Fixes:
* [`apps/cms/src/components/customFields/liveUrl/views.tsx`](diffhunk://#diff-6293226e9ba15a5e5beb5dda1d51bda90f814e50006b0c60601a6a97e2e48210R20): Added a type check to ensure `value` is a string before rendering the live URL field.