### PR TITLE
Fix/cors0 errors

### DIFF
--- a/apps/cms/keystone.ts
+++ b/apps/cms/keystone.ts
@@ -47,7 +47,7 @@ export default config<TypeInfo<Session>>({
           : [
               'http://localhost:3000',
               'http://localhost:3001',
-              'https://localhost:3333',
+              'http://localhost:3333',
             ],
       credentials: true,
       methods: ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS', 'PATCH'],

--- a/apps/cms/keystone.ts
+++ b/apps/cms/keystone.ts
@@ -35,7 +35,20 @@ export default config<TypeInfo<Session>>({
   // https://keystonejs.com/docs/config/config#server
   server: {
     cors: {
-      origin: ['*'],
+      origin:
+        appConfig.nodeEnv === 'production'
+          ? [
+              'https://matsu.gov',
+              'https://www.matsu.gov',
+              'https://widgets.matsu.gov',
+              'https://cms.matsu.gov',
+              'https://cms-internal.matsu.gov',
+            ]
+          : [
+              'http://localhost:3000',
+              'http://localhost:3001',
+              'https://localhost:3333',
+            ],,
       credentials: true,
       methods: ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS', 'PATCH'],
     },

--- a/apps/cms/keystone.ts
+++ b/apps/cms/keystone.ts
@@ -48,7 +48,7 @@ export default config<TypeInfo<Session>>({
               'http://localhost:3000',
               'http://localhost:3001',
               'https://localhost:3333',
-            ],,
+            ],
       credentials: true,
       methods: ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS', 'PATCH'],
     },


### PR DESCRIPTION
This pull request updates the CORS configuration in `apps/cms/keystone.ts` to restrict allowed origins based on the environment (`production` vs. `development`).

CORS configuration changes:

* Updated the `origin` property in the `server.cors` configuration to dynamically allow specific URLs based on the `nodeEnv` value. In production, only government-related domains are permitted, while in development, localhost URLs are allowed.