### PR TITLE
can now create urls and other polymorphic items from action view

### DIFF
--- a/apps/cms/src/app/models/linksAndUrls/Url.ts
+++ b/apps/cms/src/app/models/linksAndUrls/Url.ts
@@ -1,5 +1,5 @@
 import { list } from '@keystone-6/core';
-import { generalOperationAccess, isContentManager } from '../../access';
+import { generalOperationAccess } from '../../access';
 import {
   docDelete,
   owner,
@@ -15,9 +15,7 @@ export const Url = list({
   access: {
     operation: generalOperationAccess,
   },
-  ui: {
-    isHidden: async (args) => !(await isContentManager(args)),
-  },
+
   fields: {
     ...titleAndDescription(),
     url: text({

--- a/apps/cms/src/components/customFields/polymorphicRelationship/views.tsx
+++ b/apps/cms/src/components/customFields/polymorphicRelationship/views.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   FieldController,
   FieldControllerConfig,
@@ -17,6 +17,7 @@ import {
   FieldDescription,
   Select,
 } from '@keystone-ui/fields';
+import { Button } from '@keystone-ui/button';
 
 import { CreateItemDrawer } from '@keystone-6/core/admin-ui/components';
 import { DrawerController } from '@keystone-ui/modals';
@@ -33,7 +34,41 @@ export function Field({
   const toast = useToasts();
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [isTypePickerOpen, setIsTypePickerOpen] = useState(false);
+  const [drawerItemType, setDrawerItemType] = useState<{
+    label: string;
+    value: string;
+  } | null>(null);
+  const [createTypeOption, setCreateTypeOption] = useState<{
+    label: string;
+    value: string;
+  } | null>(null);
   const { query, setQuery, data, error } = useInternalSearchQuery();
+
+  const createTypeOptions = useMemo(() => {
+    const typeMap = new Map<string, { label: string; value: string }>();
+
+    data?.internalSearch?.forEach((item: any) => {
+      if (!item?.__typename) return;
+      typeMap.set(item.__typename, {
+        label: item.__typename,
+        value: v.camelCase(item.__typename),
+      });
+    });
+
+    if (!typeMap.has('Url')) {
+      typeMap.set('Url', { label: 'Url', value: v.camelCase('Url') });
+    }
+
+    return Array.from(typeMap.values()).sort((a, b) =>
+      a.label.localeCompare(b.label),
+    );
+  }, [data?.internalSearch]);
+
+  function openDrawerForItemType(itemType: { label: string; value: string }) {
+    setDrawerItemType(itemType);
+    setIsDrawerOpen(true);
+  }
 
   if (error) {
     toast.addToast({
@@ -76,16 +111,51 @@ export function Field({
             }}
           ></Select>
         </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            size="small"
+            onClick={() => setIsTypePickerOpen((open) => !open)}
+          >
+            {isTypePickerOpen ? 'Cancel' : 'Create New Item'}
+          </Button>
+          <Button
+            size="small"
+            onClick={() =>
+              openDrawerForItemType({ label: 'Url', value: v.camelCase('Url') })
+            }
+          >
+            Create new URL
+          </Button>
+        </div>
+        {isTypePickerOpen && (
+          <Select
+            className="w-full"
+            placeholder="Select item type to create..."
+            value={createTypeOption}
+            options={createTypeOptions}
+            onChange={(option) => {
+              const selectedType = option as {
+                label: string;
+                value: string;
+              } | null;
+              setCreateTypeOption(selectedType);
+              if (selectedType) {
+                openDrawerForItemType(selectedType);
+                setIsTypePickerOpen(false);
+              }
+            }}
+          ></Select>
+        )}
       </div>
-      {value?.itemType && (
+      {drawerItemType && (
         <DrawerController isOpen={isDrawerOpen}>
           <CreateItemDrawer
-            listKey={value?.itemType.label.replace(/\s+/g, '')}
+            listKey={drawerItemType.label.replace(/\s+/g, '')}
             onClose={() => setIsDrawerOpen(false)}
             onCreate={(val) => {
               setIsDrawerOpen(false);
               onChange?.({
-                itemType: value?.itemType,
+                itemType: drawerItemType,
                 itemId: {
                   label: val.label,
                   value: val.id,


### PR DESCRIPTION
This pull request introduces improvements to the custom polymorphic relationship field UI and makes a minor access control adjustment to the `Url` model. The main focus is on enhancing the user experience for creating related items of various types directly from the relationship field, including a dedicated option for creating a new `Url`. Additionally, the `Url` model's UI visibility logic has been simplified.

**Improvements to the polymorphic relationship field UI:**

* Added a "Create New Item" button that toggles a type picker, allowing users to select which type of related item to create, and a dedicated "Create new URL" button for quick access.
* Implemented logic to dynamically generate available item types for creation based on search results, ensuring "Url" is always an option.
* Refactored the drawer logic to use the selected item type and improved state management for type selection and drawer visibility. [[1]](diffhunk://#diff-bf2e8c34b38f9f617f59760f834484d9f665829189662cf4d8cce47710472b81R37-R72) [[2]](diffhunk://#diff-bf2e8c34b38f9f617f59760f834484d9f665829189662cf4d8cce47710472b81R114-R158)
* Added `Button` import from `@keystone-ui/button` and used `useMemo` for efficient option generation. [[1]](diffhunk://#diff-bf2e8c34b38f9f617f59760f834484d9f665829189662cf4d8cce47710472b81L2-R2) [[2]](diffhunk://#diff-bf2e8c34b38f9f617f59760f834484d9f665829189662cf4d8cce47710472b81R20)

**Access control simplification in `Url` model:**

* Removed the `isHidden` UI property and its dependency on the `isContentManager` access check, making the `Url` list always visible in the admin UI. [[1]](diffhunk://#diff-a495f87050bf9fa79c402ad34682f46bb12dd35bf7a1cb10c06ed46f4b1d0057L2-R2) [[2]](diffhunk://#diff-a495f87050bf9fa79c402ad34682f46bb12dd35bf7a1cb10c06ed46f4b1d0057L18-R18)