### PR TITLE
fix: improved unpublish date handling

### DIFF
--- a/apps/cms/migrations/20260803185749_public_notice_unpublish_field_required/migration.sql
+++ b/apps/cms/migrations/20260803185749_public_notice_unpublish_field_required/migration.sql
@@ -1,0 +1,13 @@
+-- Update existing records to have a default value for unpublishAt for two weeks from now.
+UPDATE "PublicNotice" SET "unpublishAt" = NOW() + INTERVAL '2 weeks' WHERE "unpublishAt" IS NULL;
+UPDATE "PublicNoticeDraft" SET "unpublishAt" = NOW() + INTERVAL '2 weeks' WHERE "unpublishAt" IS NULL;
+UPDATE "PublicNoticeVersion" SET "unpublishAt" = NOW() + INTERVAL '2 weeks' WHERE "unpublishAt" IS NULL;
+
+-- AlterTable
+ALTER TABLE "PublicNotice" ALTER COLUMN "unpublishAt" SET DEFAULT NOW() + INTERVAL '2 weeks';
+
+-- AlterTable
+ALTER TABLE "PublicNoticeDraft" ALTER COLUMN "unpublishAt" SET DEFAULT NOW() + INTERVAL '2 weeks';
+
+-- AlterTable
+ALTER TABLE "PublicNoticeVersion" ALTER COLUMN "unpublishAt" SET DEFAULT NOW() + INTERVAL '2 weeks';

--- a/apps/cms/migrations/20260803190917_muffins/migration.sql
+++ b/apps/cms/migrations/20260803190917_muffins/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "PublicNotice" ALTER COLUMN "unpublishAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "PublicNoticeDraft" ALTER COLUMN "unpublishAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "PublicNoticeVersion" ALTER COLUMN "unpublishAt" DROP DEFAULT;

--- a/apps/cms/src/app/fieldUtils.ts
+++ b/apps/cms/src/app/fieldUtils.ts
@@ -29,6 +29,7 @@ import { logger } from '../configs/logger';
 import v from 'voca';
 import { plural } from 'pluralize';
 import { getSearchData, ModelDelegateKey } from '../utils/draftUtils';
+import { isDate } from 'date-fns';
 
 export const urlRegex = /^(https?:\/\/)[^\s/$.?#].[^\s]*$/;
 export const phoneNumberRegex =
@@ -166,6 +167,7 @@ export function timestampField(opts?: {
 }
 
 export function publishable(opts?: {
+  unPublishRequired?: boolean;
   isDraft?: boolean;
   isVersion?: boolean;
 }): BaseFields<any> {
@@ -176,6 +178,7 @@ export function publishable(opts?: {
       fields: {
         publishAt: timestampField({
           hideView: !opts?.isDraft,
+          hideCreateView: true,
           hooks: {
             async resolveInput({
               operation,
@@ -200,13 +203,67 @@ export function publishable(opts?: {
         }),
 
         unpublishAt: timestampField({
+          isRequired: opts?.unPublishRequired ?? false,
           hooks: {
+            resolveInput: ({
+              resolvedData: updatedData,
+              item: originalItem,
+              fieldKey,
+            }) => {
+              let muffins = null;
+              if (opts?.unPublishRequired) {
+                const newStatus = updatedData?.['status'];
+                const unpublishAt = updatedData?.['unpublishAt'];
+                const itemUnpublishAt = originalItem?.['unpublishAt'];
+
+                // When publishing a new item and unpublish is required,
+                if (newStatus === 'published') {
+                  // If unpublishAt is a valid date, return it.
+                  if (unpublishAt && isDate(unpublishAt)) {
+                    // If unpublishAt is in the past, return a default unpublishAt date of 14 days from now.
+                    if (unpublishAt < new Date()) {
+                      const defaultUnpublishAt = new Date();
+                      defaultUnpublishAt.setDate(
+                        defaultUnpublishAt.getDate() + 14,
+                      );
+                      muffins = defaultUnpublishAt;
+                    } else {
+                      muffins = unpublishAt;
+                    }
+                    // If unpublishAt is not a valid date, check if the original item has an unpublishAt date. If it does, return that. If it doesn't, return a default unpublishAt date of 14 days from now.
+                  } else if (itemUnpublishAt && isDate(itemUnpublishAt)) {
+                    // If itemUnpublishAt is in the past, return a default unpublishAt date of 14 days from now.
+                    if (itemUnpublishAt < new Date()) {
+                      const defaultUnpublishAt = new Date();
+                      defaultUnpublishAt.setDate(
+                        defaultUnpublishAt.getDate() + 14,
+                      );
+                      muffins = defaultUnpublishAt;
+                    } else {
+                      muffins = itemUnpublishAt;
+                    }
+                  } else {
+                    const defaultUnpublishAt = new Date();
+                    defaultUnpublishAt.setDate(
+                      defaultUnpublishAt.getDate() + 14,
+                    );
+
+                    muffins = defaultUnpublishAt;
+                  }
+                } else {
+                  muffins = updatedData?.[fieldKey] || originalItem?.[fieldKey];
+                }
+              }
+
+              return muffins;
+            },
             validate: ({ resolvedData, item, addValidationError }) => {
               const publishAt =
                 resolvedData?.['publishAt'] || item?.['publishAt'];
               const unpublishAt = resolvedData?.['unpublishAt'];
+              const status = resolvedData?.['status'] || item?.['status'];
 
-              if (!publishAt && unpublishAt) {
+              if (status === 'published' && !publishAt && unpublishAt) {
                 addValidationError(
                   'You have set an Unpublish date but no Publish date. Either remove the Unpublish date or add a Publish date.',
                 );
@@ -218,6 +275,20 @@ export function publishable(opts?: {
                 if (unPub <= pub) {
                   addValidationError(
                     'Invalid unpublish date. Please select an unpublish date that is after the publish date.',
+                  );
+                }
+              }
+
+              // prevent creation of unpublish date that is longer than a year and two weeks after the publish date
+              if (publishAt && unpublishAt) {
+                const pub = new Date(publishAt);
+                const unPub = new Date(unpublishAt);
+                const oneYearLater = new Date(pub);
+                oneYearLater.setFullYear(oneYearLater.getFullYear() + 1);
+                oneYearLater.setDate(oneYearLater.getDate() + 14); // add two weeks
+                if (unPub > oneYearLater) {
+                  addValidationError(
+                    'Invalid unpublish date. Please select an unpublish date that is within a year and two weeks of the publish date.',
                   );
                 }
               }
@@ -465,6 +536,7 @@ export type BasePageOptions = {
   isDraft?: boolean;
   isVersion?: boolean;
   disableDefaultRelationships?: boolean;
+  unPublishRequired?: boolean;
 };
 
 interface OpArgs {

--- a/apps/cms/src/app/models/basePage.ts
+++ b/apps/cms/src/app/models/basePage.ts
@@ -61,7 +61,11 @@ export function basePage(
     }),
     heroImage: blueHarvestImage(opts?.heroImageConfig),
     ...titleAndDescription(opts?.titleAndDescriptionOpts),
-    ...publishable({ isDraft: opts?.isDraft, isVersion: opts?.isVersion }),
+    ...publishable({
+      isDraft: opts?.isDraft,
+      isVersion: opts?.isVersion,
+      unPublishRequired: opts?.unPublishRequired,
+    }),
     liveUrl: liveUrl(listNamePlural),
     ...(!opts?.noSlug && !opts?.isVersion && !opts?.isDraft && { slug }),
     ...((opts?.isVersion || opts?.isDraft) && {

--- a/apps/cms/src/app/models/pages/PublicNotice.ts
+++ b/apps/cms/src/app/models/pages/PublicNotice.ts
@@ -16,7 +16,12 @@ const {
   'PublicNotice',
   (listNamePlural, opts) => {
     return {
-      ...basePage(listNamePlural, { ...opts, actions: true, documents: true }),
+      ...basePage(listNamePlural, {
+        ...opts,
+        actions: true,
+        documents: true,
+        unPublishRequired: true,
+      }),
       type: text({
         defaultValue: 'none',
         validation: {


### PR DESCRIPTION
This pull request introduces a required `unpublishAt` field for all `PublicNotice`-related models, ensures data consistency for existing and future records, and adds business logic for validating and handling unpublish dates. The changes affect both the database schema and the application logic, enforcing that every published Public Notice has an appropriate unpublish date.

**Database migration changes:**

* Existing records in `PublicNotice`, `PublicNoticeDraft`, and `PublicNoticeVersion` tables are updated to set a default `unpublishAt` value of two weeks from now if not already set. The default is then enforced at the schema level, and subsequently removed to ensure future flexibility. [[1]](diffhunk://#diff-bfe330c6b9a9dcea87253faf6940399e52c127811337d584280f5184d5b94f17R1-R13) [[2]](diffhunk://#diff-cde34a4d8fa6eae9e2a599da90b8efb521ebbba29264ed5d16bfbd83aa31fa6dR1-R8)

**Field and validation logic enhancements:**

* The `publishable` field utility now supports an `unPublishRequired` option. When enabled (as for `PublicNotice`), it enforces that `unpublishAt` is required, automatically sets a default value if needed, and ensures the date is valid and within a year and two weeks from `publishAt`. [[1]](diffhunk://#diff-b3154a531adf10e42c506c5993b5288373ccf4ca7af569930dd7e36c60b639c4R170) [[2]](diffhunk://#diff-b3154a531adf10e42c506c5993b5288373ccf4ca7af569930dd7e36c60b639c4R181) [[3]](diffhunk://#diff-b3154a531adf10e42c506c5993b5288373ccf4ca7af569930dd7e36c60b639c4R206-R266) [[4]](diffhunk://#diff-b3154a531adf10e42c506c5993b5288373ccf4ca7af569930dd7e36c60b639c4R281-R294)
* The `basePage` and `PublicNotice` models are updated to pass the new `unPublishRequired` flag, ensuring that all Public Notices require an `unpublishAt` date. [[1]](diffhunk://#diff-95be62402858d6d7320020bbb3b58a6920537d86cfac41af7dea497daecb0e71L64-R68) [[2]](diffhunk://#diff-b89336a2748185111aeb7481561f2f847a12cad0caf5abc7a8ef2913c1bc86f9L19-R24)
* The `BasePageOptions` and related types are updated to include the new `unPublishRequired` option for flexibility across models.

**Dependency updates:**

* Added `isDate` import from `date-fns` for improved date validation in field hooks.