### PR TITLE
fix: fixed migrations

### DIFF
--- a/apps/cms/migrations/20260729190451_muffins/migration.sql
+++ b/apps/cms/migrations/20260729190451_muffins/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "PublicNotice" ALTER COLUMN "type" SET DEFAULT 'none';
+
+-- AlterTable
+ALTER TABLE "PublicNoticeDraft" ALTER COLUMN "type" SET DEFAULT 'none';
+
+-- AlterTable
+ALTER TABLE "PublicNoticeVersion" ALTER COLUMN "type" SET DEFAULT 'none';

--- a/apps/cms/schema.prisma
+++ b/apps/cms/schema.prisma
@@ -1405,7 +1405,7 @@ model PublicNotice {
   hideSideNav                                Boolean                   @default(false)
   createdAt                                  DateTime?                 @default(now())
   updatedAt                                  DateTime?                 @default(now()) @updatedAt
-  type                                       String                    @default("AKMATSUGOV_PublicNotice")
+  type                                       String                    @default("none")
   urgency                                    Int                       @default(2)
   effectiveDate                              DateTime?
   endDate                                    DateTime?
@@ -1482,7 +1482,7 @@ model PublicNoticeVersion {
   hideSideNav       Boolean            @default(false)
   createdAt         DateTime?          @default(now())
   updatedAt         DateTime?          @default(now()) @updatedAt
-  type              String             @default("AKMATSUGOV_PublicNotice")
+  type              String             @default("none")
   urgency           Int                @default(2)
   effectiveDate     DateTime?
   endDate           DateTime?
@@ -1531,7 +1531,7 @@ model PublicNoticeDraft {
   hideSideNav       Boolean            @default(false)
   createdAt         DateTime?          @default(now())
   updatedAt         DateTime?          @default(now()) @updatedAt
-  type              String             @default("AKMATSUGOV_PublicNotice")
+  type              String             @default("none")
   urgency           Int                @default(2)
   effectiveDate     DateTime?
   endDate           DateTime?


### PR DESCRIPTION
This pull request updates the default value for the `type` field in the `PublicNotice`, `PublicNoticeDraft`, and `PublicNoticeVersion` models. The default value is changed from `'AKMATSUGOV_PublicNotice'` to `'none'` to ensure consistency across the database schema and Prisma models.

**Database schema and model updates:**

* Updated the default value of the `type` column to `'none'` in the `PublicNotice`, `PublicNoticeDraft`, and `PublicNoticeVersion` tables via a migration SQL script.
* Changed the default value of the `type` field to `'none'` in the `PublicNotice`, `PublicNoticeDraft`, and `PublicNoticeVersion` models in `schema.prisma`. [[1]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5L1408-R1408) [[2]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5L1534-R1534) [[3]](diffhunk://#diff-9ed9c9c0587c90dfafd73c7d643a94b4ff9c5dbf830196e6a2e3b8cfbb1704d5L1485-R1485)