### PR TITLE
feat: added calendar id and calendar query to board ct

### DIFF
--- a/apps/cms/migrations/20250728181002_add_calendar_id_and_calendar_query_string_to_board_ct/migration.sql
+++ b/apps/cms/migrations/20250728181002_add_calendar_id_and_calendar_query_string_to_board_ct/migration.sql
@@ -1,0 +1,22 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `meetingSchedule` on the `Board` table. All the data in the column will be lost.
+  - You are about to drop the column `meetingSchedule` on the `BoardDraft` table. All the data in the column will be lost.
+  - You are about to drop the column `meetingSchedule` on the `BoardVersion` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Board" DROP COLUMN "meetingSchedule",
+ADD COLUMN     "calendarId" TEXT NOT NULL DEFAULT '',
+ADD COLUMN     "calendarQueryString" TEXT NOT NULL DEFAULT '';
+
+-- AlterTable
+ALTER TABLE "BoardDraft" DROP COLUMN "meetingSchedule",
+ADD COLUMN     "calendarId" TEXT NOT NULL DEFAULT '',
+ADD COLUMN     "calendarQueryString" TEXT NOT NULL DEFAULT '';
+
+-- AlterTable
+ALTER TABLE "BoardVersion" DROP COLUMN "meetingSchedule",
+ADD COLUMN     "calendarId" TEXT NOT NULL DEFAULT '',
+ADD COLUMN     "calendarQueryString" TEXT NOT NULL DEFAULT '';

--- a/apps/cms/schema.graphql
+++ b/apps/cms/schema.graphql
@@ -959,7 +959,8 @@ type Board implements BasePage & BasePageWithSlug {
   createdAt: DateTime
   updatedAt: DateTime
   directory: Document
-  meetingSchedule: String
+  calendarId: String
+  calendarQueryString: String
   linkToAgendas: ExternalLink
   linkToResolutions: ExternalLink
   linkToPublicOpinionMessage: ExternalLink
@@ -1008,7 +1009,8 @@ input BoardWhereInput {
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
   directory: DocumentWhereInput
-  meetingSchedule: StringFilter
+  calendarId: StringFilter
+  calendarQueryString: StringFilter
   linkToAgendas: ExternalLinkWhereInput
   linkToResolutions: ExternalLinkWhereInput
   linkToPublicOpinionMessage: ExternalLinkWhereInput
@@ -1064,7 +1066,8 @@ input BoardOrderByInput {
   body: MyOrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
-  meetingSchedule: OrderDirection
+  calendarId: OrderDirection
+  calendarQueryString: OrderDirection
   type: OrderDirection
   isActive: OrderDirection
   status: OrderDirection
@@ -1089,7 +1092,8 @@ input BoardUpdateInput {
   createdAt: DateTime
   updatedAt: DateTime
   directory: DocumentRelateToOneForUpdateInput
-  meetingSchedule: String
+  calendarId: String
+  calendarQueryString: String
   linkToAgendas: ExternalLinkRelateToOneForUpdateInput
   linkToResolutions: ExternalLinkRelateToOneForUpdateInput
   linkToPublicOpinionMessage: ExternalLinkRelateToOneForUpdateInput
@@ -1174,7 +1178,8 @@ input BoardCreateInput {
   createdAt: DateTime
   updatedAt: DateTime
   directory: DocumentRelateToOneForCreateInput
-  meetingSchedule: String
+  calendarId: String
+  calendarQueryString: String
   linkToAgendas: ExternalLinkRelateToOneForCreateInput
   linkToResolutions: ExternalLinkRelateToOneForCreateInput
   linkToPublicOpinionMessage: ExternalLinkRelateToOneForCreateInput
@@ -1250,7 +1255,8 @@ type BoardDraft {
   createdAt: DateTime
   updatedAt: DateTime
   directory: Document
-  meetingSchedule: String
+  calendarId: String
+  calendarQueryString: String
   linkToAgendas: ExternalLink
   linkToResolutions: ExternalLink
   linkToPublicOpinionMessage: ExternalLink
@@ -1290,7 +1296,8 @@ input BoardDraftWhereInput {
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
   directory: DocumentWhereInput
-  meetingSchedule: StringFilter
+  calendarId: StringFilter
+  calendarQueryString: StringFilter
   linkToAgendas: ExternalLinkWhereInput
   linkToResolutions: ExternalLinkWhereInput
   linkToPublicOpinionMessage: ExternalLinkWhereInput
@@ -1312,7 +1319,8 @@ input BoardDraftOrderByInput {
   body: MyOrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
-  meetingSchedule: OrderDirection
+  calendarId: OrderDirection
+  calendarQueryString: OrderDirection
   type: OrderDirection
   isActive: OrderDirection
   publish: OrderDirection
@@ -1336,7 +1344,8 @@ input BoardDraftUpdateInput {
   createdAt: DateTime
   updatedAt: DateTime
   directory: DocumentRelateToOneForUpdateInput
-  meetingSchedule: String
+  calendarId: String
+  calendarQueryString: String
   linkToAgendas: ExternalLinkRelateToOneForUpdateInput
   linkToResolutions: ExternalLinkRelateToOneForUpdateInput
   linkToPublicOpinionMessage: ExternalLinkRelateToOneForUpdateInput
@@ -1377,7 +1386,8 @@ input BoardDraftCreateInput {
   createdAt: DateTime
   updatedAt: DateTime
   directory: DocumentRelateToOneForCreateInput
-  meetingSchedule: String
+  calendarId: String
+  calendarQueryString: String
   linkToAgendas: ExternalLinkRelateToOneForCreateInput
   linkToResolutions: ExternalLinkRelateToOneForCreateInput
   linkToPublicOpinionMessage: ExternalLinkRelateToOneForCreateInput
@@ -1419,7 +1429,8 @@ type BoardVersion {
   createdAt: DateTime
   updatedAt: DateTime
   directory: Document
-  meetingSchedule: String
+  calendarId: String
+  calendarQueryString: String
   linkToAgendas: ExternalLink
   linkToResolutions: ExternalLink
   linkToPublicOpinionMessage: ExternalLink
@@ -1461,7 +1472,8 @@ input BoardVersionWhereInput {
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
   directory: DocumentWhereInput
-  meetingSchedule: StringFilter
+  calendarId: StringFilter
+  calendarQueryString: StringFilter
   linkToAgendas: ExternalLinkWhereInput
   linkToResolutions: ExternalLinkWhereInput
   linkToPublicOpinionMessage: ExternalLinkWhereInput
@@ -1484,7 +1496,8 @@ input BoardVersionOrderByInput {
   body: MyOrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
-  meetingSchedule: OrderDirection
+  calendarId: OrderDirection
+  calendarQueryString: OrderDirection
   type: OrderDirection
   isActive: OrderDirection
   republish: OrderDirection
@@ -1508,7 +1521,8 @@ input BoardVersionUpdateInput {
   createdAt: DateTime
   updatedAt: DateTime
   directory: DocumentRelateToOneForUpdateInput
-  meetingSchedule: String
+  calendarId: String
+  calendarQueryString: String
   linkToAgendas: ExternalLinkRelateToOneForUpdateInput
   linkToResolutions: ExternalLinkRelateToOneForUpdateInput
   linkToPublicOpinionMessage: ExternalLinkRelateToOneForUpdateInput
@@ -1544,7 +1558,8 @@ input BoardVersionCreateInput {
   createdAt: DateTime
   updatedAt: DateTime
   directory: DocumentRelateToOneForCreateInput
-  meetingSchedule: String
+  calendarId: String
+  calendarQueryString: String
   linkToAgendas: ExternalLinkRelateToOneForCreateInput
   linkToResolutions: ExternalLinkRelateToOneForCreateInput
   linkToPublicOpinionMessage: ExternalLinkRelateToOneForCreateInput

--- a/apps/cms/schema.prisma
+++ b/apps/cms/schema.prisma
@@ -180,7 +180,8 @@ model Board {
   updatedAt                           DateTime?                 @default(now()) @updatedAt
   directory                           Document?                 @relation("Board_directory", fields: [directoryId], references: [id])
   directoryId                         String?                   @map("directory")
-  meetingSchedule                     String                    @default("")
+  calendarId                          String                    @default("")
+  calendarQueryString                 String                    @default("")
   linkToAgendas                       ExternalLink?             @relation("Board_linkToAgendas", fields: [linkToAgendasId], references: [id])
   linkToAgendasId                     String?                   @map("linkToAgendas")
   linkToResolutions                   ExternalLink?             @relation("Board_linkToResolutions", fields: [linkToResolutionsId], references: [id])
@@ -237,7 +238,8 @@ model BoardDraft {
   updatedAt                    DateTime?          @default(now()) @updatedAt
   directory                    Document?          @relation("BoardDraft_directory", fields: [directoryId], references: [id])
   directoryId                  String?            @map("directory")
-  meetingSchedule              String             @default("")
+  calendarId                   String             @default("")
+  calendarQueryString          String             @default("")
   linkToAgendas                ExternalLink?      @relation("BoardDraft_linkToAgendas", fields: [linkToAgendasId], references: [id])
   linkToAgendasId              String?            @map("linkToAgendas")
   linkToResolutions            ExternalLink?      @relation("BoardDraft_linkToResolutions", fields: [linkToResolutionsId], references: [id])
@@ -281,7 +283,8 @@ model BoardVersion {
   updatedAt                    DateTime?          @default(now()) @updatedAt
   directory                    Document?          @relation("BoardVersion_directory", fields: [directoryId], references: [id])
   directoryId                  String?            @map("directory")
-  meetingSchedule              String             @default("")
+  calendarId                   String             @default("")
+  calendarQueryString          String             @default("")
   linkToAgendas                ExternalLink?      @relation("BoardVersion_linkToAgendas", fields: [linkToAgendasId], references: [id])
   linkToAgendasId              String?            @map("linkToAgendas")
   linkToResolutions            ExternalLink?      @relation("BoardVersion_linkToResolutions", fields: [linkToResolutionsId], references: [id])

--- a/apps/cms/src/app/models/Board.ts
+++ b/apps/cms/src/app/models/Board.ts
@@ -41,7 +41,8 @@ export const {
         },
       }),
 
-      meetingSchedule: text(),
+      calendarId: text(),
+      calendarQueryString: text(),
 
       linkToAgendas: relationship({
         ref: 'ExternalLink',


### PR DESCRIPTION
This pull request introduces significant changes to the `Board`, `BoardDraft`, and `BoardVersion` entities across multiple files in the CMS application. The primary update involves replacing the `meetingSchedule` field with two new fields: `calendarId` and `calendarQueryString`. These changes impact database migrations, GraphQL schema definitions, Prisma models, and TypeScript models.

### Database Migration Changes:
* [`apps/cms/migrations/20250728181002_add_calendar_id_and_calendar_query_string_to_board_ct/migration.sql`](diffhunk://#diff-8820998bf9f09cad5345c24ad3b91c86333e7a8658b591e28202388862accbc3R1-R22): Dropped the `meetingSchedule` column and added `calendarId` and `calendarQueryString` columns to the `Board`, `BoardDraft`, and `BoardVersion` tables. Both new columns are non-nullable and default to empty strings.

### GraphQL Schema Updates:
* [`apps/cms/schema.graphql`](diffhunk://#diff-52ce3d3de74ce21d0621817bcd5701d9145cd13a12d13065d9dd1403f241293fL962-R963): Updated fields in the `Board`, `BoardDraft`, and `BoardVersion` types, as well as their corresponding input types (`BoardWhereInput`, `BoardOrderByInput`, `BoardUpdateInput`, `BoardCreateInput`, etc.), to replace `meetingSchedule` with `calendarId` and `calendarQueryString`. [[1]](diffhunk://#diff-52ce3d3de74ce21d0621817bcd5701d9145cd13a12d13065d9dd1403f241293fL962-R963) [[2]](diffhunk://#diff-52ce3d3de74ce21d0621817bcd5701d9145cd13a12d13065d9dd1403f241293fL1011-R1013) [[3]](diffhunk://#diff-52ce3d3de74ce21d0621817bcd5701d9145cd13a12d13065d9dd1403f241293fL1067-R1070) [[4]](diffhunk://#diff-52ce3d3de74ce21d0621817bcd5701d9145cd13a12d13065d9dd1403f241293fL1092-R1096) [[5]](diffhunk://#diff-52ce3d3de74ce21d0621817bcd5701d9145cd13a12d13065d9dd1403f241293fL1177-R1182) [[6]](diffhunk://#diff-52ce3d3de74ce21d0621817bcd5701d9145cd13a12d13065d9dd1403f241293fL1253-R1259) [[7]](diffhunk://#diff-52ce3d3de74ce21d0621817bcd5701d9145cd13a12d13065d9dd1403f241293fL1293-R1300) [[8]](diffhunk://#diff-52ce3d3de74ce21d0621817bcd5701d9145cd13a12d13065d9dd1403f241293fL1315-R1323) [[9]](diffhunk://#diff-52ce3d3de74ce21d0621817bcd5701d9145cd13a12d13065d9dd1403f241293fL1339-R1348) [[10]](diffhunk://#diff-52ce3d3de74ce21d0621817bcd5701d9145cd13a12d13065d9dd1403f241293fL1380-R1390) [[11]](diffhunk://#diff-52ce3d3de74ce21d0621817bcd5701d9145cd13a12d13065d9dd1403f241293fL1422-R1433) [[12]](diffhunk://#diff-52ce3d3de74ce21d0621817bcd5701d9145cd13a12d13065d9dd1403f241293fL1464-R1476) [[13]](diffhunk://#diff-52ce3d3de74ce21d0621817bcd5701d9145cd13a12d13065d9dd1403f241293fL1487-R1500) [[14]](diffhunk://#diff-52ce3d3de74ce21d0621817bcd5701d9145cd13a12d13065d9dd1403f241293fL1511-R1525) [[15]](diffhunk://#diff-52ce3d3de74ce21d0621817bcd5701d9145cd13a12d13065d9dd1403f241293fL1547-R1562)

### Prisma Model Adjustments:
* [`apps/cms/schema.prisma`](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5L183-R184): Modified the `Board`, `BoardDraft`, and `BoardVersion` models by replacing the `meetingSchedule` field with `calendarId` and `calendarQueryString`. Both new fields have default values set to empty strings. [[1]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5L183-R184) [[2]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5L240-R242) [[3]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5L284-R287)

### TypeScript Model Updates:
* [`apps/cms/src/app/models/Board.ts`](diffhunk://#diff-f716882da112b5ccde2c25759ac519edd2edce6f13d22e67a80ebf211bcc73c6L44-R45): Updated the `Board` model to replace `meetingSchedule` with `calendarId` and `calendarQueryString`.